### PR TITLE
fix: verification tag showing revoked for transferable document

### DIFF
--- a/src/components/CertificateDropZone/Views/UnverifiedView.js
+++ b/src/components/CertificateDropZone/Views/UnverifiedView.js
@@ -1,25 +1,19 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
-import {
-  certificateNotIssued,
-  getAllButRevokeFragment,
-  getRevokeFragment,
-  isValid,
-} from "../../../services/verify/fragments";
+import { interpretFragments } from "../../../services/verify/fragments";
 import { TYPES, MESSAGES } from "../../../constants/VerificationErrorMessages";
 import css from "./viewerStyles.module.scss";
 
 const DetailedErrors = ({ verificationStatus }) => {
   const errors = [];
-  const positiveFragments = getAllButRevokeFragment(verificationStatus);
-  const negativeFragments = [getRevokeFragment(verificationStatus)];
 
-  if (!isValid(positiveFragments, ["DOCUMENT_INTEGRITY"])) errors.push(TYPES.HASH);
-  if (!isValid(positiveFragments, ["DOCUMENT_STATUS"]) && certificateNotIssued(positiveFragments))
-    errors.push(TYPES.ISSUED);
-  if (!isValid(negativeFragments, ["DOCUMENT_STATUS"])) errors.push(TYPES.REVOKED);
-  if (!isValid(positiveFragments, ["ISSUER_IDENTITY"])) errors.push(TYPES.IDENTITY);
+  const { hashValid, issuedValid, revokedValid, identityValid } = interpretFragments(verificationStatus);
+
+  if (!hashValid) errors.push(TYPES.HASH);
+  if (!issuedValid) errors.push(TYPES.ISSUED);
+  if (!revokedValid) errors.push(TYPES.REVOKED);
+  if (!identityValid) errors.push(TYPES.IDENTITY);
 
   return (
     <div id="error-tab" className={css.verifications}>

--- a/src/components/DocumentStatus/DocumentStatus.stories.mdx
+++ b/src/components/DocumentStatus/DocumentStatus.stories.mdx
@@ -7,6 +7,7 @@ import {
   whenDocumentRevoked,
   whenDocumentIssuerIdentityInvalid,
   whenDocumentHashInvalidAndNotIssued,
+  whenTransferableDocumentVerified,
 } from "../../test/fixture/verifier-responses";
 
 <Meta title="DocumentStatus" component={DocumentStatus} />
@@ -31,6 +32,20 @@ Document is issued, has integrity, not revoked and has a verified issuer identit
   <Story name="Valid Document">
     {() => {
       return <DocumentStatus verificationStatus={whenDocumentValidAndIssued} />;
+    }}
+  </Story>
+</Preview>
+
+---
+
+### Transferable Document is Valid
+
+Transferable Document is issued, has integrity, not revoked and has a verified issuer identity
+
+<Preview>
+  <Story name="Valid Transferable Document">
+    {() => {
+      return <DocumentStatus verificationStatus={whenTransferableDocumentVerified} />;
     }}
   </Story>
 </Preview>

--- a/src/components/DocumentStatus/DocumentStatus.test.tsx
+++ b/src/components/DocumentStatus/DocumentStatus.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
+import { VerificationFragment } from "@govtechsg/oa-verify";
 import { DocumentStatus, IssuedBy } from "./DocumentStatus";
 import {
   whenDocumentHashInvalid,
@@ -24,7 +25,7 @@ describe("IssuedBy", () => {
           },
         ],
       },
-    ];
+    ] as VerificationFragment[];
     const container = render(<IssuedBy verificationStatus={fragments} />);
     expect(container.queryByText("ABC.COM")).not.toBeNull();
   });
@@ -50,7 +51,7 @@ describe("IssuedBy", () => {
           },
         ],
       },
-    ];
+    ] as VerificationFragment[];
     const container = render(<IssuedBy verificationStatus={fragments} />);
     expect(container.queryByText("ABC.COM, XYZ.COM and DEMO.COM")).not.toBeNull();
   });
