### PR TITLE
chore: removed revoke status

### DIFF
--- a/src/components/DocumentStatus/DocumentStatus.test.tsx
+++ b/src/components/DocumentStatus/DocumentStatus.test.tsx
@@ -4,7 +4,6 @@ import { VerificationFragment } from "@govtechsg/oa-verify";
 import { DocumentStatus, IssuedBy } from "./DocumentStatus";
 import {
   whenDocumentHashInvalid,
-  whenDocumentRevoked,
   whenDocumentNotIssued,
   whenDocumentIssuerIdentityInvalid,
   whenDocumentHashInvalidAndNotIssued,
@@ -62,7 +61,6 @@ describe("DocumentStatus", () => {
     const container = render(<DocumentStatus verificationStatus={whenDocumentHashInvalid as VerificationFragment[]} />);
     expect(container.queryByText(MESSAGES["HASH"]["failureTitle"])).not.toBeNull();
     expect(container.queryByText(MESSAGES["ISSUED"]["failureTitle"])).toBeNull();
-    expect(container.queryByText(MESSAGES["REVOKED"]["failureTitle"])).toBeNull();
     expect(container.queryByText(MESSAGES["IDENTITY"]["failureTitle"])).toBeNull();
   });
 
@@ -70,15 +68,6 @@ describe("DocumentStatus", () => {
     const container = render(<DocumentStatus verificationStatus={whenDocumentNotIssued as VerificationFragment[]} />);
     expect(container.queryByText(MESSAGES["HASH"]["failureTitle"])).toBeNull();
     expect(container.queryByText(MESSAGES["ISSUED"]["failureTitle"])).not.toBeNull();
-    expect(container.queryByText(MESSAGES["REVOKED"]["failureTitle"])).toBeNull();
-    expect(container.queryByText(MESSAGES["IDENTITY"]["failureTitle"])).toBeNull();
-  });
-
-  it("displays revocation error if the document is revoked", () => {
-    const container = render(<DocumentStatus verificationStatus={whenDocumentRevoked as VerificationFragment[]} />);
-    expect(container.queryByText(MESSAGES["HASH"]["failureTitle"])).toBeNull();
-    expect(container.queryByText(MESSAGES["ISSUED"]["failureTitle"])).toBeNull();
-    expect(container.queryByText(MESSAGES["REVOKED"]["failureTitle"])).not.toBeNull();
     expect(container.queryByText(MESSAGES["IDENTITY"]["failureTitle"])).toBeNull();
   });
 
@@ -88,7 +77,6 @@ describe("DocumentStatus", () => {
     );
     expect(container.queryByText(MESSAGES["HASH"]["failureTitle"])).toBeNull();
     expect(container.queryByText(MESSAGES["ISSUED"]["failureTitle"])).toBeNull();
-    expect(container.queryByText(MESSAGES["REVOKED"]["failureTitle"])).toBeNull();
     expect(container.queryByText(MESSAGES["IDENTITY"]["failureTitle"])).not.toBeNull();
   });
 
@@ -98,7 +86,6 @@ describe("DocumentStatus", () => {
     );
     expect(container.queryByText(MESSAGES["HASH"]["failureTitle"])).not.toBeNull();
     expect(container.queryByText(MESSAGES["ISSUED"]["failureTitle"])).not.toBeNull();
-    expect(container.queryByText(MESSAGES["REVOKED"]["failureTitle"])).not.toBeNull();
     expect(container.queryByText(MESSAGES["IDENTITY"]["failureTitle"])).not.toBeNull();
   });
 });

--- a/src/components/DocumentStatus/StatusChecks.tsx
+++ b/src/components/DocumentStatus/StatusChecks.tsx
@@ -7,20 +7,17 @@ import { mixin, vars } from "../../styles";
 import { StatusCheck } from "./StatusCheck";
 
 export const StatusChecks = styled(({ verificationStatus }: { verificationStatus: VerificationFragment[] }) => {
-  const { hashValid, issuedValid, revokedValid, identityValid } = interpretFragments(verificationStatus);
+  const { hashValid, issuedValid, identityValid } = interpretFragments(verificationStatus);
 
   return (
     <>
-      <div className="col-12 col-lg-3 col-xl-2 mb-2 mb-lg-0">
+      <div className="col-12 col-lg-4 col-xl-2 mb-2 mb-lg-0">
         <StatusCheck valid={hashValid} messageSet={MESSAGES[TYPES.HASH]} />
       </div>
-      <div className="col-12 col-lg-3 col-xl-2 mb-2 mb-lg-0">
+      <div className="col-12 col-lg-4 col-xl-2 mb-2 mb-lg-0">
         <StatusCheck valid={issuedValid} messageSet={MESSAGES[TYPES.ISSUED]} />
       </div>
-      <div className="col-12 col-lg-3 col-xl-2 mb-2 mb-lg-0">
-        <StatusCheck valid={revokedValid} messageSet={MESSAGES[TYPES.REVOKED]} />
-      </div>
-      <div className="col-12 col-lg-3 col-xl-2 mb-2 mb-lg-0">
+      <div className="col-12 col-lg-4 col-xl-2 mb-2 mb-lg-0">
         <StatusCheck valid={identityValid} messageSet={MESSAGES[TYPES.IDENTITY]} />
       </div>
     </>


### PR DESCRIPTION
- removed revoked status as it is not applicable to some classes of documents, and is not visible anyway .when it is applicable
- did not alter wording of "issued" status check as "Document Status is valid" is not informative to the user