### PR TITLE
refactoring token service to hooks [WIP]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1557,27 +1557,42 @@
       "requires": {
         "@govtechsg/open-attestation": "^1.1.41",
         "ethers": "^4.0.27"
-      }
-    },
-    "@govtechsg/open-attestation": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/@govtechsg/open-attestation/-/open-attestation-1.1.42.tgz",
-      "integrity": "sha512-6OYLTDBoZWs7rpw7lZs1qodFPqBMPd1tS+jXjeoJg90Nw94CkheDABa06kvCGDkm2o7XQAJLi8AgwTuXwLMUPA==",
-      "requires": {
-        "ajv": "^6.10.0",
-        "flatley": "^5.2.0",
-        "js-sha3": "^0.8.0",
-        "lodash": "^4.17.11",
-        "uuid": "^3.3.2",
-        "validator": "^10.11.0",
-        "verbal-expressions": "^1.0.0"
       },
       "dependencies": {
+        "@govtechsg/open-attestation": {
+          "version": "1.1.42",
+          "resolved": "https://registry.npmjs.org/@govtechsg/open-attestation/-/open-attestation-1.1.42.tgz",
+          "integrity": "sha512-6OYLTDBoZWs7rpw7lZs1qodFPqBMPd1tS+jXjeoJg90Nw94CkheDABa06kvCGDkm2o7XQAJLi8AgwTuXwLMUPA==",
+          "requires": {
+            "ajv": "^6.10.0",
+            "flatley": "^5.2.0",
+            "js-sha3": "^0.8.0",
+            "lodash": "^4.17.11",
+            "uuid": "^3.3.2",
+            "validator": "^10.11.0",
+            "verbal-expressions": "^1.0.0"
+          }
+        },
         "validator": {
           "version": "10.11.0",
           "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
           "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
         }
+      }
+    },
+    "@govtechsg/open-attestation": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@govtechsg/open-attestation/-/open-attestation-3.6.0.tgz",
+      "integrity": "sha512-MbuKTNAiW6PZbMxysKTU8WmFgv+NfFFXFHylek3g7o0h1OBPFKbWDoXdog6POFPfSo2vAHjY8WeS8Ccl47amZg==",
+      "requires": {
+        "ajv": "6.10.2",
+        "debug": "^4.1.1",
+        "flatley": "^5.2.0",
+        "js-sha3": "^0.8.0",
+        "lodash": "^4.17.15",
+        "uuid": "^3.3.3",
+        "validator": "^12.0.0",
+        "verbal-expressions": "^1.0.2"
       }
     },
     "@hot-loader/react-dom": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@govtechsg/oa-encryption": "1.3.1",
     "@govtechsg/oa-token": "^1.12.0",
     "@govtechsg/oa-verify": "^2.0.1",
-    "@govtechsg/open-attestation": "^1.1.41",
+    "@govtechsg/open-attestation": "^3.6.0",
     "@hot-loader/react-dom": "^16.9.0",
     "axios": "^0.19.0",
     "bootstrap": "^4.4.1",

