### PR TITLE
chore: remove webinar banner

### DIFF
--- a/src/components/MainPageContainer.tsx
+++ b/src/components/MainPageContainer.tsx
@@ -4,12 +4,10 @@ import { MainBenefitsSection } from "./HomePageContent/MainBenefitsSection";
 import { DocumentationSection } from "./HomePageContent/DocumentationSection";
 import { EmailSection } from "./HomePageContent/EmailSection";
 import { DropZoneSectionContainer } from "./HomePageContent/DropZoneSection";
-import { AnnoucementBar } from "./UI/AnnoucementBar";
 
 const MainPageContainer = () => {
   return (
     <>
-      <AnnoucementBar />
       <DropZoneSectionContainer />
       <LandingSection />
       <MainBenefitsSection />

--- a/src/components/UI/AnnoucementBar/AnnoucementBar.stories.tsx
+++ b/src/components/UI/AnnoucementBar/AnnoucementBar.stories.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { AnnoucementBar } from "./AnnoucementBar";
+import { ReactRouterLinkButtonSolidOrangeWhite } from "./../../UI/Button";
+import { Provider } from "react-redux";
+import initStore from "./../../../store";
+import { ConnectedRouter } from "connected-react-router";
+import { Route, Switch } from "react-router-dom";
+import { createBrowserHistory } from "history";
+
+const history = createBrowserHistory();
+const store = initStore(history);
+
+export default {
+  title: "UI/AnnoucementBar",
+  component: AnnoucementBar,
+  parameters: {
+    componentSubtitle: "Banner for any announcements.",
+  },
+};
+
+export const Default = () => {
+  return (
+    <Provider store={store}>
+      <ConnectedRouter history={history}>
+        <Switch>
+          <Route path="/">
+            <AnnoucementBar className="bg-brand-navy text-white">
+              <div className="row align-items-center">
+                <div className="col-12">
+                  <p className="mb-0">Empty banner</p>
+                </div>
+              </div>
+            </AnnoucementBar>
+          </Route>
+        </Switch>
+      </ConnectedRouter>
+    </Provider>
+  );
+};
+
+export const WebinarSeries = () => {
+  return (
+    <Provider store={store}>
+      <ConnectedRouter history={history}>
+        <Switch>
+          <Route path="/">
+            <AnnoucementBar className="bg-brand-navy text-white" backgroundImage="/static/images/webinar/banner.jpg">
+              <div className="row align-items-center">
+                <div className="col-12 col-lg-7">
+                  <img
+                    className="banner-title"
+                    src="/static/images/webinar/banner-title.png"
+                    alt="TradeTrust Tech Webinar Series banner title"
+                  />
+                </div>
+                <div className="col-12 col-lg-auto ml-lg-auto mt-4 mt-lg-0">
+                  <ReactRouterLinkButtonSolidOrangeWhite to="/webinar" large>
+                    View More
+                  </ReactRouterLinkButtonSolidOrangeWhite>
+                </div>
+              </div>
+            </AnnoucementBar>
+          </Route>
+        </Switch>
+      </ConnectedRouter>
+    </Provider>
+  );
+};

--- a/src/components/UI/AnnoucementBar/AnnoucementBar.tsx
+++ b/src/components/UI/AnnoucementBar/AnnoucementBar.tsx
@@ -1,34 +1,19 @@
 import React from "react";
 import styled from "@emotion/styled";
-import { vars } from "../../../styles";
-import { ReactRouterLinkButtonSolidOrangeWhite } from "./../../UI/Button";
 
 export interface AnnoucementBarProps {
   className?: string;
+  backgroundImage?: string;
+  children?: React.ReactNode;
 }
 
-export const AnnoucementBarUnStyled = ({ className }: AnnoucementBarProps) => {
+export const AnnoucementBarUnStyled = ({ className, children }: AnnoucementBarProps) => {
   return (
-    <section className={`${className} bg-brand-navy text-white`}>
+    <section className={`${className}`}>
       <div className="container-custom">
         <div className="row">
           <div className="col-12">
-            <div className="announcement-bar">
-              <div className="row align-items-center">
-                <div className="col-12 col-lg-7">
-                  <img
-                    className="banner-title"
-                    src="/static/images/webinar/banner-title.png"
-                    alt="TradeTrust Tech Webinar Series banner title"
-                  />
-                </div>
-                <div className="col-12 col-lg-auto ml-lg-auto mt-4 mt-lg-0">
-                  <ReactRouterLinkButtonSolidOrangeWhite to="/webinar" large>
-                    View More
-                  </ReactRouterLinkButtonSolidOrangeWhite>
-                </div>
-              </div>
-            </div>
+            <div className="announcement-bar">{children}</div>
           </div>
         </div>
       </div>
@@ -42,22 +27,11 @@ export const AnnoucementBar = styled(AnnoucementBarUnStyled)`
 
   .announcement-bar {
     position: relative;
-    background-color: #5d6975;
     border-radius: 4px;
-    background-image: url("/static/images/webinar/banner.jpg");
+    background-image: ${(props) => `url("${props.backgroundImage}")`};
     background-repeat: no-repeat;
-    padding-top: 30px;
-    padding-bottom: 30px;
-
-    background-position: 55% 63%;
-    padding-left: 15px;
-    padding-right: 15px;
-
-    @media only screen and (min-width: ${vars.lg}) {
-      background-position: 50% 68%;
-      padding-left: 50px;
-      padding-right: 50px;
-    }
+    background-position: 50% 50%;
+    padding: 30px;
 
     &::before {
       content: "";
@@ -73,11 +47,5 @@ export const AnnoucementBar = styled(AnnoucementBarUnStyled)`
   .banner-title {
     width: 100%;
     max-width: 250px;
-  }
-
-  a {
-    &:hover {
-      color: ${vars.greyLightest};
-    }
   }
 `;


### PR DESCRIPTION
### pr updates
- removing webinar banner from home page
- document banner into storybook (to reuse in future if needed)
- retain `/webinar` page, there is plans to reorganize info into past events

### user story
- https://www.pivotaltracker.com/story/show/174396737

### preview
![Screenshot 2020-08-21 at 10 18 56 AM](https://user-images.githubusercontent.com/4774314/90844996-c00f0c80-e397-11ea-9637-855d0acda36c.png)
