### PR TITLE
feat: removed holder's editable field when nominating bene

### DIFF
--- a/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementDropdown/AssetManagementDropdown.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementDropdown/AssetManagementDropdown.tsx
@@ -4,7 +4,7 @@ import { Dropdown } from "react-bootstrap";
 import { mixin, vars } from "../../../../styles";
 import { AssetManagementActions } from "./../../AssetManagementActions";
 
-interface ManageAssetsDropdownProps {
+interface AssetManagementDropdownProps {
   onSetFormAction: (nextFormAction: AssetManagementActions) => void;
   className?: string;
   canSurrender: boolean;
@@ -14,7 +14,7 @@ interface ManageAssetsDropdownProps {
   canEndorseTransfer: boolean;
 }
 
-export const ManageAssetsDropdown = styled(
+export const AssetManagementDropdown = styled(
   ({
     onSetFormAction,
     className,
@@ -23,7 +23,7 @@ export const ManageAssetsDropdown = styled(
     canEndorseBeneficiary,
     canNominateBeneficiaryHolder,
     canEndorseTransfer,
-  }: ManageAssetsDropdownProps) => {
+  }: AssetManagementDropdownProps) => {
     return (
       <Dropdown alignRight className={`${className}`}>
         <Dropdown.Toggle variant="primary" id="dropdown-basic" data-testid={"manageAssetDropdown"}>
@@ -43,7 +43,7 @@ export const ManageAssetsDropdown = styled(
               data-testid={"endorseBeneficiaryDropdown"}
               onClick={() => onSetFormAction(AssetManagementActions.EndorseBeneficiary)}
             >
-              Endorse change of beneficiary
+              Endorse change of ownership
             </Dropdown.Item>
           )}
           {canNominateBeneficiaryHolder && (
@@ -51,7 +51,7 @@ export const ManageAssetsDropdown = styled(
               data-testid={"nominateBeneficiaryHolderDropdown"}
               onClick={() => onSetFormAction(AssetManagementActions.NominateBeneficiaryHolder)}
             >
-              Nominate change of beneficiary
+              Nominate change of ownership
             </Dropdown.Item>
           )}
           {canSurrender && (
@@ -67,7 +67,7 @@ export const ManageAssetsDropdown = styled(
               data-testid={"endorseTransferDropdown"}
               onClick={() => onSetFormAction(AssetManagementActions.EndorseTransfer)}
             >
-              Endorse Transfer of beneficiary/holder
+              Endorse Transfer of ownership
             </Dropdown.Item>
           )}
         </Dropdown.Menu>

--- a/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementTitle/AssetManagementTitle.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementTitle/AssetManagementTitle.tsx
@@ -31,9 +31,9 @@ export const AssetManagementTitle = styled(
           <h3 className="action-title">
             {formAction === AssetManagementActions.Surrender && <>Surrender Document</>}
             {formAction === AssetManagementActions.TransferHolder && <>Transfer Holdership</>}
-            {formAction === AssetManagementActions.EndorseBeneficiary && <>Endorse Change of Owner</>}
-            {formAction === AssetManagementActions.NominateBeneficiaryHolder && <>Nominate Change of Owner</>}
-            {formAction === AssetManagementActions.EndorseTransfer && <>Endorse Transfer of Owner/Holder</>}
+            {formAction === AssetManagementActions.EndorseBeneficiary && <>Endorse Change of Ownership</>}
+            {formAction === AssetManagementActions.NominateBeneficiaryHolder && <>Nominate Change of Ownership</>}
+            {formAction === AssetManagementActions.EndorseTransfer && <>Endorse Transfer of Ownership</>}
           </h3>
         </div>
       </div>

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.tsx
@@ -3,7 +3,7 @@ import { ButtonSolidOrangeWhite } from "../../../../UI/Button";
 import { TagBorderedRedLarge } from "../../../../UI/Tag";
 import { AssetInformationPanel } from "../../../AssetInformationPanel";
 import { AssetManagementActions } from "../../../AssetManagementActions";
-import { ManageAssetsDropdown } from "../../AssetManagementDropdown";
+import { AssetManagementDropdown } from "../../AssetManagementDropdown";
 import { OverlayContext } from "./../../../../../common/contexts/OverlayContext";
 import {
   MessageTitle,
@@ -102,7 +102,7 @@ export const ActionSelectionForm = ({
               {account ? (
                 <>
                   {canManage ? (
-                    <ManageAssetsDropdown
+                    <AssetManagementDropdown
                       onSetFormAction={onSetFormAction}
                       canSurrender={canSurrender}
                       canChangeHolder={canChangeHolder}

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/NominateBeneficiaryHolder/NominateBeneficiaryHolder.test.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/NominateBeneficiaryHolder/NominateBeneficiaryHolder.test.tsx
@@ -1,10 +1,10 @@
 import "@testing-library/jest-dom";
 import { fireEvent, render } from "@testing-library/react";
 import React from "react";
+import { act } from "react-dom/test-utils";
 import { FormState } from "../../../../../constants/FormState";
 import { AssetManagementActions } from "../../../AssetManagementActions";
 import { NominateBeneficiaryHolderForm } from "./NominateBeneficiaryHolder";
-import { act } from "react-dom/test-utils";
 
 describe("Nominate Owner", () => {
   it("should display the editable beneficiary & static holder when the app is in NominateBeneficiaryHolder state", async () => {
@@ -23,7 +23,7 @@ describe("Nominate Owner", () => {
       );
 
       const beneficiaryComponent = container.getByTestId("editable-input-owner");
-      const holderComponent = container.getByTestId("editable-input-holder");
+      const holderComponent = container.getByTestId("non-editable-input-holder");
 
       expect(beneficiaryComponent).not.toBeNull();
       expect(holderComponent).not.toBeNull();

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/NominateBeneficiaryHolder/NominateBeneficiaryHolder.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/NominateBeneficiaryHolder/NominateBeneficiaryHolder.tsx
@@ -35,7 +35,6 @@ export const NominateBeneficiaryHolderForm = ({
   setShowEndorsementChain,
 }: NominateBeneficiaryHolderFormProps) => {
   const [newBeneficiary, setNewBeneficiary] = useState("");
-  const [newHolder, setNewHolder] = useState("");
   const isPendingConfirmation = nominationState === FormState.PENDING_CONFIRMATION;
   const isConfirmed = nominationState === FormState.CONFIRMED;
   const isEditable = nominationState !== FormState.PENDING_CONFIRMATION && nominationState !== FormState.CONFIRMED;
@@ -53,9 +52,7 @@ export const NominateBeneficiaryHolderForm = ({
   }, [isConfirmed, newBeneficiary, showOverlay, setFormActionNone]);
 
   const isValidNomination = () => {
-    if (!newBeneficiary || !newHolder) return false;
-    if (newBeneficiary === beneficiary && newHolder === holder) return false;
-    if (!isAddress(newBeneficiary) || !isAddress(newHolder)) return false;
+    if (!newBeneficiary || newBeneficiary === beneficiary || !isAddress(newBeneficiary)) return false;
 
     return true;
   };
@@ -86,14 +83,7 @@ export const NominateBeneficiaryHolderForm = ({
             />
           </div>
           <div className="col-12 col-lg">
-            <EditableAssetTitle
-              role="Holder"
-              value={holder}
-              newValue={newHolder}
-              isEditable={isEditable}
-              onSetNewValue={setNewHolder}
-              error={nominationState === FormState.ERROR}
-            />
+            <EditableAssetTitle role="Holder" value={holder} isEditable={false} />
           </div>
         </div>
         <div className="row mb-3">
@@ -111,7 +101,7 @@ export const NominateBeneficiaryHolderForm = ({
               <div className="col-auto ml-2">
                 <ButtonSolidOrangeWhite
                   disabled={!isValidNomination() || isPendingConfirmation}
-                  onClick={() => handleNomination(newBeneficiary, newHolder)}
+                  onClick={() => handleNomination(newBeneficiary, holder as string)}
                   data-testid={"nominationBtn"}
                 >
                   {isPendingConfirmation ? <LoaderSpinner data-testid={"loader"} /> : <>Nominate</>}

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/NominateBeneficiaryHolder/NominateBeneficiaryHolder.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/NominateBeneficiaryHolder/NominateBeneficiaryHolder.tsx
@@ -51,11 +51,8 @@ export const NominateBeneficiaryHolderForm = ({
     }
   }, [isConfirmed, newBeneficiary, showOverlay, setFormActionNone]);
 
-  const isValidNomination = () => {
-    if (!newBeneficiary || newBeneficiary === beneficiary || !isAddress(newBeneficiary)) return false;
-
-    return true;
-  };
+  const isInvalidNomination =
+    !newBeneficiary || !holder || newBeneficiary === beneficiary || !isAddress(newBeneficiary);
 
   return (
     <div className="row py-3">
@@ -100,8 +97,12 @@ export const NominateBeneficiaryHolderForm = ({
               </div>
               <div className="col-auto ml-2">
                 <ButtonSolidOrangeWhite
-                  disabled={!isValidNomination() || isPendingConfirmation}
-                  onClick={() => handleNomination(newBeneficiary, holder as string)}
+                  disabled={isInvalidNomination || isPendingConfirmation}
+                  onClick={() => {
+                    if (holder === undefined) return;
+                    // holder is used instead of 'NewHolder' because we do not want to change the value on the UI when nominating beneficiary.
+                    handleNomination(newBeneficiary, holder);
+                  }}
                   data-testid={"nominationBtn"}
                 >
                   {isPendingConfirmation ? <LoaderSpinner data-testid={"loader"} /> : <>Nominate</>}

--- a/src/components/UI/Overlay/OverlayContent/DocumentTransferMessage.tsx
+++ b/src/components/UI/Overlay/OverlayContent/DocumentTransferMessage.tsx
@@ -13,10 +13,10 @@ export enum MessageTitle {
   NO_USER_AUTHORIZATION = "User denied account authorization", // this error message must match error message from metamask extension itself
   TRANSACTION_ERROR = "Error - Failed transaction",
   SURRENDER_DOCUMENT_SUCCESS = "Surrender Document Success",
-  CHANGE_BENEFICIARY_SUCCESS = "Change Owner Success",
+  CHANGE_BENEFICIARY_SUCCESS = "Change Ownership Success",
   NOMINATE_BENEFICIARY_HOLDER_SUCCESS = "Nomination Success",
   TRANSFER_HOLDER_SUCCESS = "Transfer Holder Success",
-  ENDORSE_TRANSFER_SUCCESS = "Endorse Owner/Holder Success",
+  ENDORSE_TRANSFER_SUCCESS = "Endorse Ownership/Holdership Success",
 }
 
 const ButtonClose = () => {


### PR DESCRIPTION
In this PR:

- Updated the editable field of holder to non-editable field when nominating beneficiary.
![Screenshot 2020-08-27 at 12 43 39 PM](https://user-images.githubusercontent.com/28627909/91385199-f13d8000-e862-11ea-9867-69923410bc98.png)

- Updated on some text that is still "beneficiary" when it should be "owner" or "ownership"
