### PR TITLE
feat: feature flag override in browser console

### DIFF
--- a/src/common/hooks/useFeatureFlagOverride.ts
+++ b/src/common/hooks/useFeatureFlagOverride.ts
@@ -1,0 +1,12 @@
+import createPersistedState from "use-persisted-state";
+
+export interface FeatureFlagOverride {
+  [key: string]: boolean | undefined;
+}
+
+export const useFeatureFlagOverride = () => {
+  const defaultOverride: FeatureFlagOverride = {};
+  const [featureFlagOverride, setFeatureFlagOverride] = createPersistedState("FEATURE_FLAG")(defaultOverride);
+  const getFeatureFlagOverride = (flag: string) => featureFlagOverride[flag];
+  return { featureFlagOverride, setFeatureFlagOverride, getFeatureFlagOverride };
+};

--- a/src/common/hooks/useFeatureFlagOverride.ts
+++ b/src/common/hooks/useFeatureFlagOverride.ts
@@ -1,14 +1,46 @@
 import createPersistedState from "use-persisted-state";
+import { useEffect } from "react";
 
 export interface FeatureFlagOverride {
   [key: string]: boolean | undefined;
   ALL?: boolean;
 }
 
+const originalSetItem = localStorage.setItem;
+
+const EVENT_NAME = "LocalStorageInserted";
+// use custom event because storage event doesn't work for the current window
+// https://stackoverflow.com/questions/26974084/listen-for-changes-with-localstorage-on-the-same-window
+// the event must be triggered AFTER updating the storage
+localStorage.setItem = function (...args) {
+  const event = new Event(EVENT_NAME);
+  originalSetItem.apply(this, args);
+  document.dispatchEvent(event);
+};
+
 export const useFeatureFlagOverride = () => {
   const defaultOverride: FeatureFlagOverride = {};
   const [featureFlagOverride, setFeatureFlagOverride] = createPersistedState("FEATURE_FLAG")(defaultOverride);
   const getFeatureFlagOverride = (flag: string) =>
     typeof featureFlagOverride.ALL === "boolean" ? featureFlagOverride.ALL : featureFlagOverride[flag];
+
+  // listen to the local storages changes, and update the flag accordingly
+  useEffect(() => {
+    const localStorageInsertedHandler = () => {
+      const localStorageObject = JSON.parse(window.localStorage.getItem("FEATURE_FLAG") ?? "{}");
+      const changed = Object.keys(localStorageObject).find((key) => {
+        return localStorageObject[key] !== featureFlagOverride[key];
+      });
+      // only update IF there is at least one change in the object updated
+      if (changed) {
+        setFeatureFlagOverride(localStorageObject);
+      }
+    };
+
+    document.addEventListener(EVENT_NAME, localStorageInsertedHandler, false);
+    return () => {
+      document.removeEventListener(EVENT_NAME, localStorageInsertedHandler, false);
+    };
+  }, [featureFlagOverride, setFeatureFlagOverride]);
   return { featureFlagOverride, setFeatureFlagOverride, getFeatureFlagOverride };
 };

--- a/src/common/hooks/useFeatureFlagOverride.ts
+++ b/src/common/hooks/useFeatureFlagOverride.ts
@@ -2,11 +2,13 @@ import createPersistedState from "use-persisted-state";
 
 export interface FeatureFlagOverride {
   [key: string]: boolean | undefined;
+  ALL?: boolean;
 }
 
 export const useFeatureFlagOverride = () => {
   const defaultOverride: FeatureFlagOverride = {};
   const [featureFlagOverride, setFeatureFlagOverride] = createPersistedState("FEATURE_FLAG")(defaultOverride);
-  const getFeatureFlagOverride = (flag: string) => featureFlagOverride[flag];
+  const getFeatureFlagOverride = (flag: string) =>
+    typeof featureFlagOverride.ALL === "boolean" ? featureFlagOverride.ALL : featureFlagOverride[flag];
   return { featureFlagOverride, setFeatureFlagOverride, getFeatureFlagOverride };
 };

--- a/src/components/AssetInfo/AssetInfo.test.tsx
+++ b/src/components/AssetInfo/AssetInfo.test.tsx
@@ -9,6 +9,7 @@ jest.mock("react-redux", () => ({
   useDispatch: () => jest.fn(),
   useSelector: () => ({
     token: { beneficiaryAddress: "", holderAddress: "" },
+    networkIdVerbose: "ropsten",
   }),
 }));
 