--- a/src/services/token/helpers.ts
+++ b/src/services/token/helpers.ts
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useReducer } from "react";
+import { states } from "../../reducers/certificate";
 
 export interface TransactionState {
   status: TransactionStateStatus;
@@ -24,16 +25,25 @@ export enum TransactionStateStatus {
   ERROR = "error"
 }
 
-export const useEthereumTransactionState = (): UseEthereumTransactionState => {
-  const [state, setState] = useState<TransactionState>({ status: TransactionStateStatus.LOADING, error: undefined });
+function ethereumStateReducer(state, action) {
+    switch (action.type) {
+        case TransactionStateStatus.LOADING:
+            return {...state, ...{ status: TransactionStateStatus.LOADING, error: undefined }}
+        case TransactionStateStatus.READY:
+            return {...state, ...{ status: TransactionStateStatus.READY, error: undefined }}
+        case TransactionStateStatus.NO_WALLET:
+            return {...state, ...{ status: TransactionStateStatus.NO_WALLET, error: undefined }}
+        case TransactionStateStatus.SUCCESS:
+            return {...state, ...{ status: TransactionStateStatus.SUCCESS, error: undefined }}
+        case TransactionStateStatus.TRANSACTION_MINING:
+            return {...state, ...{ status: TransactionStateStatus.TRANSACTION_MINING, error: undefined }}
+        case TransactionStateStatus.ERROR:
+            return {...state, ...{ status: TransactionStateStatus.ERROR, error: action.message }}
+        default:
+            return {...state, ...{ status: TransactionStateStatus.LOADING, error: undefined }}
+    }
+}
 
-  const setLoading = (): void => setState({ status: TransactionStateStatus.LOADING, error: undefined });
-  const setNoWallet = (): void => setState({ status: TransactionStateStatus.NO_WALLET, error: undefined });
-  const setReady = (): void => setState({ status: TransactionStateStatus.READY, error: undefined });
-  const setSuccess = (): void => setState({ status: TransactionStateStatus.SUCCESS, error: undefined });
-  const setMining = (): void => setState({ status: TransactionStateStatus.TRANSACTION_MINING, error: undefined });
-
-  const setError = (e: any): void => setState({ status: TransactionStateStatus.ERROR, error: e.message });
-
-  return { state, setLoading, setNoWallet, setReady, setSuccess, setMining, setError };
+export const useEthereumTransactionState = () => {
+  return useReducer(ethereumStateReducer, { status: TransactionStateStatus.LOADING, error: undefined });
 };

--- a/src/services/token/helpers.ts
+++ b/src/services/token/helpers.ts
@@ -1,0 +1,39 @@
+import { useState } from "react";
+
+export interface TransactionState {
+  status: TransactionStateStatus;
+  error: any;
+}
+
+export interface UseEthereumTransactionState {
+  state: TransactionState;
+  setLoading: () => void;
+  setNoWallet: () => void;
+  setReady: () => void;
+  setSuccess: () => void;
+  setMining: () => void;
+  setError: (e: any) => void;
+}
+
+export enum TransactionStateStatus {
+  LOADING = "loading",
+  READY = "ready",
+  SUCCESS = "success",
+  NO_WALLET = "no_wallet",
+  TRANSACTION_MINING = "transaction-mining",
+  ERROR = "error"
+}
+
+export const useEthereumTransactionState = (): UseEthereumTransactionState => {
+  const [state, setState] = useState<TransactionState>({ status: TransactionStateStatus.LOADING, error: undefined });
+
+  const setLoading = (): void => setState({ status: TransactionStateStatus.LOADING, error: undefined });
+  const setNoWallet = (): void => setState({ status: TransactionStateStatus.NO_WALLET, error: undefined });
+  const setReady = (): void => setState({ status: TransactionStateStatus.READY, error: undefined });
+  const setSuccess = (): void => setState({ status: TransactionStateStatus.SUCCESS, error: undefined });
+  const setMining = (): void => setState({ status: TransactionStateStatus.TRANSACTION_MINING, error: undefined });
+
+  const setError = (e: any): void => setState({ status: TransactionStateStatus.ERROR, error: e.message });
+
+  return { state, setLoading, setNoWallet, setReady, setSuccess, setMining, setError };
+};

--- a/src/services/token/readOnlyTokenHook.ts
+++ b/src/services/token/readOnlyTokenHook.ts
@@ -1,0 +1,52 @@
+/**
+ *  TODO: Extract this code out to its own package to reuse in tradetrust-website
+ */
+
+import { ReadOnlyToken } from "@govtechsg/oa-token";
+
+import { getLogger } from "../../utils/logger";
+
+import { useState, useEffect, useCallback } from "react";
+import { WrappedDocument } from "@govtechsg/open-attestation";
+import { useEthereumTransactionState, TransactionState } from "./helpers";
+const { trace, error } = getLogger("useToken");
+
+type UseReadOnlyToken = { state: TransactionState; tokenInstance: ReadOnlyToken | null; getTokenOwner: GetTokenOwner };
+type GetTokenOwner = () => Promise<string>;
+
+export const useReadOnlyToken = ({ document }: { document: WrappedDocument<any> }): UseReadOnlyToken => {
+  trace(`document to initialize ${JSON.stringify(document)}`);
+
+  const [tokenInstance, setTokenInstance] = useState<ReadOnlyToken | null>(null);
+  const { state, setReady, setLoading, setError, setSuccess } = useEthereumTransactionState();
+
+  const setErrorCallback = useCallback(setError, []);
+  const setReadyCallback = useCallback(setReady, []);
+
+  const getTokenOwner: GetTokenOwner = async (): Promise<string> => {
+    try {
+      if (!tokenInstance) {
+        throw new Error(`Token is not initialised`);
+      }
+      setLoading();
+      const tokenOwner = await tokenInstance.getOwner();
+      setSuccess();
+      return tokenOwner.address;
+    } catch (e) {
+      error(`Error minting token: ${e}`);
+      setError(e);
+    }
+  };
+
+  useEffect(() => {
+    try {
+      setTokenInstance(new ReadOnlyToken({ document }));
+      setReadyCallback();
+    } catch (e) {
+      error(`Error initialising token: ${e}`);
+      setErrorCallback(e);
+    }
+  }, [document, setReadyCallback, setErrorCallback]);
+
+  return { state, tokenInstance, getTokenOwner };
+};

--- a/src/services/token/tokenOwnerHook.ts
+++ b/src/services/token/tokenOwnerHook.ts
@@ -1,0 +1,72 @@
+/**
+ *  TODO: Extract this code out to its own package to reuse in tradetrust-website
+ */
+
+import { WriteableToken, WriteableTitleEscrowOwner, TitleEscrowOwner, Owner } from "@govtechsg/oa-token";
+
+import { getLogger } from "../../utils/logger";
+
+import { useState, useEffect, useCallback } from "react";
+import { WrappedDocument } from "@govtechsg/open-attestation";
+import { ethers, Wallet } from "ethers";
+import { useEthereumTransactionState, TransactionState } from "./helpers";
+const { trace, error } = getLogger("useToken");
+
+type UseWriteableTitleEscrowOwner = {
+  state: TransactionState;
+  tokenInstance: TokenOwnerInstance;
+  isEscrowContract: IsEscrowContract;
+};
+type IsEscrowContract = () => Promise<any>;
+type TokenOwnerInstance = WriteableTitleEscrowOwner | Owner | null;
+type UseWriteableTitleEscrowOwnerProps = {
+  document: WrappedDocument<any>;
+  web3Provider: ethers.providers.BaseProvider;
+  wallet: Wallet;
+};
+
+export const useWriteableTitleEscrowOwner = ({
+  document,
+  web3Provider,
+  wallet
+}: UseWriteableTitleEscrowOwnerProps): UseWriteableTitleEscrowOwner => {
+  trace(`document to initialize ${JSON.stringify(document)}`);
+
+  const [tokenInstance, setTokenInstance] = useState<TokenOwnerInstance>(null);
+  const { state, setReady, setMining, setLoading, setError, setSuccess } = useEthereumTransactionState();
+
+  const setErrorCallback = useCallback(setError, []);
+  const setReadyCallback = useCallback(setReady, []);
+
+  const isEscrowContract: IsEscrowContract = async (): Promise<boolean | void> => {
+    try {
+      if (!tokenInstance) {
+        throw new Error(`Token is not initialised`);
+      }
+      setLoading();
+      const isEscrowContract = await tokenInstance.isTitleEscrow();
+      setSuccess();
+      return isEscrowContract;
+    } catch (e) {
+      error(`Error minting token: ${e}`);
+      setError(e);
+    }
+  };
+
+  const initializeToken = async ({ document, web3Provider, wallet }: UseWriteableTitleEscrowOwnerProps) => {
+    try {
+      const writeableTokenInstance = new WriteableToken({ document, web3Provider, wallet });
+      setTokenInstance(await writeableTokenInstance.getOwner());
+      setReadyCallback();
+    } catch (e) {
+      error(`Error initialising token: ${e}`);
+      setErrorCallback(e);
+    }
+  };
+
+  useEffect(() => {
+    initializeToken({ document, web3Provider, wallet });
+  }, [document, web3Provider, wallet, initializeToken]);
+
+  return { state, tokenInstance, isEscrowContract };
+};

--- a/src/services/token/writeableTokenHook.ts
+++ b/src/services/token/writeableTokenHook.ts
@@ -1,0 +1,65 @@
+/**
+ *  TODO: Extract this code out to its own package to reuse in tradetrust-website
+ */
+
+import { WriteableToken } from "@govtechsg/oa-token";
+
+import { getLogger } from "../../utils/logger";
+
+import { useState, useEffect, useCallback } from "react";
+import { WrappedDocument } from "@govtechsg/open-attestation";
+import { ethers, Wallet } from "ethers";
+import { useEthereumTransactionState, TransactionState } from "./helpers";
+const { trace, error } = getLogger("useToken");
+
+type UseWriteableToken = {
+  state: TransactionState;
+  tokenInstance: WriteableToken | null;
+  surrenderToken: SurrenderToken;
+};
+type SurrenderToken = () => Promise<any>;
+
+export const useWriteableToken = ({
+  document,
+  web3Provider,
+  wallet
+}: {
+  document: WrappedDocument<any>;
+  web3Provider: ethers.providers.BaseProvider;
+  wallet: Wallet;
+}): UseWriteableToken => {
+  trace(`document to initialize ${JSON.stringify(document)}`);
+
+  const [tokenInstance, setTokenInstance] = useState<WriteableToken | null>(null);
+  const { state, setReady, setMining, setError, setSuccess } = useEthereumTransactionState();
+
+  const setErrorCallback = useCallback(setError, []);
+  const setReadyCallback = useCallback(setReady, []);
+
+  const surrenderToken: SurrenderToken = async (): Promise<string | void> => {
+    try {
+      if (!tokenInstance) {
+        throw new Error(`Token is not initialised`);
+      }
+      setMining();
+      const txHash = await tokenInstance.surrender();
+      setSuccess();
+      return txHash;
+    } catch (e) {
+      error(`Error minting token: ${e}`);
+      setError(e);
+    }
+  };
+
+  useEffect(() => {
+    try {
+      setTokenInstance(new WriteableToken({ document, web3Provider, wallet }));
+      setReadyCallback();
+    } catch (e) {
+      error(`Error initialising token: ${e}`);
+      setErrorCallback(e);
+    }
+  }, [document, web3Provider, wallet, setReadyCallback, setErrorCallback]);
+
+  return { state, tokenInstance, surrenderToken };
+};


### PR DESCRIPTION
- Refactoring services/token.js. The approach I am taking 
- currently, three global instances are there. their respective functionality mapped to respective hooks - 
 1. writeableTokenInstance - writeableTokenHook.ts
 2. readonlyTokenInstance - readOnlyTokenHook.ts
3. tokenOwnerInstance- tokenOwnerHook.ts

These hooks exposes the respected methods to perform the respective action.