### PR TITLE
feat: allow NET to take any network that ethersjs supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,17 @@ npm run dev
 
 ### Environmental Variables
 
-`NET` is used for setting the default network, setting it to `mainnet` uses the public Ethereum network. If it is not set it defaults to Ropsten testnet
+`NET` is used for setting the default network, setting it to `mainnet` uses the public Ethereum network. If it is not set it defaults to Ropsten testnet.
+It can also take any network names that Ethers.JS supports, such as `rinkeby`, `kovan`, etc.
+However do note that there are only drag & drop demo files provided for main net and ropsten.
 
 E.g:
 ```bash
 NET=mainnet npm run dev
+```
+or
+```bash
+NET=rinkeby npm run dev
 ```
 
 ### Troubleshooting

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,7 +1,7 @@
 import { getLogger } from "../utils/logger";
 
 const { trace } = getLogger("config");
-const NETWORK = process.env.NET;
+const NETWORK = process.env.NET || "ropsten";
 
 export const NETWORK_TYPES = {
   INFURA_MAINNET: "INFURA_MAINNET",
@@ -20,9 +20,9 @@ export const INFURA_PROJECT_ID = "1f1ff2b3fca04f8d99f67d465c59e4ef";
 export const LEGACY_OPENCERTS_RENDERER = "https://legacy.opencerts.io/";
 
 export const NETWORK_ID = IS_MAINNET ? "1" : "3";
-export const NETWORK_NAME = IS_MAINNET ? "homestead" : "ropsten";
+export const NETWORK_NAME = IS_MAINNET ? "homestead" : NETWORK;
 
-export const ETHERSCAN_BASE_URL = `https://${NETWORK_NAME === "ropsten" ? "ropsten." : ""}etherscan.io/`;
+export const ETHERSCAN_BASE_URL = `https://${IS_MAINNET ? "" : NETWORK_NAME + "."}etherscan.io/`;
 
 trace(`DEFAULT_NETWORK: ${DEFAULT_NETWORK}`);
 trace(`CAPTCHA_CLIENT_KEY: ${CAPTCHA_CLIENT_KEY}`);


### PR DESCRIPTION
NET can now take any string that ethersjs supports

demo cert to be added in a separate story since it involves a non-trivial amount of work such as deploying a token registry and re-wrapping the demo document