### PR TITLE
feat: add qrcode rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42523,6 +42523,11 @@
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
+    "qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8="
+    },
     "qrcode-terminal": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.10.0.tgz",
@@ -43349,6 +43354,15 @@
         "jsqr": "^1.2.0",
         "prop-types": "^15.7.2",
         "webrtc-adapter": "^7.2.1"
+      }
+    },
+    "react-qr-svg": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-qr-svg/-/react-qr-svg-2.2.2.tgz",
+      "integrity": "sha512-uUsleAZBsQ0DmN88hBXkUfzxdKzMgQMZxMfIrIj3SXyLM5iqVrGBkMWw57tiknmdet0vu/lvmljgROdLN8KzEA==",
+      "requires": {
+        "prop-types": "^15.5.8",
+        "qr.js": "0.0.0"
       }
     },
     "react-redux": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-helmet": "^5.2.1",
     "react-hot-loader": "^4.12.14",
     "react-qr-reader": "^2.2.1",
+    "react-qr-svg": "^2.2.2",
     "react-redux": "^7.1.1",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",

--- a/src/components/DocumentUtility/DocumentUtility.stories.tsx
+++ b/src/components/DocumentUtility/DocumentUtility.stories.tsx
@@ -1,15 +1,34 @@
 import React from "react";
 import { DocumentUtility, DocumentUtilityUnStyled } from "./DocumentUtility";
-import document from "../../test/fixture/ebl.json";
 
 export default {
   title: "Viewer/DocumentUtility",
   component: DocumentUtilityUnStyled,
   parameters: {
-    componentSubtitle: "Utility functions relating to document, Print, Download.",
+    componentSubtitle: "Utility functions relating to document, Display QR Code, Print, Download.",
+  },
+};
+
+const documentWithoutQr = {
+  data: {
+    name: "bah bah black sheep",
+  },
+};
+
+const documentWithQr = {
+  data: {
+    name: "bah bah black sheep",
+    links: {
+      self: {
+        href: "https://openattestation.com",
+      },
+    },
   },
 };
 
 export const PrintAndDownload = () => {
-  return <DocumentUtility document={document as any} handleSharingToggle={() => {}} />;
+  return <DocumentUtility document={documentWithoutQr as any} handleSharingToggle={() => {}} />;
+};
+export const QRPrintAndDownload = () => {
+  return <DocumentUtility document={documentWithQr as any} handleSharingToggle={() => {}} />;
 };

--- a/src/components/DocumentUtility/DocumentUtility.test.tsx
+++ b/src/components/DocumentUtility/DocumentUtility.test.tsx
@@ -1,0 +1,42 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import React from "react";
+import { act } from "react-dom/test-utils";
+import { DocumentUtility } from "./DocumentUtility";
+
+describe("Nominate Beneficiary", () => {
+  it("should show QR code when document has one", async () => {
+    const document = {
+      data: {
+        name: "bah bah black sheep",
+        links: {
+          self: {
+            href: "https://openattestation.com",
+          },
+        },
+      },
+    };
+    await act(async () => {
+      const container = render(<DocumentUtility document={document as any} handleSharingToggle={() => {}} />);
+
+      const qrbuttonComponent = container.getByRole("button", { name: "document-utility-qr-button" });
+
+      expect(qrbuttonComponent).toBeVisible();
+    });
+  });
+
+  it("should not show QR code when document does not have one", async () => {
+    const document = {
+      data: {
+        name: "bah bah black sheep",
+      },
+    };
+    await act(async () => {
+      const container = render(<DocumentUtility document={document as any} handleSharingToggle={() => {}} />);
+
+      const qrbuttonComponent = container.queryByRole("button", { name: "document-utility-qr-button" });
+
+      expect(qrbuttonComponent).toBeNull();
+    });
+  });
+});

