### PR TITLE
fix: Rename ViewerPageContainer class correctly

### DIFF
--- a/src/components/ViewerPageContainer.js
+++ b/src/components/ViewerPageContainer.js
@@ -16,7 +16,7 @@ import {
 } from "../reducers/certificate";
 import CertificateViewer from "./CertificateViewer";
 
-class MainPageContainer extends Component {
+class ViewerPageContainer extends Component {
   constructor(props) {
     super(props);
 
@@ -88,9 +88,9 @@ const mapDispatchToProps = dispatch => ({
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(withRouter(MainPageContainer));
+)(withRouter(ViewerPageContainer));
 
-MainPageContainer.propTypes = {
+ViewerPageContainer.propTypes = {
   updateCertificate: PropTypes.func,
   document: PropTypes.object,
   certificate: PropTypes.object,


### PR DESCRIPTION
ViewerPageContainer.js was exporting a class named MainPageContainer, renamed it to ViewerPageContainer