### PR TITLE
fix: editable asset title

### DIFF
--- a/src/components/AddressInfo/AddressInfo.stories.tsx
+++ b/src/components/AddressInfo/AddressInfo.stories.tsx
@@ -28,7 +28,7 @@ export const AddressInfoHolder = () => {
 
 export const AddressInfoBLInfo = () => {
   return (
-    <AddressInfo title="BL information">
+    <AddressInfo title="BL information" name="">
       <>
         <ExternalLink name="View BL Registry" href="#" />
         <br />

--- a/src/components/AddressInfo/AddressInfo.tsx
+++ b/src/components/AddressInfo/AddressInfo.tsx
@@ -5,7 +5,7 @@ import { mixin, vars } from "../../styles";
 interface AddressInfoProps {
   className?: string;
   title: string;
-  name?: string;
+  name: string;
   children: React.ReactNode;
 }
 
@@ -13,7 +13,7 @@ export const AddressInfoUnStyled = ({ className, title, name, children }: Addres
   return (
     <div className={`${className}`}>
       <h6>{title}:</h6>
-      {name && <h5>{name}</h5>}
+      <h5>{name}</h5>
       <div className="etherum-address">{children}</div>
     </div>
   );

--- a/src/components/AssetManagementPanel/AssetInformationPanel/index.tsx
+++ b/src/components/AssetManagementPanel/AssetInformationPanel/index.tsx
@@ -10,7 +10,7 @@ interface AssetInformationPanel {
 export const AssetInformationPanel: FunctionComponent<AssetInformationPanel> = ({ tokenId, tokenRegistryAddress }) => {
   return (
     <div className="py-3">
-      <AddressInfo title="BL information">
+      <AddressInfo title="BL information" name="">
         <>
           <div>
             <ExternalLinkEtherscanAddress name="View BL Registry" address={tokenRegistryAddress} />

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/EditableAssetTitle/EditableAssetTitle.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/EditableAssetTitle/EditableAssetTitle.tsx
@@ -33,7 +33,7 @@ export const EditableAssetTitle = ({
       </AssetTitle>
     );
   return (
-    <AssetTitle role={role} address={value}>
+    <AssetTitle role={role} address="">
       <div className="row no-gutters align-items-center">
         <InputEditableWrapper className="col">
           <InputEditableAssetTitle


### PR DESCRIPTION
### pr updates
- when addresses becomes editable, not to show resolved entity names.

### story
- https://www.pivotaltracker.com/story/show/173282178

### preview
![Screenshot 2020-06-11 at 1 56 50 PM](https://user-images.githubusercontent.com/4774314/84350262-95604500-abeb-11ea-953e-9a43bb6ba72f.png)