--- a/src/components/DocumentUtility/DocumentUtility.tsx
+++ b/src/components/DocumentUtility/DocumentUtility.tsx
@@ -16,17 +16,12 @@ interface DocumentUtilityProps {
 
 export const DocumentUtilityUnStyled = ({ document, handleSharingToggle, className }: DocumentUtilityProps) => {
   const fileName = getData(document).name;
+  const qrcodeUrl = getData(document)?.links?.self?.href ?? "";
 
-  const qrCodePopover = (
+  const qrCodePopover = (url: string) => (
     <Popover id="qr-code-popover" style={{ borderRadius: 0, border: "1px solid #DDDDDD" }}>
-      <Popover.Content style={{padding:0}}>
-        <QRCode
-          bgColor="#FFFFFF"
-          fgColor="#000000"
-          level="Q"
-          style={{ width: 150, padding: "10px" }}
-          value="some textsome textsome textsome textsome"
-        />
+      <Popover.Content style={{ padding: 0 }}>
+        <QRCode bgColor="#FFFFFF" fgColor="#000000" level="Q" style={{ width: 200, padding: "10px" }} value={url} />
       </Popover.Content>
     </Popover>
   );
@@ -36,8 +31,8 @@ export const DocumentUtilityUnStyled = ({ document, handleSharingToggle, classNa
       <div className="container-custom">
         <div className="row no-gutters">
           <div className="col-auto ml-auto">
-            <OverlayTrigger trigger="click" placement="bottom-end" overlay={qrCodePopover}>
-              <ButtonIconWhiteBlue>
+            <OverlayTrigger trigger="click" placement="bottom-end" overlay={qrCodePopover(qrcodeUrl)}>
+              <ButtonIconWhiteBlue aria-label="document-utility-qr-button" hidden={!qrcodeUrl}>
                 <SvgIcon strokeWidth="0.5" fill="currentColor">
                   <SvgIconQRCode />
                 </SvgIcon>
@@ -45,7 +40,7 @@ export const DocumentUtilityUnStyled = ({ document, handleSharingToggle, classNa
             </OverlayTrigger>
           </div>
           <div className="col-auto ml-3">
-            <ButtonIconWhiteBlue onClick={() => window.print()}>
+            <ButtonIconWhiteBlue aria-label="document-utility-print-button" onClick={() => window.print()}>
               <SvgIcon>
                 <SvgIconPrinter />
               </SvgIcon>
@@ -53,7 +48,10 @@ export const DocumentUtilityUnStyled = ({ document, handleSharingToggle, classNa
           </div>
           <FeatureFlag name="SHARE_BY_EMAIL">
             <div className="col-auto ml-3">
-              <ButtonIconWhiteBlue onClick={() => handleSharingToggle()}>
+              <ButtonIconWhiteBlue
+                aria-label="document-utility-share-by-email-button"
+                onClick={() => handleSharingToggle()}
+              >
                 <SvgIcon>
                   <SvgIconEmail />
                 </SvgIcon>
@@ -66,7 +64,7 @@ export const DocumentUtilityUnStyled = ({ document, handleSharingToggle, classNa
               target="_black"
               href={`data:text/plain;,${encodeURIComponent(JSON.stringify(document, null, 2))}`}
             >
-              <ButtonIconWhiteBlue>
+              <ButtonIconWhiteBlue aria-label="document-utility-download-document-button">
                 <SvgIcon>
                   <SvgIconDownload />
                 </SvgIcon>

--- a/src/components/DocumentUtility/DocumentUtility.tsx
+++ b/src/components/DocumentUtility/DocumentUtility.tsx
@@ -31,13 +31,15 @@ export const DocumentUtilityUnStyled = ({ document, handleSharingToggle, classNa
       <div className="container-custom">
         <div className="row no-gutters">
           <div className="col-auto ml-auto">
-            <OverlayTrigger trigger="click" placement="bottom-end" overlay={qrCodePopover(qrcodeUrl)}>
-              <ButtonIconWhiteBlue aria-label="document-utility-qr-button" hidden={!qrcodeUrl}>
-                <SvgIcon strokeWidth="0.5" fill="currentColor">
-                  <SvgIconQRCode />
-                </SvgIcon>
-              </ButtonIconWhiteBlue>
-            </OverlayTrigger>
+            {qrcodeUrl && (
+              <OverlayTrigger trigger="click" placement="bottom-end" overlay={qrCodePopover(qrcodeUrl)}>
+                <ButtonIconWhiteBlue aria-label="document-utility-qr-button">
+                  <SvgIcon strokeWidth="0.5" fill="currentColor">
+                    <SvgIconQRCode />
+                  </SvgIcon>
+                </ButtonIconWhiteBlue>
+              </OverlayTrigger>
+            )}
           </div>
           <div className="col-auto ml-3">
             <ButtonIconWhiteBlue aria-label="document-utility-print-button" onClick={() => window.print()}>

--- a/src/components/DocumentUtility/DocumentUtility.tsx
+++ b/src/components/DocumentUtility/DocumentUtility.tsx
@@ -5,6 +5,8 @@ import { mixin, vars } from "../../styles";
 import { FeatureFlag } from "../FeatureFlag";
 import { SvgIcon, SvgIconPrinter, SvgIconEmail, SvgIconDownload, SvgIconQRCode } from "../UI/SvgIcon";
 import { ButtonIconWhiteBlue } from "../UI/Button";
+import { Popover, OverlayTrigger } from "react-bootstrap";
+import { QRCode } from "react-qr-svg";
 
 interface DocumentUtilityProps {
   document: WrappedDocument;
@@ -15,16 +17,32 @@ interface DocumentUtilityProps {
 export const DocumentUtilityUnStyled = ({ document, handleSharingToggle, className }: DocumentUtilityProps) => {
   const fileName = getData(document).name;
 
+  const qrCodePopover = (
+    <Popover id="qr-code-popover" style={{ borderRadius: 0, border: "1px solid #DDDDDD" }}>
+      <Popover.Content style={{padding:0}}>
+        <QRCode
+          bgColor="#FFFFFF"
+          fgColor="#000000"
+          level="Q"
+          style={{ width: 150, padding: "10px" }}
+          value="some textsome textsome textsome textsome"
+        />
+      </Popover.Content>
+    </Popover>
+  );
+
   return (
     <div className={`${className}`}>
       <div className="container-custom">
         <div className="row no-gutters">
           <div className="col-auto ml-auto">
-            <ButtonIconWhiteBlue onClick={() => window.print()}>
-              <SvgIcon strokeWidth="0.5" fill="currentColor">
-                <SvgIconQRCode />
-              </SvgIcon>
-            </ButtonIconWhiteBlue>
+            <OverlayTrigger trigger="click" placement="bottom-end" overlay={qrCodePopover}>
+              <ButtonIconWhiteBlue>
+                <SvgIcon strokeWidth="0.5" fill="currentColor">
+                  <SvgIconQRCode />
+                </SvgIcon>
+              </ButtonIconWhiteBlue>
+            </OverlayTrigger>
           </div>
           <div className="col-auto ml-3">
             <ButtonIconWhiteBlue onClick={() => window.print()}>

--- a/src/components/DocumentUtility/DocumentUtility.tsx
+++ b/src/components/DocumentUtility/DocumentUtility.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { getData, WrappedDocument } from "@govtechsg/open-attestation";
 import { mixin, vars } from "../../styles";
 import { FeatureFlag } from "../FeatureFlag";
-import { SvgIcon, SvgIconPrinter, SvgIconEmail, SvgIconDownload } from "../UI/SvgIcon";
+import { SvgIcon, SvgIconPrinter, SvgIconEmail, SvgIconDownload, SvgIconQRCode } from "../UI/SvgIcon";
 import { ButtonIconWhiteBlue } from "../UI/Button";
 
 interface DocumentUtilityProps {
@@ -20,6 +20,13 @@ export const DocumentUtilityUnStyled = ({ document, handleSharingToggle, classNa
       <div className="container-custom">
         <div className="row no-gutters">
           <div className="col-auto ml-auto">
+            <ButtonIconWhiteBlue onClick={() => window.print()}>
+              <SvgIcon strokeWidth="0.5" fill="currentColor">
+                <SvgIconQRCode />
+              </SvgIcon>
+            </ButtonIconWhiteBlue>
+          </div>
+          <div className="col-auto ml-3">
             <ButtonIconWhiteBlue onClick={() => window.print()}>
               <SvgIcon>
                 <SvgIconPrinter />

--- a/src/components/UI/Button/Button.tsx
+++ b/src/components/UI/Button/Button.tsx
@@ -8,7 +8,6 @@ interface ButtonProps {
   children?: React.ReactNode;
   className?: string;
   disabled?: boolean;
-  hidden?: boolean;
   onClick?(event: React.MouseEvent<HTMLButtonElement>): void;
 }
 

--- a/src/components/UI/Button/Button.tsx
+++ b/src/components/UI/Button/Button.tsx
@@ -8,6 +8,7 @@ interface ButtonProps {
   children?: React.ReactNode;
   className?: string;
   disabled?: boolean;
+  hidden?: boolean;
   onClick?(event: React.MouseEvent<HTMLButtonElement>): void;
 }
 

--- a/src/components/UI/SvgIcon/SvgIcon.stories.tsx
+++ b/src/components/UI/SvgIcon/SvgIcon.stories.tsx
@@ -22,6 +22,7 @@ import {
   SvgIconTrash2,
   SvgIconPaperClip,
   SvgIconFlag,
+  SvgIconQRCode,
 } from "./SvgIcon";
 
 export default {
@@ -180,6 +181,13 @@ export const PaperClip = () => {
   return (
     <SvgIcon>
       <SvgIconPaperClip />
+    </SvgIcon>
+  );
+};
+export const QrCode = () => {
+  return (
+    <SvgIcon strokeWidth="0.5" fill="currentColor">
+      <SvgIconQRCode />
     </SvgIcon>
   );
 };

--- a/src/components/UI/SvgIcon/SvgIcon.tsx
+++ b/src/components/UI/SvgIcon/SvgIcon.tsx
@@ -218,6 +218,39 @@ export const SvgIconFlag = () => {
   );
 };
 
+export const SvgIconQRCode = () => {
+  return (
+    <g className="qrcode">
+      <path d="M9 0H0V9H9V0ZM7.5 7.5H1.5V1.5H7.5V7.5Z" />
+      <path d="M3 3H6V6H3V3Z" />
+      <path d="M0 24H9V15H0V24ZM1.5 16.5H7.5V22.5H1.5V16.5Z" />
+      <path d="M3 18H6V21H3V18Z" />
+      <path d="M15 0V9H24V0H15ZM22.5 7.5H16.5V1.5H22.5V7.5Z" />
+      <path d="M18 3H21V6H18V3Z" />
+      <path d="M3 10.5H0V13.5H4.5V12H3V10.5Z" />
+      <path d="M10.5 13.5H13.5V16.5H10.5V13.5Z" />
+      <path d="M4.5 10.5H7.5V12H4.5V10.5Z" />
+      <path d="M13.5 18H10.5V19.5H12V21H13.5V19.5V18Z" />
+      <path d="M9 10.5V12H7.5V13.5H10.5V10.5H9Z" />
+      <path d="M12 6H13.5V9H12V6Z" />
+      <path d="M13.5 12V13.5H16.5V10.5H12V12H13.5Z" />
+      <path d="M10.5 9H12V10.5H10.5V9Z" />
+      <path d="M13.5 21H16.5V24H13.5V21Z" />
+      <path d="M10.5 21H12V24H10.5V21Z" />
+      <path d="M13.5 16.5H15V18H13.5V16.5Z" />
+      <path d="M13.5 4.5V1.5H12V0H10.5V6H12V4.5H13.5Z" />
+      <path d="M18 21H19.5V24H18V21Z" />
+      <path d="M18 18H21V19.5H18V18Z" />
+      <path d="M16.5 19.5H18V21H16.5V19.5Z" />
+      <path d="M15 18H16.5V19.5H15V18Z" />
+      <path d="M21 15V16.5H22.5V18H24V15H22.5H21Z" />
+      <path d="M22.5 19.5H21V24H24V21H22.5V19.5Z" />
+      <path d="M15 15V16.5H19.5V13.5H16.5V15H15Z" />
+      <path d="M18 10.5V12H21V13.5H24V10.5H21H18Z" />
+    </g>
+  );
+};
+
 export const SvgIcon = ({ tooltipId, children, ...props }: SvgIconProps) => {
   const tooltipProps = tooltipId
     ? {

--- a/src/test/fixture/ebl-with-qrcode.json
+++ b/src/test/fixture/ebl-with-qrcode.json
@@ -1,0 +1,60 @@
+{
+  "version": "https://schema.openattestation.com/2.0/schema.json",
+  "data": {
+    "links": {
+      "self": {
+        "href": "4f27b234-ab28-40a9-be72-dccb59e438c5:string:https://action.openattestation.com/?q=%7B%22type%22:%22DOCUMENT%22,%22payload%22:%20%7B%22uri%22:%20%22https://api-ropsten.tradetrust.io/storage/33737b71-96f6-4019-b6c1-5fcea04fcc2a%22,%22key%22:%20%22edcbadf17301fe5dfe174496c7edf29e0702e2775ee919bbccb74d0dfd5a1b4b%22,%22permittedActions%22:%20%5B%22STORE%22%5D,%22redirect%22:%20%22https://dev.tradetrust.io%22%7D%7D"
+      }
+    },
+    "$template": {
+      "type": "33488830-0854-4205-a4c3-9ba7e28e7b61:string:EMBEDDED_RENDERER",
+      "name": "9d924d6f-1154-4499-9c1c-262dd3990db6:string:BILL_OF_LADING",
+      "url": "e3edeb43-439f-4c30-8ab4-3fb2d20bd938:string:https://demo-cnm.openattestation.com"
+    },
+    "issuers": [
+      {
+        "identityProof": {
+          "type": "517691ab-e726-4531-9208-c83b0348b488:string:DNS-TXT",
+          "location": "175f08b5-a6bc-4210-8106-353fd9c99392:string:tradetrust.io"
+        },
+        "name": "fde3d483-648e-4850-90c6-7e0bd22eb559:string:DEMO STORE",
+        "tokenRegistry": "e89c9055-63a1-4f74-afd0-89026976ee84:string:0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
+      }
+    ],
+    "consignee": {
+      "name": "c30108fb-3d77-4937-8f3b-5513568d87ee:string:Demo Consignee",
+      "type": "fa895af7-8f14-4f17-a18e-5be7d474f902:string:To the owner of"
+    },
+    "notifyParty": {
+      "name": "a0faceac-dd53-4094-ba24-b9c16602a068:string:Demo Notify"
+    },
+    "shipper": {
+      "address": {
+        "street": "42349544-3334-4e4a-a5cd-dbad04421dec:string:One North",
+        "country": "1269bd96-1161-4418-98b3-df7ab8643efa:string:Singapore"
+      },
+      "name": "a64508fe-c1d1-4357-87be-aa545834a989:string:Demo Shipper"
+    },
+    "packages": [
+      {
+        "description": "f0e74d62-2329-4d99-9a23-3800d2961f9b:string:Green Apples",
+        "weight": "be90f2d5-3174-4c87-aee8-f7d00a75054c:number:20",
+        "measurement": "6a35d110-8ae6-4c9a-9390-ecbae03cf271:string:100"
+      }
+    ],
+    "blNumber": "a92811e7-fddc-4005-84cc-85dc362c417d:string:123",
+    "name": "01c1b436-f322-474a-ab5b-11f28d225899:string:Maersk Bill of Lading",
+    "vessel": "71031272-1f72-4e38-9dec-570dd042a38c:string:1",
+    "voyageNo": "daef332d-c31a-4490-8e39-9607aaa567ed:number:100",
+    "portOfLoading": "c9d3e669-6feb-4261-ba86-012aa316a089:string:Singapore Port",
+    "portOfDischarge": "4b5f0295-e6e4-45c5-8603-e8567e64f703:string:China Port",
+    "placeOfReceipt": "28823079-e50a-4114-81e6-a84a4c703ba6:string:Beijing",
+    "placeOfDelivery": "9bc210a1-8ba7-47d9-be49-198858032f75:string:Singapore"
+  },
+  "signature": {
+    "type": "SHA3MerkleProof",
+    "targetHash": "bfacf3a62425e1514b55d2f9a585f06e84bc5453ad76eedc26f34d709ef4d2d7",
+    "proof": [],
+    "merkleRoot": "bfacf3a62425e1514b55d2f9a585f06e84bc5453ad76eedc26f34d709ef4d2d7"
+  }
+}

--- a/src/test/qrcode.spec.js
+++ b/src/test/qrcode.spec.js
@@ -1,0 +1,28 @@
+import { Selector } from "testcafe";
+
+fixture("Token Document Rendering").page`http://localhost:3000`;
+
+const Document = "./fixture/ebl-with-qrcode.json";
+const IframeBlock = Selector("#iframe");
+const SampleTemplate = Selector("#root");
+const DocumentStatus = Selector("#document-status");
+const IssuedByDomainName = Selector("#issuedby .domain");
+
+const validateTextContent = async (t, component, texts) =>
+  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
+
+test("UI renders QR code correctly when present in the document", async (t) => {
+  const container = Selector("#certificate-dropzone");
+  await container();
+  await t.setFilesToUpload("input[type=file]", [Document]);
+
+  await DocumentStatus.with({ visibilityCheck: true })();
+
+  const qrcodeButtonElement = await Selector("button").withAttribute("aria-label", "document-utility-qr-button");
+  await t.click(qrcodeButtonElement);
+  await validateTextContent(t, IssuedByDomainName, ["TRADETRUST.IO"]);
+
+  await t.switchToIframe(IframeBlock);
+
+  await validateTextContent(t, SampleTemplate, ["BILL OF LADING FOR OCEAN TRANSPORT OR MULTIMODAL TRANSPORT"]);
+});

--- a/src/test/qrcode.spec.js
+++ b/src/test/qrcode.spec.js
@@ -1,6 +1,6 @@
 import { Selector } from "testcafe";
 
-fixture("Token Document Rendering").page`http://localhost:3000`;
+fixture("QRcode Rendering").page`http://localhost:3000`;
 
 const Document = "./fixture/ebl-with-qrcode.json";
 const IframeBlock = Selector("#iframe");
@@ -19,7 +19,7 @@ test("UI renders QR code correctly when present in the document", async (t) => {
   await DocumentStatus.with({ visibilityCheck: true })();
 
   const qrcodeButtonElement = await Selector("button").withAttribute("aria-label", "document-utility-qr-button");
-  await t.click(qrcodeButtonElement);
+  await t.click(qrcodeButtonElement); // asserts that button exists and can be clicked
   await validateTextContent(t, IssuedByDomainName, ["TRADETRUST.IO"]);
 
   await t.switchToIframe(IframeBlock);


### PR DESCRIPTION
- added a popover for qrcode using react-bootstrap
- qrcode button is hidden if no url is located at { data: { links: self: href: "xx" } } }
- qrcode button is shown otherwise
- qr code format is simply a url, can use format at https://github.com/Open-Attestation/adr/blob/master/universal_actions.md
- can use ebl-with-qr-code.json in test fixtures to test
- has storybook story showing how it looks like