### PR TITLE
fix: remove revoked status check for unverified document

### DIFF
--- a/src/components/CertificateDropZone/Views/UnverifiedView.js
+++ b/src/components/CertificateDropZone/Views/UnverifiedView.js
@@ -8,11 +8,10 @@ import css from "./viewerStyles.module.scss";
 const DetailedErrors = ({ verificationStatus }) => {
   const errors = [];
 
-  const { hashValid, issuedValid, revokedValid, identityValid } = interpretFragments(verificationStatus);
+  const { hashValid, issuedValid, identityValid } = interpretFragments(verificationStatus);
 
   if (!hashValid) errors.push(TYPES.HASH);
   if (!issuedValid) errors.push(TYPES.ISSUED);
-  if (!revokedValid) errors.push(TYPES.REVOKED);
   if (!identityValid) errors.push(TYPES.IDENTITY);
 
   return (

--- a/src/components/CertificateDropZone/Views/UnverifiedView.test.js
+++ b/src/components/CertificateDropZone/Views/UnverifiedView.test.js
@@ -5,7 +5,6 @@ import { UnverifiedView } from "./UnverifiedView";
 import { TYPES, MESSAGES } from "../../../constants/VerificationErrorMessages";
 import {
   whenDocumentHashInvalid,
-  whenDocumentRevoked,
   whenDocumentNotIssued,
   whenDocumentIssuerIdentityInvalid,
 } from "../../../test/fixture/verifier-responses";
@@ -39,21 +38,6 @@ describe("unverifiedView", () => {
     const errorContainerElm = wrapper.find("#error-tab");
     expect(errorContainerElm.text()).toContain(MESSAGES[TYPES.ISSUED].failureTitle);
     expect(errorContainerElm.text()).toContain(MESSAGES[TYPES.ISSUED].failureMessage);
-  });
-
-  it("display revocation error if the document is revoked", () => {
-    const wrapper = mount(
-      <MemoryRouter>
-        <UnverifiedView
-          handleRenderOverwrite={() => {}}
-          verificationStatus={whenDocumentRevoked}
-          resetData={() => {}}
-        />
-      </MemoryRouter>
-    );
-    const errorContainerElm = wrapper.find("#error-tab");
-    expect(errorContainerElm.text()).toContain(MESSAGES[TYPES.REVOKED].failureTitle);
-    expect(errorContainerElm.text()).toContain(MESSAGES[TYPES.REVOKED].failureMessage);
   });
 
   it("displays identity error if the identity is not verified", () => {


### PR DESCRIPTION
forgot to do this in previous PR to remove all mention of revoked status