@@ -58,7 +59,7 @@ describe("IssuedBy", () => {
 
 describe("DocumentStatus", () => {
   it("should display hash error if the hash is invalid", () => {
-    const container = render(<DocumentStatus verificationStatus={whenDocumentHashInvalid as any} />);
+    const container = render(<DocumentStatus verificationStatus={whenDocumentHashInvalid as VerificationFragment[]} />);
     expect(container.queryByText(MESSAGES["HASH"]["failureTitle"])).not.toBeNull();
     expect(container.queryByText(MESSAGES["ISSUED"]["failureTitle"])).toBeNull();
     expect(container.queryByText(MESSAGES["REVOKED"]["failureTitle"])).toBeNull();
@@ -66,7 +67,7 @@ describe("DocumentStatus", () => {
   });
 
   it("displays issuing error if the document is not issued", () => {
-    const container = render(<DocumentStatus verificationStatus={whenDocumentNotIssued as any} />);
+    const container = render(<DocumentStatus verificationStatus={whenDocumentNotIssued as VerificationFragment[]} />);
     expect(container.queryByText(MESSAGES["HASH"]["failureTitle"])).toBeNull();
     expect(container.queryByText(MESSAGES["ISSUED"]["failureTitle"])).not.toBeNull();
     expect(container.queryByText(MESSAGES["REVOKED"]["failureTitle"])).toBeNull();
@@ -74,7 +75,7 @@ describe("DocumentStatus", () => {
   });
 
   it("displays revocation error if the document is revoked", () => {
-    const container = render(<DocumentStatus verificationStatus={whenDocumentRevoked as any} />);
+    const container = render(<DocumentStatus verificationStatus={whenDocumentRevoked as VerificationFragment[]} />);
     expect(container.queryByText(MESSAGES["HASH"]["failureTitle"])).toBeNull();
     expect(container.queryByText(MESSAGES["ISSUED"]["failureTitle"])).toBeNull();
     expect(container.queryByText(MESSAGES["REVOKED"]["failureTitle"])).not.toBeNull();
@@ -82,7 +83,9 @@ describe("DocumentStatus", () => {
   });
 
   it("displays identity error if the identity is not verified", () => {
-    const container = render(<DocumentStatus verificationStatus={whenDocumentIssuerIdentityInvalid as any} />);
+    const container = render(
+      <DocumentStatus verificationStatus={whenDocumentIssuerIdentityInvalid as VerificationFragment[]} />
+    );
     expect(container.queryByText(MESSAGES["HASH"]["failureTitle"])).toBeNull();
     expect(container.queryByText(MESSAGES["ISSUED"]["failureTitle"])).toBeNull();
     expect(container.queryByText(MESSAGES["REVOKED"]["failureTitle"])).toBeNull();
@@ -90,7 +93,9 @@ describe("DocumentStatus", () => {
   });
 
   it("displays error in all fields when all verification fail", () => {
-    const container = render(<DocumentStatus verificationStatus={whenDocumentHashInvalidAndNotIssued as any} />);
+    const container = render(
+      <DocumentStatus verificationStatus={whenDocumentHashInvalidAndNotIssued as VerificationFragment[]} />
+    );
     expect(container.queryByText(MESSAGES["HASH"]["failureTitle"])).not.toBeNull();
     expect(container.queryByText(MESSAGES["ISSUED"]["failureTitle"])).not.toBeNull();
     expect(container.queryByText(MESSAGES["REVOKED"]["failureTitle"])).not.toBeNull();

--- a/src/components/DocumentStatus/DocumentStatus.tsx
+++ b/src/components/DocumentStatus/DocumentStatus.tsx
@@ -2,17 +2,10 @@ import React from "react";
 import styled from "@emotion/styled";
 import { mixin, vars } from "../../styles";
 import { StatusChecks } from "./StatusChecks";
+import { VerificationFragment } from "@govtechsg/oa-verify";
 
 interface DocumentStatusProps {
-  verificationStatus: {
-    name: string;
-    type: string;
-    status: string;
-    data: {
-      status: string;
-      location: string;
-    }[];
-  }[];
+  verificationStatus: VerificationFragment[];
   className?: string;
 }
 

--- a/src/components/DocumentStatus/DocumentStatus.tsx
+++ b/src/components/DocumentStatus/DocumentStatus.tsx
@@ -1,44 +1,7 @@
 import React from "react";
 import styled from "@emotion/styled";
-import { TYPES, MESSAGES } from "../../constants/VerificationErrorMessages";
-import { isValid } from "../../services/verify/fragments";
-import { getAllButRevokeFragment, getRevokeFragment, certificateNotIssued } from "../../services/verify/fragments";
-import { SvgIcon, SvgIconCheckCircle, SvgIconXCircle } from "./../UI/SvgIcon";
 import { mixin, vars } from "../../styles";
-
-interface StatusProps {
-  message: string;
-  icon: React.ReactNode;
-}
-
-const Status = ({ message, icon }: StatusProps) => (
-  <div className="status">
-    <div className="row no-gutters align-items-center">
-      <div className="col-auto">
-        <SvgIcon>{icon}</SvgIcon>
-      </div>
-      <div className="col">
-        <p className="pl-2 mb-0 message">{message}</p>
-      </div>
-    </div>
-  </div>
-);
-
-interface StatusCheck {
-  valid: boolean;
-  messageSet: {
-    failureTitle: string;
-    successTitle: string;
-    failureMessage: string;
-  };
-}
-
-const StatusCheck = ({ valid, messageSet }: StatusCheck) => {
-  const message = valid ? messageSet.successTitle : messageSet.failureTitle;
-  const icon = valid ? <SvgIconCheckCircle /> : <SvgIconXCircle />;
-
-  return <Status message={message} icon={icon} />;
-};
+import { StatusChecks } from "./StatusChecks";
 
 interface DocumentStatusProps {
   verificationStatus: {
@@ -71,13 +34,6 @@ export const IssuedBy = ({ verificationStatus }: DocumentStatusProps) => {
 };
 
 export const DocumentStatus = styled(({ verificationStatus, className }: DocumentStatusProps) => {
-  const positiveFragments = getAllButRevokeFragment(verificationStatus);
-  const negativeFragments = [getRevokeFragment(verificationStatus)];
-  const hashValid = isValid(positiveFragments, ["DOCUMENT_INTEGRITY"]);
-  const issuedValid = isValid(positiveFragments, ["DOCUMENT_STATUS"]) && !certificateNotIssued(positiveFragments);
-  const revokedValid = isValid(negativeFragments, ["DOCUMENT_STATUS"]);
-  const identityValid = isValid(verificationStatus, ["ISSUER_IDENTITY"]);
-
   return (
     <div className={`py-3 ${className}`}>
       <div className="container-custom">
@@ -87,18 +43,7 @@ export const DocumentStatus = styled(({ verificationStatus, className }: Documen
               <div className="col-12 col-xl-4 mb-3 mb-xl-0">
                 <IssuedBy verificationStatus={verificationStatus} />
               </div>
-              <div className="col-12 col-lg-3 col-xl-2 mb-2 mb-lg-0">
-                <StatusCheck valid={hashValid} messageSet={MESSAGES[TYPES.HASH]} />
-              </div>
-              <div className="col-12 col-lg-3 col-xl-2 mb-2 mb-lg-0">
-                <StatusCheck valid={issuedValid} messageSet={MESSAGES[TYPES.ISSUED]} />
-              </div>
-              <div className="col-12 col-lg-3 col-xl-2 mb-2 mb-lg-0">
-                <StatusCheck valid={revokedValid} messageSet={MESSAGES[TYPES.REVOKED]} />
-              </div>
-              <div className="col-12 col-lg-3 col-xl-2 mb-2 mb-lg-0">
-                <StatusCheck valid={identityValid} messageSet={MESSAGES[TYPES.IDENTITY]} />
-              </div>
+              <StatusChecks verificationStatus={verificationStatus} />
             </div>
           </div>
         </div>

--- a/src/components/DocumentStatus/StatusCheck.tsx
+++ b/src/components/DocumentStatus/StatusCheck.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { SvgIcon, SvgIconCheckCircle, SvgIconXCircle } from "./../UI/SvgIcon";
+
+interface StatusProps {
+  message: string;
+  icon: React.ReactNode;
+}
+
+const Status = ({ message, icon }: StatusProps) => (
+  <div className="status">
+    <div className="row no-gutters align-items-center">
+      <div className="col-auto">
+        <SvgIcon>{icon}</SvgIcon>
+      </div>
+      <div className="col">
+        <p className="pl-2 mb-0 message">{message}</p>
+      </div>
+    </div>
+  </div>
+);
+
+interface StatusCheck {
+  valid: boolean;
+  messageSet: {
+    failureTitle: string;
+    successTitle: string;
+    failureMessage: string;
+  };
+}
+
+export const StatusCheck = ({ valid, messageSet }: StatusCheck) => {
+  const message = valid ? messageSet.successTitle : messageSet.failureTitle;
+  const icon = valid ? <SvgIconCheckCircle /> : <SvgIconXCircle />;
+
+  return <Status message={message} icon={icon} />;
+};

--- a/src/components/DocumentStatus/StatusChecks.tsx
+++ b/src/components/DocumentStatus/StatusChecks.tsx
@@ -1,23 +1,12 @@
 import React from "react";
 import styled from "@emotion/styled";
+import { VerificationFragment } from "@govtechsg/oa-verify";
 import { TYPES, MESSAGES } from "../../constants/VerificationErrorMessages";
 import { interpretFragments } from "../../services/verify/fragments";
 import { mixin, vars } from "../../styles";
 import { StatusCheck } from "./StatusCheck";
 
-interface StatusChecks {
-  verificationStatus: {
-    name: string;
-    type: string;
-    status: string;
-    data: {
-      status: string;
-      location: string;
-    }[];
-  }[];
-}
-
-export const StatusChecks = styled(({ verificationStatus }: StatusChecks) => {
+export const StatusChecks = styled(({ verificationStatus }: { verificationStatus: VerificationFragment[] }) => {
   const { hashValid, issuedValid, revokedValid, identityValid } = interpretFragments(verificationStatus);
 
   return (

--- a/src/components/DocumentStatus/StatusChecks.tsx
+++ b/src/components/DocumentStatus/StatusChecks.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { TYPES, MESSAGES } from "../../constants/VerificationErrorMessages";
+import { interpretFragments } from "../../services/verify/fragments";
+import { mixin, vars } from "../../styles";
+import { StatusCheck } from "./StatusCheck";
+
+interface StatusChecks {
+  verificationStatus: {
+    name: string;
+    type: string;
+    status: string;
+    data: {
+      status: string;
+      location: string;
+    }[];
+  }[];
+}
+
+export const StatusChecks = styled(({ verificationStatus }: StatusChecks) => {
+  const { hashValid, issuedValid, revokedValid, identityValid } = interpretFragments(verificationStatus);
+
+  return (
+    <>
+      <div className="col-12 col-lg-3 col-xl-2 mb-2 mb-lg-0">
+        <StatusCheck valid={hashValid} messageSet={MESSAGES[TYPES.HASH]} />
+      </div>
+      <div className="col-12 col-lg-3 col-xl-2 mb-2 mb-lg-0">
+        <StatusCheck valid={issuedValid} messageSet={MESSAGES[TYPES.ISSUED]} />
+      </div>
+      <div className="col-12 col-lg-3 col-xl-2 mb-2 mb-lg-0">
+        <StatusCheck valid={revokedValid} messageSet={MESSAGES[TYPES.REVOKED]} />
+      </div>
+      <div className="col-12 col-lg-3 col-xl-2 mb-2 mb-lg-0">
+        <StatusCheck valid={identityValid} messageSet={MESSAGES[TYPES.IDENTITY]} />
+      </div>
+    </>
+  );
+})`
+  .statusbar {
+    background-color: ${vars.white};
+    padding: 10px 0;
+    border-radius: ${vars.buttonRadius};
+  }
+
+  svg {
+    color: ${vars.teal};
+
+    .x-circle {
+      color: ${vars.red};
+    }
+  }
+
+  .message {
+    line-height: 1.2;
+    ${mixin.fontSize(14)};
+  }
+`;

--- a/src/services/verify/fragments.test.tsx
+++ b/src/services/verify/fragments.test.tsx
@@ -1,0 +1,70 @@
+import { VerificationFragment } from "@govtechsg/oa-verify";
+import { interpretFragments } from "./fragments";
+import {
+  whenDocumentHashInvalidAndNotIssued,
+  whenDocumentNotIssued,
+  whenDocumentValidAndIssued,
+  whenDocumentHashInvalid,
+  whenDocumentRevoked,
+  whenDocumentIssuerIdentityInvalid,
+  whenTransferableDocumentVerified,
+} from "../../test/fixture/verifier-responses";
+
+describe("interpretFragments", () => {
+  it("should interpret whenDocumentHashInvalidAndNotIssued correctly", () => {
+    expect(interpretFragments(whenDocumentHashInvalidAndNotIssued as VerificationFragment[])).toEqual({
+      hashValid: false,
+      issuedValid: false,
+      identityValid: false,
+      revokedValid: false,
+    });
+  });
+  it("should interpret whenDocumentNotIssued correctly", () => {
+    expect(interpretFragments(whenDocumentNotIssued as VerificationFragment[])).toEqual({
+      hashValid: true,
+      issuedValid: false,
+      identityValid: true,
+      revokedValid: true,
+    });
+  });
+  it("should interpret whenDocumentValidAndIssued correctly", () => {
+    expect(interpretFragments(whenDocumentValidAndIssued as VerificationFragment[])).toEqual({
+      hashValid: true,
+      issuedValid: true,
+      identityValid: true,
+      revokedValid: true,
+    });
+  });
+  it("should interpret whenDocumentHashInvalid correctly", () => {
+    expect(interpretFragments(whenDocumentHashInvalid as VerificationFragment[])).toEqual({
+      hashValid: false,
+      issuedValid: true,
+      identityValid: true,
+      revokedValid: true,
+    });
+  });
+  it("should interpret whenDocumentRevoked correctly", () => {
+    expect(interpretFragments(whenDocumentRevoked as VerificationFragment[])).toEqual({
+      hashValid: true,
+      issuedValid: true,
+      identityValid: true,
+      revokedValid: false,
+    });
+  });
+  it("should interpret whenDocumentIssuerIdentityInvalid correctly", () => {
+    expect(interpretFragments(whenDocumentIssuerIdentityInvalid as VerificationFragment[])).toEqual({
+      hashValid: true,
+      issuedValid: true,
+      identityValid: false,
+      revokedValid: true,
+    });
+  });
+  it("should interpret whenTransferableDocumentVerified correctly", () => {
+    expect(interpretFragments(whenTransferableDocumentVerified as VerificationFragment[])).toEqual({
+      hashValid: true,
+      issuedValid: true,
+      identityValid: true,
+      revokedValid: true,
+    });
+  });
+});

--- a/src/services/verify/index.js
+++ b/src/services/verify/index.js
@@ -1,6 +1,0 @@
-import { verify } from "@govtechsg/oa-verify";
-import { NETWORK_NAME } from "../../config";
-
-export const verifyDocument = async (document) => {
-  return verify(document, { network: NETWORK_NAME });
-};

--- a/src/services/verify/index.tsx
+++ b/src/services/verify/index.tsx
@@ -1,0 +1,9 @@
+import { WrappedDocument, v2, v3 } from "@govtechsg/open-attestation";
+import { verify } from "@govtechsg/oa-verify";
+import { NETWORK_NAME } from "../../config";
+
+export const verifyDocument = async (
+  document: WrappedDocument<v3.OpenAttestationDocument> | WrappedDocument<v2.OpenAttestationDocument>
+) => {
+  return verify(document, { network: NETWORK_NAME });
+};

--- a/src/test/fixture/verifier-responses.js
+++ b/src/test/fixture/verifier-responses.js
@@ -352,3 +352,45 @@ export const whenDocumentIssuerIdentityInvalid = [
     type: "ISSUER_IDENTITY",
   },
 ];
+
+export const whenTransferableDocumentVerified = [
+  { type: "DOCUMENT_INTEGRITY", name: "OpenAttestationHash", data: true, status: "VALID" },
+  {
+    status: "SKIPPED",
+    type: "DOCUMENT_STATUS",
+    name: "OpenAttestationEthereumDocumentStoreIssued",
+    reason: {
+      code: 4,
+      codeString: "SKIPPED",
+      message: 'Document issuers doesn\'t have "documentStore" or "certificateStore" property or DOCUMENT_STORE method',
+    },
+  },
+  {
+    name: "OpenAttestationEthereumTokenRegistryMinted",
+    type: "DOCUMENT_STATUS",
+    data: { mintedOnAll: true, details: [{ minted: true, address: "0xc3E9eBc6aDA9BA4B4Ce65D71901Cb2307e9670cE" }] },
+    status: "VALID",
+  },
+  {
+    status: "SKIPPED",
+    type: "DOCUMENT_STATUS",
+    name: "OpenAttestationEthereumDocumentStoreRevoked",
+    reason: {
+      code: 4,
+      codeString: "SKIPPED",
+      message: 'Document issuers doesn\'t have "documentStore" or "certificateStore" property or DOCUMENT_STORE method',
+    },
+  },
+  {
+    name: "OpenAttestationDnsTxt",
+    type: "ISSUER_IDENTITY",
+    data: [
+      {
+        status: "VALID",
+        location: "demo-tradetrust.openattestation.com",
+        value: "0xc3E9eBc6aDA9BA4B4Ce65D71901Cb2307e9670cE",
+      },
+    ],
+    status: "VALID",
+  },
+];


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172596422

Fixed the calculation for the different tags.

Recommendation is to follow the new architecture of verification tag, instead of 4 labels, just have 3 in the different category of `DOCUMENT_STATUS`, `DOCUMENT_INTEGRITY`, `ISSUER_IDENTITY`.

Will suggest that change to PO.