### PR TITLE
fix: dropdown with tabpane

### DIFF
--- a/src/components/CertificateViewer.tsx
+++ b/src/components/CertificateViewer.tsx
@@ -53,32 +53,36 @@ export const CertificateViewer = ({
   }, []);
 
   const validCertificateContent = (
-    <Tab.Container defaultActiveKey="tab-document">
+    <>
       <div className="bg-blue-lighter no-print">
         <DocumentStatus verificationStatus={verificationStatus} />
         {tokenRegistryAddress && <AssetManagementContainer document={document} />}
         <MultiButtons tokenRegistryAddress={tokenRegistryAddress} />
-        <MultiTabs
-          hasAttachments={hasAttachments}
-          attachments={attachments}
-          templates={templates}
-          setSelectedTemplate={setSelectedTemplate}
-          selectedTemplate={selectedTemplate}
-        />
       </div>
-      <div className="bg-white">
-        <Tab.Content className="py-4">
-          <Tab.Pane eventKey="tab-document">
-            <DocumentUtility className="no-print" document={document} handleSharingToggle={handleSharingToggle} />
-            <DecentralisedRendererContainer
-              rawDocument={document}
-              updateTemplates={updateTemplates}
-              selectedTemplate={selectedTemplate}
-            />
-          </Tab.Pane>
-          {hasAttachments && <TabPaneAttachments attachments={attachments} />}
-        </Tab.Content>
-      </div>
+      <Tab.Container defaultActiveKey="tab-document">
+        <div className="bg-blue-lighter no-print">
+          <MultiTabs
+            hasAttachments={hasAttachments}
+            attachments={attachments}
+            templates={templates}
+            setSelectedTemplate={setSelectedTemplate}
+            selectedTemplate={selectedTemplate}
+          />
+        </div>
+        <div className="bg-white">
+          <Tab.Content className="py-4">
+            <Tab.Pane eventKey="tab-document">
+              <DocumentUtility className="no-print" document={document} handleSharingToggle={handleSharingToggle} />
+              <DecentralisedRendererContainer
+                rawDocument={document}
+                updateTemplates={updateTemplates}
+                selectedTemplate={selectedTemplate}
+              />
+            </Tab.Pane>
+            {hasAttachments && <TabPaneAttachments attachments={attachments} />}
+          </Tab.Content>
+        </div>
+      </Tab.Container>
       <ModalDialog show={showSharing} toggle={handleSharingToggle}>
         <CertificateSharingForm
           emailSendingState={emailSendingState}
@@ -86,7 +90,7 @@ export const CertificateViewer = ({
           handleSharingToggle={handleSharingToggle}
         />
       </ModalDialog>
-    </Tab.Container>
+    </>
   );
 
   return <ErrorBoundary>{validCertificateContent}</ErrorBoundary>;


### PR DESCRIPTION
### pr updates
- move AssetManagementContainer (which contains dropdown) outside of Tab.Container (which contains Tab.Pane) to prevent conflicting intention, which rendered Tab.Pane without `.show.active` classes causing the renderer to "disappear"
- issue referenced at https://react-bootstrap.github.io/components/tabs/#tabs-with-dropdown

### user story
- https://www.pivotaltracker.com/story/show/173789848

### preview
![Screenshot 2020-07-14 at 3 57 31 PM](https://user-images.githubusercontent.com/4774314/87399981-c49f1300-c5ea-11ea-8273-f5c2b71f6ff3.png)
