### PR TITLE
feat(ERC721): Added etherscan link for asset-type documents

### DIFF
--- a/src/components/AssetInfo/AssetInfo.test.js
+++ b/src/components/AssetInfo/AssetInfo.test.js
@@ -1,0 +1,11 @@
+import React from "react";
+import { mount } from "enzyme";
+import { AssetInfo } from "./AssetInfo";
+
+describe("assetInfo", () => {
+  it("renders with correct etherscan url", () => {
+    const wrapper = mount(<AssetInfo registryAddress="0xa" tokenId="0xff" />);
+    expect(wrapper.text()).toStrictEqual("Manage Asset");
+    expect(wrapper.find("a").prop("href")).toStrictEqual("https://ropsten.etherscan.io/token/0xa?a=255");
+  });
+});

--- a/src/components/AssetInfo/AssetInfo.tsx
+++ b/src/components/AssetInfo/AssetInfo.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { FunctionComponent } from "react";
 import { hexToNumberString } from "web3-utils";
 
 import { ETHERSCAN_BASE_URL } from "../../config";
@@ -13,7 +13,7 @@ interface ERC721TokenParameters {
   tokenId: string;
 }
 
-export const AssetInfo = ({ registryAddress, tokenId }: ERC721TokenParameters) => {
+export const AssetInfo: FunctionComponent<ERC721TokenParameters> = ({ registryAddress, tokenId }) => {
   return (
     <div>
       <a

--- a/src/components/AssetInfo/AssetInfo.tsx
+++ b/src/components/AssetInfo/AssetInfo.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { hexToNumberString } from "web3-utils";
+
+import { ETHERSCAN_BASE_URL } from "../../config";
+
+const makeEtherscanTokenURL = ({ registryAddress, tokenId }: ERC721TokenParameters) => {
+  const tokenIdDecimal = hexToNumberString(tokenId);
+  return `${ETHERSCAN_BASE_URL}token/${registryAddress}?a=${tokenIdDecimal}`;
+};
+
+interface ERC721TokenParameters {
+  registryAddress: string;
+  tokenId: string;
+}
+
+export const AssetInfo = ({ registryAddress, tokenId }: ERC721TokenParameters) => {
+  return (
+    <div>
+      <a
+        href={makeEtherscanTokenURL({ registryAddress, tokenId })}
+        id="asset-info-etherscan-link"
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        Manage Asset
+      </a>
+    </div>
+  );
+};

--- a/src/components/AssetInfo/index.js
+++ b/src/components/AssetInfo/index.js
@@ -1,0 +1,3 @@
+import { AssetInfo } from "./AssetInfo";
+
+export { AssetInfo };

--- a/src/components/CertificateViewer.js
+++ b/src/components/CertificateViewer.js
@@ -12,6 +12,7 @@ import { selectTemplateTab as selectTemplateTabAction } from "../reducers/certif
 import { LEGACY_OPENCERTS_RENDERER } from "../config";
 import { isEmailFeatureActive } from "../config/feature-config";
 import CertificateSharingForm from "./CertificateSharing/CertificateSharingForm";
+import { AssetInfo } from "./AssetInfo";
 
 const renderVerifyBlock = props => (
   <CertificateVerifyBlock
@@ -22,12 +23,25 @@ const renderVerifyBlock = props => (
   />
 );
 
+const getAssetInfo = document => {
+  const { tokenRegistry } = getData(document).issuers[0];
+  const { merkleRoot: tokenId } = document.signature;
+  return { tokenRegistry, tokenId };
+};
+
+const renderAssetInfo = props => {
+  const { tokenRegistry, tokenId } = getAssetInfo(props.document);
+
+  return tokenRegistry ? <AssetInfo registryAddress={tokenRegistry} tokenId={tokenId} /> : undefined;
+};
+
 const renderHeaderBlock = props => {
   const renderedVerifyBlock = renderVerifyBlock(props);
   return (
     <div className={`container-fluid ${styles["pd-0"]} ${styles.container}`}>
       <div className="row">
         <div>{renderedVerifyBlock}</div>
+        <div>{renderAssetInfo(props)}</div>
         <div className={`row flex-nowrap`}>
           <div className="">
             <div id="btn-print" className={styles["print-btn"]} onClick={() => window.print()}>

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -22,6 +22,8 @@ export const LEGACY_OPENCERTS_RENDERER = "https://legacy.opencerts.io/";
 export const NETWORK_ID = IS_MAINNET ? "1" : "3";
 export const NETWORK_NAME = IS_MAINNET ? "homestead" : "ropsten";
 
+export const ETHERSCAN_BASE_URL = `https://${NETWORK_NAME === "ropsten" ? "ropsten." : ""}etherscan.io/`;
+
 trace(`DEFAULT_NETWORK: ${DEFAULT_NETWORK}`);
 trace(`CAPTCHA_CLIENT_KEY: ${CAPTCHA_CLIENT_KEY}`);
 trace(`EMAIL_API_URL: ${EMAIL_API_URL}`);

--- a/src/test/ebl.spec.js
+++ b/src/test/ebl.spec.js
@@ -2,7 +2,7 @@ import { Selector } from "testcafe";
 
 fixture("Token Document Rendering").page`http://localhost:3000`;
 
-const Document = "./fixture/tokenRegistry.json";
+const Document = "./fixture/ebl.json";
 const IframeBlock = Selector("#iframe");
 const SampleTemplate = Selector("#root");
 const StatusButton = Selector("#certificate-status");
@@ -11,13 +11,21 @@ const validateTextContent = async (t, component, texts) =>
   texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
 
 test("Token is verified and rendered correctly", async t => {
+  const container = Selector("#certificate-dropzone");
+  await container();
   await t.setFilesToUpload("input[type=file]", [Document]);
 
   await StatusButton.with({ visibilityCheck: true })();
 
+  const assetInfoLinkElement = await Selector("#asset-info-etherscan-link");
+  await t
+    .expect(assetInfoLinkElement.getAttribute("href"))
+    .eql(
+      "https://ropsten.etherscan.io/token/0x48399Fb88bcD031C556F53e93F690EEC07963Af3?a=44462799421286370332860487499556741868509423910583906203271800828184419823283"
+    );
   await validateTextContent(t, StatusButton, ["Issued by TRADETRUST.IO"]);
 
   await t.switchToIframe(IframeBlock);
 
-  await validateTextContent(t, SampleTemplate, ["Name & Address of Shipping", "DEMO CUSTOMS"]);
+  await validateTextContent(t, SampleTemplate, ["BILL OF LADING FOR OCEAN TRANSPORT OR MULTIMODAL TRANSPORT"]);
 });

--- a/src/test/fixture/ebl.json
+++ b/src/test/fixture/ebl.json
@@ -1,0 +1,57 @@
+{
+  "schema": "tradetrust/v1.0",
+  "data": {
+    "id": "d29151cc-7af4-409b-9230-1b936ffb2c00:string:56107057",
+    "$template": {
+      "name": "df76045b-2db7-49a0-9ff4-6dc7f7c26221:string:BILL_OF_LADING",
+      "type": "40102267-a445-4906-9dba-8745c61d0865:string:EMBEDDED_RENDERER",
+      "url": "0becc4d4-16bd-4d6a-ac24-55ebdee8b703:string:https://demo-cnm.openattestation.com"
+    },
+    "issuers": [
+      {
+        "name": "7e652043-5b29-433a-a850-23ab4c9c90f2:string:DEMO STORE",
+        "tokenRegistry": "b42ec8d4-3853-4f68-b4cb-5aa65d0efca8:string:0x48399Fb88bcD031C556F53e93F690EEC07963Af3",
+        "identityProof": {
+          "type": "3bf0918c-4f46-429f-bbbb-2a2a4edcf352:string:DNS-TXT",
+          "location": "f366cbda-f287-48a8-a232-9fe208ee1330:string:tradetrust.io"
+        }
+      }
+    ],
+    "consignee": {
+      "type": "20a929a3-a7b2-48b4-ad52-cfa0a4c4324d:string:NEGOTIABLE",
+      "name": "b6fba66b-21ab-4ec3-901f-76bad33f8396:string:THE NATIONAL COMMERCIAL BANK JEDDAH"
+    },
+    "notifyParty": {
+      "name": "b0c2fe89-8797-4e1c-99dc-869844a7a557:string:AL-JIFRI PLASTIC MATERIALS COMPANY ALHENDAWEYAH, JEDDAH, SAUDI ARABIA"
+    },
+    "shipper": {
+      "name": "2bcd940b-7a4c-4ea9-b155-17bda67f0e5a:string:BEMA GMBH",
+      "address": {
+        "street": "873e3317-1432-4588-a4ab-99eb46573b15:string:Anton Sorg Str.1 Befa GmbH 86199 Augburg",
+        "country": "4aaa4846-76f9-4d87-92ba-061dacd9fd57:string:GERMANY"
+      }
+    },
+    "vessel": "7814b707-1079-41f4-bc75-c6c660b4d705:string:LAURA MAERSK",
+    "voyageNo": "8d5c959e-3688-4067-b507-8d88d6756cec:string:1417",
+    "portOfLoading": "bba57724-ca7c-4da9-a83e-b42ff2869bbe:string:HAMBURG PORT",
+    "portOfDischarge": "5f4c24e4-6aee-447a-bef7-70de3178fd33:string:JEDDAH PORT",
+    "placeOfReceipt": "a1392a01-07d6-44c5-9ca1-db863c64fe27:string:",
+    "placeOfDelivery": "17ec1c34-967b-4e9f-9f0d-b2963bb13084:string:",
+    "packages": [
+      {
+        "description": "3bbdb53d-9836-45ab-b80e-af364c7a8bed:string:1 Container Said to Contain 890 Pieces",
+        "weight": "c487b5fd-84c0-434c-a4c5-9c647f60ff8e:string:6711.380 KGS",
+        "measurement": "f7ff8f0b-45aa-4b62-9974-adf28df37520:string:"
+      }
+    ]
+  },
+  "privacy": {
+    "obfuscatedData": []
+  },
+  "signature": {
+    "type": "SHA3MerkleProof",
+    "targetHash": "624d0d7ae6f44d41d368d8280856dbaac6aa29fb3b35f45b80a7c1c90032eeb3",
+    "proof": [],
+    "merkleRoot": "624d0d7ae6f44d41d368d8280856dbaac6aa29fb3b35f45b80a7c1c90032eeb3"
+  }
+}


### PR DESCRIPTION
Originally worked with a few more details on the asset directly in the page, but realised a lot of it was superfluous since no one's going to actually read the hex addresses and we don't have a mapping of hex addresses to metadata.

Have reduced it to simply an external link to Etherscan so that asset owners can manipulate the asset over there instead.