### PR TITLE
feat: add video page link

### DIFF
--- a/src/components/UI/AnnoucementBar/AnnoucementBar.tsx
+++ b/src/components/UI/AnnoucementBar/AnnoucementBar.tsx
@@ -23,7 +23,9 @@ export const AnnoucementBarUnStyled = ({ className }: AnnoucementBarProps) => {
                   />
                 </div>
                 <div className="col-12 col-lg-auto ml-lg-auto mt-4 mt-lg-0">
-                  <ReactRouterLinkButtonSolidOrangeWhite to="/webinar">View More</ReactRouterLinkButtonSolidOrangeWhite>
+                  <ReactRouterLinkButtonSolidOrangeWhite to="/webinar" large>
+                    View More
+                  </ReactRouterLinkButtonSolidOrangeWhite>
                 </div>
               </div>
             </div>
@@ -74,9 +76,6 @@ export const AnnoucementBar = styled(AnnoucementBarUnStyled)`
   }
 
   a {
-    padding: 8px 24px 12px;
-    ${mixin.fontSize(26)};
-
     &:hover {
       color: ${vars.greyLightest};
     }

--- a/src/components/UI/AnnoucementBar/AnnoucementBar.tsx
+++ b/src/components/UI/AnnoucementBar/AnnoucementBar.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "@emotion/styled";
-import { vars, mixin } from "../../../styles";
+import { vars } from "../../../styles";
 import { ReactRouterLinkButtonSolidOrangeWhite } from "./../../UI/Button";
 
 export interface AnnoucementBarProps {

--- a/src/components/UI/Button/Button.tsx
+++ b/src/components/UI/Button/Button.tsx
@@ -45,6 +45,7 @@ interface ReactRouterLinkProps {
   className?: string;
   children?: React.ReactNode;
   to: string;
+  large?: boolean;
 }
 
 export const ReactRouterLink = ({ className, children, to }: ReactRouterLinkProps) => {
@@ -296,4 +297,18 @@ export const ReactRouterLinkButtonSolidOrangeWhite = styled(ReactRouterLink)`
     text-decoration: none;
     color: ${vars.white};
   }
+
+  ${(props) => (props.large ? `${mixin.buttonLarge()}; ` : ``)};
+`;
+
+export const ReactRouterLinkButtonSolidNavyWhite = styled(ReactRouterLink)`
+  ${baseStyleButton({
+    bgColor: vars.brandNavy,
+    textColor: vars.white,
+  })} :hover {
+    text-decoration: none;
+    color: ${vars.white};
+  }
+
+  ${(props) => (props.large ? `${mixin.buttonLarge()}; ` : ``)};
 `;

--- a/src/components/WebinarPageContent/RegisterButton.tsx
+++ b/src/components/WebinarPageContent/RegisterButton.tsx
@@ -6,6 +6,7 @@ import { AnchorLinkButtonSolidOrangeWhite } from "./../UI/Button";
 interface RegisterButtonProps {
   className?: string;
   children: React.ReactNode;
+  large?: boolean;
 }
 
 export const RegisterButtonUnStyled = ({ className, children }: RegisterButtonProps) => {

--- a/src/components/WebinarPageContent/SectionRegister.tsx
+++ b/src/components/WebinarPageContent/SectionRegister.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "@emotion/styled";
 import { vars } from "../../styles";
 import { RegisterButton } from "./RegisterButton";
+import { ReactRouterLinkButtonSolidNavyWhite } from "./../UI/Button";
 
 interface SectionRegisterProps {
   className?: string;
@@ -20,9 +21,12 @@ export const SectionRegisterUnStyled = ({ className }: SectionRegisterProps) => 
             />
           </div>
         </div>
-        <div className="row">
+        <div className="row mt-5">
           <div className="col-auto">
-            <RegisterButton className="mt-5">Register Now</RegisterButton>
+            <RegisterButton>Register Now</RegisterButton>
+            <ReactRouterLinkButtonSolidNavyWhite to="/training-videos" className="ml-2" large>
+              Watch Now
+            </ReactRouterLinkButtonSolidNavyWhite>
           </div>
         </div>
       </div>

--- a/src/components/WebinarPageContent/SectionTopics.tsx
+++ b/src/components/WebinarPageContent/SectionTopics.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled";
 import { SvgIcon, SvgIconChecked } from "./../UI/SvgIcon";
 import { mixin, vars } from "../../styles";
 import { RegisterButton } from "./RegisterButton";
+import { ReactRouterLinkButtonSolidNavyWhite } from "./../UI/Button";
 
 interface SectionTopicsProps {
   className?: string;
@@ -159,6 +160,9 @@ export const SectionTopicsUnStyled = ({ className }: SectionTopicsProps) => {
         <div className="row my-5">
           <div className="col-auto mx-auto">
             <RegisterButton>Register Now</RegisterButton>
+            <ReactRouterLinkButtonSolidNavyWhite to="/training-videos" className="ml-2" large>
+              Watch Now
+            </ReactRouterLinkButtonSolidNavyWhite>
           </div>
         </div>
         <div className="row">

--- a/src/styles/abstracts/mixin.tsx
+++ b/src/styles/abstracts/mixin.tsx
@@ -163,3 +163,10 @@ export const baseStyleInput = () => {
     }
   `;
 };
+
+export const buttonLarge = () => {
+  return `
+    padding: 8px 24px 12px;
+    ${fontSize(26)};
+  `;
+};


### PR DESCRIPTION
### pr updates
- add watch now button to link to training video page
- refactor large button styles to `large` prop

### preview
![Screenshot 2020-08-17 at 2 44 24 PM](https://user-images.githubusercontent.com/4774314/90365380-42e24f80-e098-11ea-96f0-0a741ec09f78.png)
![Screenshot 2020-08-17 at 2 44 34 PM](https://user-images.githubusercontent.com/4774314/90365387-4544a980-e098-11ea-9871-05a763165e03.png)
