### PR TITLE
chore: developer friendly feature flag

### DIFF
--- a/src/components/AssetInfo/AssetInfo.tsx
+++ b/src/components/AssetInfo/AssetInfo.tsx
@@ -60,42 +60,40 @@ export const AssetInfo: FunctionComponent<{ document: SignedDocument }> = ({ doc
   };
 
   if (!registryAddress) return null;
+
+  const legacyView = (
+    <a
+      href={makeEtherscanTokenURL({ registryAddress, tokenId })}
+      id="asset-info-etherscan-link"
+      rel="noreferrer noopener"
+      target="_blank"
+    >
+      Manage Asset
+    </a>
+  );
   return (
     <>
-      <FeatureFlag
-        name="MANAGE_ASSET"
-        render={() => (
-          <div>
-            <a
-              href={makeEtherscanTokenURL({ registryAddress, tokenId })}
-              id="asset-info-etherscan-link"
-              rel="noreferrer noopener"
-              target="_blank"
-              onClick={handlerToggleSideBar}
-            >
-              Manage Asset
-            </a>
-            <TokenSideBar
-              adminAddress={adminAddress}
-              registryAddress={registryAddress}
-              holderAddress={holderAddress}
-              beneficiaryAddress={beneficiaryAddress}
-              handler={handlerToggleSideBar}
-              isSideBarExpand={isSideBarExpand}
-            />
-          </div>
-        )}
-        fallback={() => (
+      <FeatureFlag name="MANAGE_ASSET" fallback={legacyView}>
+        <div>
           <a
             href={makeEtherscanTokenURL({ registryAddress, tokenId })}
             id="asset-info-etherscan-link"
             rel="noreferrer noopener"
             target="_blank"
+            onClick={handlerToggleSideBar}
           >
             Manage Asset
           </a>
-        )}
-      />
+          <TokenSideBar
+            adminAddress={adminAddress}
+            registryAddress={registryAddress}
+            holderAddress={holderAddress}
+            beneficiaryAddress={beneficiaryAddress}
+            handler={handlerToggleSideBar}
+            isSideBarExpand={isSideBarExpand}
+          />
+        </div>
+      </FeatureFlag>
     </>
   );
 };

--- a/src/components/FeatureFlag.test.tsx
+++ b/src/components/FeatureFlag.test.tsx
@@ -23,33 +23,31 @@ describe("featureFlag", () => {
   afterEach(() => {
     process.env = OLD_ENV;
   });
+
   it("should render component when MANAGE_ASSET feature flag is set to true", () => {
+    const fallback = <div>This feature is not available</div>;
     const wrapper = mount(
-      <FeatureFlag
-        name="MANAGE_ASSET"
-        render={() => <div>Share link is active</div>}
-        fallback={() => <div>This feature is not available</div>}
-      />
+      <FeatureFlag name="MANAGE_ASSET" fallback={fallback}>
+        <div>Share link is active</div>
+      </FeatureFlag>
     );
     expect(wrapper.find("div").text()).toStrictEqual("Share link is active");
   });
   it("should render fallback component when OTHER feature flag is set to false", () => {
+    const fallback = <div>This feature is not available</div>;
     const wrapper = mount(
-      <FeatureFlag
-        name="jobPost"
-        render={() => <div>Other feature is active</div>}
-        fallback={() => <div>This feature is not available</div>}
-      />
+      <FeatureFlag name="jobPost" fallback={fallback}>
+        <div>Other feature is active</div>
+      </FeatureFlag>
     );
     expect(wrapper.find("div").text()).toStrictEqual("This feature is not available");
   });
   it("should render fallback component when EXTRA_FEATURE feature flag is not set", () => {
+    const fallback = <div>This feature is not available</div>;
     const wrapper = mount(
-      <FeatureFlag
-        name="EXTRA_FEATURE"
-        render={() => <div>Extra feature is active</div>}
-        fallback={() => <div>This feature is not available</div>}
-      />
+      <FeatureFlag name="EXTRA_FEATURE" fallback={fallback}>
+        <div>Extra feature is active</div>
+      </FeatureFlag>
     );
     expect(wrapper.find("div").text()).toStrictEqual("This feature is not available");
   });

--- a/src/components/FeatureFlag.tsx
+++ b/src/components/FeatureFlag.tsx
@@ -1,26 +1,27 @@
-import React from "react";
+import React, { FunctionComponent, ReactElement } from "react";
 import Features from "../config/feature-toggle.json";
 
-interface FeatureFlagProps {
+interface FeatureFlag {
   name: string;
-  render?: () => React.ReactElement;
-  fallback?: () => React.ReactElement;
+  fallback?: React.ReactElement;
 }
 
 interface FeatureJson {
   [key: string]: any;
 }
 
-export const FeatureFlag = ({ name, render, fallback }: FeatureFlagProps): React.ReactElement | null => {
+export const FeatureFlag: FunctionComponent<FeatureFlag> = ({ name, children, fallback }) => {
   const environment = process.env.NODE_ENV || "production";
   const features = Features as FeatureJson;
   const featureFlag: boolean = features?.[name]?.[environment];
 
-  if (featureFlag && render) {
-    return render();
+  if (featureFlag && children) {
+    // Casting because of incompatibility of ReactNode with FunctionComponent
+    // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
+    return children as ReactElement;
   }
   if (!featureFlag && fallback) {
-    return fallback();
+    return fallback;
   }
   return null;
 };


### PR DESCRIPTION
Changed the `FeatureFlag` to allow feature-flagged components to be written and read easily.

The rational is that the current implementation will nest the wrapped component by two levels and contributes to the unreadability. To remove the feature flag, we will also need to unwrap the child component. With the new interface, we simply remove the <FeatureFlag> component without touching the children.

Previous Interface:

```jsx
<FeatureFlag
  render={() => <SomeComponent/>}
  fallback={() => <SomeOtherComponent/>}
/>
```

New Interface:

```jsx
const fallback = <SomeOtherComponent/>;
<FeatureFlag fallback={fallback}>
  <SomeComponent/>
</FeatureFlag>
```