### PR TITLE
chore: add npm caching to circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,16 @@ jobs:
       - image: 'circleci/node:lts-browsers'
     steps:
       - checkout
+      - restore_cache: # special step to restore the dependency cache
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
+          key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: install
           command: npm install
+      - save_cache: # special step to save the dependency cache
+          key: dependency-cache-{{ checksum "package-lock.json" }}
+          paths:
+            - ./node_modules
       - run:
           name: lint
           command: npm run lint


### PR DESCRIPTION
circleci npm install takes too long so we can save some time by caching dependencies if they haven't changed between builds

https://circleci.com/docs/2.0/caching/