--- a/src/components/FeatureFlag.test.tsx
+++ b/src/components/FeatureFlag.test.tsx
@@ -25,53 +25,53 @@ describe("featureFlag", () => {
   });
 
   it("should follow default behavior when override is not present", () => {
-    const notFound = mount(
+    const wrapperJob = mount(
       <FeatureFlag name="JOB_POST">
         <div>Job post</div>
       </FeatureFlag>
     );
-    expect(notFound.find("div").length).toBe(0);
+    expect(wrapperJob.find("div").length).toBe(0);
 
-    const found = mount(
+    const wrapperAsset = mount(
       <FeatureFlag name="MANAGE_ASSET">
         <div>Manage asset</div>
       </FeatureFlag>
     );
-    expect(found.find("div").text()).toStrictEqual("Manage asset");
+    expect(wrapperAsset.find("div").text()).toStrictEqual("Manage asset");
   });
   it("should render component when override is true", () => {
     mockGetFeature.mockReturnValue(true);
 
-    const notFound = mount(
+    const wrapperJob = mount(
       <FeatureFlag name="JOB_POST">
         <div>Job post</div>
       </FeatureFlag>
     );
-    expect(notFound.find("div").text()).toStrictEqual("Job post");
+    expect(wrapperJob.find("div").text()).toStrictEqual("Job post");
 
-    const found = mount(
+    const wrapperAsset = mount(
       <FeatureFlag name="MANAGE_ASSET">
         <div>Manage asset</div>
       </FeatureFlag>
     );
-    expect(found.find("div").text()).toStrictEqual("Manage asset");
+    expect(wrapperAsset.find("div").text()).toStrictEqual("Manage asset");
   });
   it("should not render component when override is false", () => {
     mockGetFeature.mockReturnValue(false);
 
-    const notFound = mount(
+    const wrapperJob = mount(
       <FeatureFlag name="JOB_POST">
         <div>Job post</div>
       </FeatureFlag>
     );
-    expect(notFound.find("div").length).toBe(0);
+    expect(wrapperJob.find("div").length).toBe(0);
 
-    const found = mount(
+    const wrapperAsset = mount(
       <FeatureFlag name="MANAGE_ASSET">
         <div>Manage asset</div>
       </FeatureFlag>
     );
-    expect(found.find("div").length).toBe(0);
+    expect(wrapperAsset.find("div").length).toBe(0);
   });
 
   it("should render component when MANAGE_ASSET feature flag is set to true", () => {

--- a/src/components/FeatureFlag.test.tsx
+++ b/src/components/FeatureFlag.test.tsx
@@ -8,8 +8,8 @@ jest.mock("../config/feature-toggle.json", () => ({
     development: true,
   },
   JOB_POST: {
-    development: false
-  }
+    development: false,
+  },
 }));
 
 const mockUseFeatureFlagOverride = useFeatureFlagOverride as jest.Mock;
@@ -24,89 +24,93 @@ describe("featureFlag", () => {
     mockGetFeature.mockReturnValue(undefined);
   });
 
-  it("should follow default behavior when override is not present", () => {
-    const wrapperJob = mount(
-      <FeatureFlag name="JOB_POST">
-        <div>Job post</div>
-      </FeatureFlag>
-    );
-    expect(wrapperJob.find("div").length).toBe(0);
+  describe("without overridden feature flag", () => {
+    it("should follow default behavior when override is not present", () => {
+      const wrapperJob = mount(
+        <FeatureFlag name="JOB_POST">
+          <div>Job post</div>
+        </FeatureFlag>
+      );
+      expect(wrapperJob.find("div").length).toBe(0);
 
-    const wrapperAsset = mount(
-      <FeatureFlag name="MANAGE_ASSET">
-        <div>Manage asset</div>
-      </FeatureFlag>
-    );
-    expect(wrapperAsset.find("div").text()).toStrictEqual("Manage asset");
-  });
-  it("should render component when override is true", () => {
-    mockGetFeature.mockReturnValue(true);
+      const wrapperAsset = mount(
+        <FeatureFlag name="MANAGE_ASSET">
+          <div>Manage asset</div>
+        </FeatureFlag>
+      );
+      expect(wrapperAsset.find("div").text()).toStrictEqual("Manage asset");
+    });
 
-    const wrapperJob = mount(
-      <FeatureFlag name="JOB_POST">
-        <div>Job post</div>
-      </FeatureFlag>
-    );
-    expect(wrapperJob.find("div").text()).toStrictEqual("Job post");
+    it("should render component when MANAGE_ASSET feature flag is set to true", () => {
+      const fallback = <div>This feature is not available</div>;
+      const wrapper = mount(
+        <FeatureFlag name="MANAGE_ASSET" fallback={fallback}>
+          <div>Share link is active</div>
+        </FeatureFlag>
+      );
+      expect(wrapper.find("div").text()).toStrictEqual("Share link is active");
+    });
+    it("should render fallback component when OTHER feature flag is set to false", () => {
+      const fallback = <div>This feature is not available</div>;
+      const wrapper = mount(
+        <FeatureFlag name="JOB_POST" fallback={fallback}>
+          <div>Other feature is active</div>
+        </FeatureFlag>
+      );
+      expect(wrapper.find("div").text()).toStrictEqual("This feature is not available");
+    });
+    it("should render fallback component when EXTRA_FEATURE feature flag is not set", () => {
+      const fallback = <div>This feature is not available</div>;
+      const wrapper = mount(
+        <FeatureFlag name="EXTRA_FEATURE" fallback={fallback}>
+          <div>Extra feature is active</div>
+        </FeatureFlag>
+      );
+      expect(wrapper.find("div").text()).toStrictEqual("This feature is not available");
+    });
+    it("should not render anything when there is no render function and MANAGE_ASSET feature flag is true", () => {
+      const wrapper = mount(<FeatureFlag name="MANAGE_ASSET" />);
+      expect(wrapper.find("div")).toHaveLength(0);
+    });
+    it("should not render anything when there is no fallback function and OTHER feature flag is false", () => {
+      const wrapper = mount(<FeatureFlag name="JOB_POST" />);
+      expect(wrapper.find("div")).toHaveLength(0);
+    });
+  });
+  describe("without overridden feature flag", () => {
+    it("should render component when override is true", () => {
+      mockGetFeature.mockReturnValue(true);
 
-    const wrapperAsset = mount(
-      <FeatureFlag name="MANAGE_ASSET">
-        <div>Manage asset</div>
-      </FeatureFlag>
-    );
-    expect(wrapperAsset.find("div").text()).toStrictEqual("Manage asset");
-  });
-  it("should not render component when override is false", () => {
-    mockGetFeature.mockReturnValue(false);
+      const wrapperJob = mount(
+        <FeatureFlag name="JOB_POST">
+          <div>Job post</div>
+        </FeatureFlag>
+      );
+      expect(wrapperJob.find("div").text()).toStrictEqual("Job post");
 
-    const wrapperJob = mount(
-      <FeatureFlag name="JOB_POST">
-        <div>Job post</div>
-      </FeatureFlag>
-    );
-    expect(wrapperJob.find("div").length).toBe(0);
+      const wrapperAsset = mount(
+        <FeatureFlag name="MANAGE_ASSET">
+          <div>Manage asset</div>
+        </FeatureFlag>
+      );
+      expect(wrapperAsset.find("div").text()).toStrictEqual("Manage asset");
+    });
+    it("should not render component when override is false", () => {
+      mockGetFeature.mockReturnValue(false);
 
-    const wrapperAsset = mount(
-      <FeatureFlag name="MANAGE_ASSET">
-        <div>Manage asset</div>
-      </FeatureFlag>
-    );
-    expect(wrapperAsset.find("div").length).toBe(0);
-  });
+      const wrapperJob = mount(
+        <FeatureFlag name="JOB_POST">
+          <div>Job post</div>
+        </FeatureFlag>
+      );
+      expect(wrapperJob.find("div").length).toBe(0);
 
-  it("should render component when MANAGE_ASSET feature flag is set to true", () => {
-    const fallback = <div>This feature is not available</div>;
-    const wrapper = mount(
-      <FeatureFlag name="MANAGE_ASSET" fallback={fallback}>
-        <div>Share link is active</div>
-      </FeatureFlag>
-    );
-    expect(wrapper.find("div").text()).toStrictEqual("Share link is active");
-  });
-  it("should render fallback component when OTHER feature flag is set to false", () => {
-    const fallback = <div>This feature is not available</div>;
-    const wrapper = mount(
-      <FeatureFlag name="JOB_POST" fallback={fallback}>
-        <div>Other feature is active</div>
-      </FeatureFlag>
-    );
-    expect(wrapper.find("div").text()).toStrictEqual("This feature is not available");
-  });
-  it("should render fallback component when EXTRA_FEATURE feature flag is not set", () => {
-    const fallback = <div>This feature is not available</div>;
-    const wrapper = mount(
-      <FeatureFlag name="EXTRA_FEATURE" fallback={fallback}>
-        <div>Extra feature is active</div>
-      </FeatureFlag>
-    );
-    expect(wrapper.find("div").text()).toStrictEqual("This feature is not available");
-  });
-  it("should not render anything when there is no render function and MANAGE_ASSET feature flag is true", () => {
-    const wrapper = mount(<FeatureFlag name="MANAGE_ASSET" />);
-    expect(wrapper.find("div")).toHaveLength(0);
-  });
-  it("should not render anything when there is no fallback function and OTHER feature flag is false", () => {
-    const wrapper = mount(<FeatureFlag name="JOB_POST" />);
-    expect(wrapper.find("div")).toHaveLength(0);
+      const wrapperAsset = mount(
+        <FeatureFlag name="MANAGE_ASSET">
+          <div>Manage asset</div>
+        </FeatureFlag>
+      );
+      expect(wrapperAsset.find("div").length).toBe(0);
+    });
   });
 });

--- a/src/components/FeatureFlag.tsx
+++ b/src/components/FeatureFlag.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, ReactElement } from "react";
+import { useFeatureFlagOverride } from "../common/hooks/useFeatureFlagOverride";
 import Features from "../config/feature-toggle.json";
 
 interface FeatureFlag {
@@ -6,16 +7,27 @@ interface FeatureFlag {
   fallback?: React.ReactElement;
 }
 
+type Environment = "test" | "development" | "production";
+
+interface EnvironmentToggle {
+  development: boolean;
+  production: boolean;
+}
+
 interface FeatureJson {
-  [key: string]: any;
+  [key: string]: EnvironmentToggle;
 }
 
 export const FeatureFlag: FunctionComponent<FeatureFlag> = ({ name, children, fallback }) => {
-  const environment = process.env.NODE_ENV || "production";
+  const { getFeatureFlagOverride } = useFeatureFlagOverride();
+  const override = getFeatureFlagOverride(name);
+  // Combining allowing both test and development environment to render the development features
+  const isDevelopment = process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
+  const environment: Environment = isDevelopment ? "development" : "production";
   const features = Features as FeatureJson;
   const featureFlag: boolean = features?.[name]?.[environment];
 
-  if (featureFlag && children) {
+  if ((override || (featureFlag && override === undefined)) && children) {
     // Casting because of incompatibility of ReactNode with FunctionComponent
     // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051
     return children as ReactElement;

--- a/src/components/FeatureFlag.tsx
+++ b/src/components/FeatureFlag.tsx
@@ -27,6 +27,9 @@ export const FeatureFlag: FunctionComponent<FeatureFlag> = ({ name, children, fa
   const features = Features as FeatureJson;
   const featureFlag: boolean = features?.[name]?.[environment];
 
+  // display the feature if the flag has been overridden
+  // OR
+  // if the flag HAS NOT been set to FALSE (override === undefined) and the flag is enabled
   if ((override || (featureFlag && override === undefined)) && children) {
     // Casting because of incompatibility of ReactNode with FunctionComponent
     // See https://github.com/DefinitelyTyped/DefinitelyTyped/issues/18051

--- a/src/components/FeatureFlag.tsx
+++ b/src/components/FeatureFlag.tsx
@@ -7,7 +7,7 @@ interface FeatureFlag {
   fallback?: React.ReactElement;
 }
 
-type Environment = "test" | "development" | "production";
+type Environment = "development" | "production";
 
 interface EnvironmentToggle {
   development: boolean;


### PR DESCRIPTION
## Goal

Allow in console overrides of feature flags in non-development environment. This is useful for viewing hidden features in branch deploy or even production deploy.

One can either enable a single feature flag or enable all the flags.

## Test single flag

To test, simply run the following in console and refresh the website: 

```js
localStorage.setItem("FEATURE_FLAG", JSON.stringify({ADDRESS_BOOK_UPLOAD: true}))
```

or

```js
localStorage.FEATURE_FLAG =  JSON.stringify({ADDRESS_BOOK_UPLOAD: true})
```

## Test all flags

```js
localStorage.setItem("FEATURE_FLAG", JSON.stringify({ALL: true}))
```

or

```js
localStorage.FEATURE_FLAG =  JSON.stringify({ALL: true})
```

## Limitation

### Webpage refresh

Storage event only fires when the storage is changed in the context of another window/tab, see https://developer.mozilla.org/en-US/docs/Web/API/Window/storage_event. As such it's not possible to allow dynamic feature flag toggle without refreshing the web page. Even the [debug](https://www.npmjs.com/package/debug#browser-support) module requires users to refresh.

### JSON string storage instead of object storage

```js
localStorage.setItem("FEATURE_FLAG", {ADDRESS_BOOK_UPLOAD: true})
```

is not used as the package `use-persisted-state` parses the string in it's implementation. 