### PR TITLE
fix: footer text

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -11,7 +11,7 @@ const Footer = ({ className }: FooterProps) => {
       <div className="container-custom">
         <div className="row justify-content-center">
           <div className="col-auto">
-            <p className="mb-0">Copyright &copy; 2019 All rights reserved</p>
+            <p className="mb-0">Copyright &copy; 2019 TradeTrust</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
footer text change from `Copyright 2019 All rights reserved` to `Copyright 2019 TradeTrust`