### PR TITLE
chore: run integration test cases in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint:fix": "npm run lint -- --fix",
     "integration": "testcafe chrome src/**/*.spec.js",
     "integration:single": "testcafe chrome -L",
-    "integration:headless": "testcafe chrome:headless src/**/*.spec.js",
+    "integration:headless": "testcafe -c 4 chrome:headless src/**/*.spec.js",
     "integration:watch": "nodemon --exec \"npm run integration\" --watch src",
     "prep": "run-p lint:fix stylelint:fix test integration",
     "serve-static": "http-server dist -s -p 3000",


### PR DESCRIPTION
testcafe takes a -c <no. processes> flag that lets you run testcases in parallel

1m12s -> 32s on my machine with 4 processes