### PR TITLE
fix: Added waits to integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "stylelint": "^12.0.1",
     "stylelint-config-recommended": "^3.0.0",
     "stylelint-config-standard": "^19.0.0",
-    "testcafe": "^1.1.0",
+    "testcafe": "^1.6.0",
     "typescript": "^3.7.5",
     "webpack": "^4.41.0",
     "webpack-cli": "^3.3.9",

--- a/src/test/dns-verified.spec.js
+++ b/src/test/dns-verified.spec.js
@@ -11,6 +11,8 @@ const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("sample document is rendered correctly when dns is verified", async (t) => {
+  const container = Selector("#certificate-dropzone");
+  await container();
   await t.setFilesToUpload("input[type=file]", [Document]);
 
   await StatusButton.with({ visibilityCheck: true })();

--- a/src/test/load-addressbook.spec.js
+++ b/src/test/load-addressbook.spec.js
@@ -19,6 +19,8 @@ const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("AddressBook local names to be resolved correctly, search filtered to 1", async (t) => {
+  const container = Selector("#certificate-dropzone");
+  await container();
   await t.setFilesToUpload("input[type=file]", [Document]);
   await TitleTransferPanel.with({ visibilityCheck: true })();
   await t.expect(ButtonUploadAddressBook.count).eql(1);

--- a/src/test/multi-dns-verified.spec.js
+++ b/src/test/multi-dns-verified.spec.js
@@ -11,6 +11,8 @@ const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Sample document is rendered correctly when multiple dns is verfied", async (t) => {
+  const container = Selector("#certificate-dropzone");
+  await container();
   await t.setFilesToUpload("input[type=file]", [Document]);
 
   await StatusButton.with({ visibilityCheck: true })();

--- a/src/test/unverified-issuer.spec.js
+++ b/src/test/unverified-issuer.spec.js
@@ -11,6 +11,8 @@ const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Error view rendered when document issuers are unverified", async (t) => {
+  const container = Selector("#certificate-dropzone");
+  await container();
   await t.setFilesToUpload("input[type=file]", [Document]);
 
   await InvalidMessage.with({ visibilityCheck: true })();


### PR DESCRIPTION
Added awaits for the dropzone to load just in case the page isn't ready by the time the test starts