### PR TITLE
feat: select address

### DIFF
--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/EditableAssetTitle/EditableAssetTitle.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/EditableAssetTitle/EditableAssetTitle.tsx
@@ -1,15 +1,19 @@
-import React from "react";
+import React, { useContext } from "react";
 import { ExternalLinkEtherscanAddress } from "../../../../UI/ExternalLink";
 import { InputEditableAssetTitle, InputEditableWrapper, InputError } from "../../../../UI/Input";
 import { AssetTitle } from "../../../AssetTitle";
 import { SkeletonPlaceholder } from "../../SkeletonPlaceholder";
+import { ButtonIconOrangeWhite } from "./../../../../UI/Button";
+import { SvgIcon, SvgIconBook } from "./../../../../UI/SvgIcon";
+import { OverlayContext } from "./../../../../../common/contexts/OverlayContext";
+import { AddressBook } from "./../../../../../components/UI/Overlay/OverlayContent/AddressBook";
 
 interface EditableAssetTitleProps {
   role: string;
   value?: string;
   isEditable: boolean;
   newValue?: string;
-  onSetNewValue?: (newBeneficiary: string) => void;
+  onSetNewValue?: (newValue: string) => void;
   error?: boolean;
 }
 
@@ -21,6 +25,11 @@ export const EditableAssetTitle = ({
   onSetNewValue,
   error,
 }: EditableAssetTitleProps) => {
+  const { showOverlay } = useContext(OverlayContext);
+  const onOverlayHandler = () => {
+    showOverlay(<AddressBook title="Address Book" onSetNewValue={onSetNewValue} />);
+  };
+
   if (!value) return <SkeletonPlaceholder />;
   if (!isEditable)
     return (
@@ -33,9 +42,9 @@ export const EditableAssetTitle = ({
       </AssetTitle>
     );
   return (
-    <AssetTitle role={role} address="">
+    <AssetTitle role={role} address={newValue ? newValue : ""}>
       <div className="row no-gutters align-items-center">
-        <InputEditableWrapper className="col">
+        <InputEditableWrapper className="col mr-2">
           <InputEditableAssetTitle
             data-testid={`editable-input-${role.toLowerCase()}`}
             value={newValue}
@@ -50,6 +59,13 @@ export const EditableAssetTitle = ({
             <InputError data-testid={"error-msg"}>Unidentified address. Please check and input again.</InputError>
           )}
         </InputEditableWrapper>
+        <div className="col-auto">
+          <ButtonIconOrangeWhite onClick={onOverlayHandler}>
+            <SvgIcon>
+              <SvgIconBook />
+            </SvgIcon>
+          </ButtonIconOrangeWhite>
+        </div>
       </div>
     </AssetTitle>
   );

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/EditableAssetTitle/EditableAssetTitle.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/EditableAssetTitle/EditableAssetTitle.tsx
@@ -27,7 +27,7 @@ export const EditableAssetTitle = ({
 }: EditableAssetTitleProps) => {
   const { showOverlay } = useContext(OverlayContext);
   const onOverlayHandler = () => {
-    showOverlay(<AddressBook title="Address Book" onSetNewValue={onSetNewValue} />);
+    showOverlay(<AddressBook title="Address Book" onAddressSelected={onSetNewValue} />);
   };
 
   if (!value) return <SkeletonPlaceholder />;
@@ -42,7 +42,7 @@ export const EditableAssetTitle = ({
       </AssetTitle>
     );
   return (
-    <AssetTitle role={role} address={newValue ? newValue : ""}>
+    <AssetTitle role={role} address={newValue || ""}>
       <div className="row no-gutters align-items-center">
         <InputEditableWrapper className="col mr-2">
           <InputEditableAssetTitle

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/EndorseBeneficiary/EndorseBeneficiary.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/EndorseBeneficiary/EndorseBeneficiary.tsx
@@ -88,6 +88,7 @@ export const EndorseBeneficiaryForm = ({
             <EditableAssetTitle
               role="Holder"
               value={holder}
+              newValue={newHolder}
               isEditable={isEditable}
               onSetNewValue={setNewHolder}
               error={beneficiaryEndorseState === FormState.ERROR}

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/NominateBeneficiaryHolder/NominateBeneficiaryHolder.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/NominateBeneficiaryHolder/NominateBeneficiaryHolder.tsx
@@ -86,6 +86,7 @@ export const NominateBeneficiaryHolderForm = ({
             <EditableAssetTitle
               role="Holder"
               value={holder}
+              newValue={newHolder}
               isEditable={isEditable}
               onSetNewValue={setNewHolder}
               error={nominationState === FormState.ERROR}

--- a/src/components/MultiButtons/MultiButtons.tsx
+++ b/src/components/MultiButtons/MultiButtons.tsx
@@ -13,7 +13,7 @@ interface MultiButtonsProps {
 export const MultiButtonsUnStyled = ({ className, tokenRegistryAddress }: MultiButtonsProps) => {
   const { showOverlay } = useContext(OverlayContext);
   const onOverlayHandler = () => {
-    showOverlay(<AddressBook title="Address Book" data-testid="overlay-addressbook" />);
+    showOverlay(<AddressBook title="Address Book" />);
   };
 
   return (

--- a/src/components/UI/Button/Button.tsx
+++ b/src/components/UI/Button/Button.tsx
@@ -120,6 +120,19 @@ const bgWhiteModifier = ({ hoverColor }: BgWhiteModifierProps) => {
   `;
 };
 
+const iconButtonStyle = () => {
+  return `
+    width: 40px;
+    height: 40px;
+
+    svg {
+      max-width: 16px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+  `;
+};
+
 const bgWhiteTextSecondary = `
   ${baseStyleButton({
     bgColor: vars.white,
@@ -206,9 +219,7 @@ export const ButtonIconWhiteOrange = styled(Button)`
     hoverColor: vars.brandOrange,
   })}
 
-  svg {
-    max-width: 16px;
-  }
+  ${iconButtonStyle()};
 `;
 
 export const ButtonIconWhiteBlue = styled(Button)`
@@ -221,9 +232,7 @@ export const ButtonIconWhiteBlue = styled(Button)`
     hoverColor: vars.brandBlue,
   })}
 
-  svg {
-    max-width: 16px;
-  }
+  ${iconButtonStyle()};
 `;
 
 export const ButtonIconOrangeWhite = styled(Button)`
@@ -236,9 +245,7 @@ export const ButtonIconOrangeWhite = styled(Button)`
     hoverColor: vars.brandOrange,
   })}
 
-  svg {
-    max-width: 16px;
-  }
+  ${iconButtonStyle()};
 `;
 
 export const ButtonCircleGreylight = styled(Button)`

--- a/src/components/UI/Input/Input.tsx
+++ b/src/components/UI/Input/Input.tsx
@@ -53,6 +53,7 @@ export const InputEditableAssetTitle = styled.input`
   ${mixin.baseStyleInput()};
   margin-bottom: 0;
   width: 100%;
+  min-height: 40px;
   ${({ hasError }: EditableAssetTitleProps) => hasError && `border: 1px solid ${vars.red}`};
 `;
 

--- a/src/components/UI/Overlay/OverlayContent/AddressBook.tsx
+++ b/src/components/UI/Overlay/OverlayContent/AddressBook.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { OverlayContentBaseStyle } from "./../Overlay";
 import { TableStyle } from "./../../../AddressResolver/AddressesTable";
 import { OverlayContent, OverlayContentProps } from "./index";
@@ -9,8 +9,14 @@ import { CsvUploadButton } from "../../../AddressBook/CsvUploadButton";
 import { isEmpty } from "lodash";
 import { makeEtherscanAddressURL } from "../../../../utils";
 import { vars } from "../../../../styles";
+import { OverlayContext } from "./../../../../common/contexts/OverlayContext";
 
-export const AddressBook = styled(({ ...props }: OverlayContentProps) => {
+interface AddressBookProps extends OverlayContentProps {
+  onSetNewValue?: (newValue: string) => void;
+}
+
+export const AddressBook = styled(({ onSetNewValue, ...props }: AddressBookProps) => {
+  const { setOverlayVisible } = useContext(OverlayContext);
   const { addressBook } = useAddressBook();
   const [searchTerm, setSearchTerm] = useState("");
 
@@ -20,7 +26,7 @@ export const AddressBook = styled(({ ...props }: OverlayContentProps) => {
   };
 
   return (
-    <OverlayContent {...props}>
+    <OverlayContent data-testid="overlay-addressbook" {...props}>
       <div className="overlay-actionsbar">
         <div className="row align-items-center">
           <div className="col">
@@ -74,6 +80,12 @@ export const AddressBook = styled(({ ...props }: OverlayContentProps) => {
                         ? ""
                         : "d-none"
                     }
+                    onClick={() => {
+                      if (onSetNewValue) {
+                        onSetNewValue(address);
+                        setOverlayVisible(false);
+                      }
+                    }}
                   >
                     <th>{name}</th>
                     <td>
@@ -124,6 +136,18 @@ export const AddressBook = styled(({ ...props }: OverlayContentProps) => {
 
   .table-tbody {
     height: 360px;
+
+    tr {
+      cursor: ${(props) => (props.onSetNewValue ? "pointer" : "default")};
+
+      &:hover {
+        background-color: ${(props) => (props.onSetNewValue ? vars.greyLighter : "inherit")};
+
+        &:nth-of-type(even) {
+          background-color: ${(props) => (props.onSetNewValue ? vars.greyLighter : "inherit")};
+        }
+      }
+    }
   }
 
   .table {

--- a/src/components/UI/Overlay/OverlayContent/AddressBook.tsx
+++ b/src/components/UI/Overlay/OverlayContent/AddressBook.tsx
@@ -4,7 +4,7 @@ import { TableStyle } from "./../../../AddressResolver/AddressesTable";
 import { OverlayContent, OverlayContentProps } from "./index";
 import styled from "@emotion/styled";
 import { useAddressBook } from "../../../../common/hooks/useAddressBook";
-import { SvgIcon, SvgIconSearch } from "../../../UI/SvgIcon";
+import { SvgIcon, SvgIconSearch, SvgIconExternalLink } from "../../../UI/SvgIcon";
 import { CsvUploadButton } from "../../../AddressBook/CsvUploadButton";
 import { isEmpty } from "lodash";
 import { makeEtherscanAddressURL } from "../../../../utils";
@@ -12,10 +12,10 @@ import { vars } from "../../../../styles";
 import { OverlayContext } from "./../../../../common/contexts/OverlayContext";
 
 interface AddressBookProps extends OverlayContentProps {
-  onSetNewValue?: (newValue: string) => void;
+  onAddressSelected?: (newValue: string) => void;
 }
 
-export const AddressBook = styled(({ onSetNewValue, ...props }: AddressBookProps) => {
+export const AddressBook = styled(({ onAddressSelected, ...props }: AddressBookProps) => {
   const { setOverlayVisible } = useContext(OverlayContext);
   const { addressBook } = useAddressBook();
   const [searchTerm, setSearchTerm] = useState("");
@@ -54,6 +54,7 @@ export const AddressBook = styled(({ onSetNewValue, ...props }: AddressBookProps
             <tr>
               <th>Name</th>
               <td>Address</td>
+              <td>&nbsp;</td>
             </tr>
           </thead>
           <tbody className="table-tbody">
@@ -61,6 +62,7 @@ export const AddressBook = styled(({ onSetNewValue, ...props }: AddressBookProps
               <tr>
                 <th>&mdash;</th>
                 <td>No Address found.</td>
+                <td>&nbsp;</td>
               </tr>
             ) : (
               Object.keys(addressBook).map((key) => {
@@ -81,16 +83,19 @@ export const AddressBook = styled(({ onSetNewValue, ...props }: AddressBookProps
                         : "d-none"
                     }
                     onClick={() => {
-                      if (onSetNewValue) {
-                        onSetNewValue(address);
+                      if (onAddressSelected) {
+                        onAddressSelected(address);
                         setOverlayVisible(false);
                       }
                     }}
                   >
                     <th>{name}</th>
+                    <td>{address}</td>
                     <td>
                       <a href={addressHref} target="_blank" rel="noreferrer noopener">
-                        {address}
+                        <SvgIcon>
+                          <SvgIconExternalLink />
+                        </SvgIcon>
                       </a>
                     </td>
                   </tr>
@@ -138,13 +143,20 @@ export const AddressBook = styled(({ onSetNewValue, ...props }: AddressBookProps
     height: 360px;
 
     tr {
-      cursor: ${(props) => (props.onSetNewValue ? "pointer" : "default")};
+      transition: background-color 0.3s ${vars.easeOutCubic};
+      cursor: ${(props) => (props.onAddressSelected ? "pointer" : "default")};
 
       &:hover {
-        background-color: ${(props) => (props.onSetNewValue ? vars.greyLighter : "inherit")};
+        background-color: ${(props) => (props.onAddressSelected ? vars.greyLighter : "inherit")};
 
         &:nth-of-type(even) {
-          background-color: ${(props) => (props.onSetNewValue ? vars.greyLighter : "inherit")};
+          background-color: ${(props) => (props.onAddressSelected ? vars.greyLighter : "inherit")};
+        }
+      }
+
+      a {
+        svg {
+          max-width: 16px;
         }
       }
     }

--- a/src/components/UI/SvgIcon/SvgIcon.stories.tsx
+++ b/src/components/UI/SvgIcon/SvgIcon.stories.tsx
@@ -23,6 +23,7 @@ import {
   SvgIconPaperClip,
   SvgIconFlag,
   SvgIconQRCode,
+  SvgIconExternalLink,
 } from "./SvgIcon";
 
 export default {
@@ -196,6 +197,14 @@ export const Flag = () => {
   return (
     <SvgIcon>
       <SvgIconFlag />
+    </SvgIcon>
+  );
+};
+
+export const ExternalLink = () => {
+  return (
+    <SvgIcon>
+      <SvgIconExternalLink />
     </SvgIcon>
   );
 };

--- a/src/components/UI/SvgIcon/SvgIcon.tsx
+++ b/src/components/UI/SvgIcon/SvgIcon.tsx
@@ -251,6 +251,16 @@ export const SvgIconQRCode = () => {
   );
 };
 
+export const SvgIconExternalLink = () => {
+  return (
+    <g className="external-link">
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <polyline points="15 3 21 3 21 9" />
+      <line x1="10" y1="14" x2="21" y2="3" />
+    </g>
+  );
+};
+
 export const SvgIcon = ({ tooltipId, children, ...props }: SvgIconProps) => {
   const tooltipProps = tooltipId
     ? {


### PR DESCRIPTION
### pr updates
- add addressbook icon beside EditableAssetTitle input field
- click on it triggers addressbook overlay
- able set target address by selecting address directly from the addressbook

### user story
- https://www.pivotaltracker.com/story/show/172242479

### preview
![Screenshot 2020-07-15 at 10 35 30 AM](https://user-images.githubusercontent.com/4774314/87496971-2a40dd00-c687-11ea-8ff7-6fba1c2b7762.png)
![Screenshot 2020-07-15 at 10 35 51 AM](https://user-images.githubusercontent.com/4774314/87496967-29a84680-c687-11ea-9e4b-c5d312e25028.png)
![Screenshot 2020-07-15 at 10 35 57 AM](https://user-images.githubusercontent.com/4774314/87496963-2745ec80-c687-11ea-89cb-23d724427c2f.png)
