### PR TITLE
fix: surrender sign not showing

### DIFF
--- a/src/components/AssetManagementPanel/AssetManagementApplication/index.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementApplication/index.tsx
@@ -46,7 +46,7 @@ export const AssetManagementApplication = ({
     <div id="title-transfer-panel">
       <div className="container-custom">
         <AssetManagementTags />
-        {isTitleEscrow && (
+        {isTitleEscrow !== undefined && (
           <AssetManagementForm
             account={account}
             onConnectToWallet={upgradeProvider}
@@ -69,12 +69,8 @@ export const AssetManagementApplication = ({
             onTransferToNewEscrow={transferToNewEscrow}
             transferToNewEscrowState={transferToNewEscrowState}
             setShowEndorsementChain={setShowEndorsementChain}
+            isTitleEscrow={isTitleEscrow}
           />
-        )}
-        {isTitleEscrow === false && (
-          <h5 id="interaction-unavailable-text">
-            At this point in time, direct interaction with Erc721 is not supported on tradetrust.io
-          </h5>
         )}
       </div>
     </div>

--- a/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementForm.stories.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementForm.stories.tsx
@@ -45,6 +45,7 @@ export const NotLoggedIn = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -83,6 +84,7 @@ export const NoMatch = () => {
           alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
         }
         transferToNewEscrowState={FormState.UNINITIALIZED}
+        isTitleEscrow={true}
       />
     </OverlayContextProvider>
   );
@@ -120,6 +122,7 @@ export const BeneficiaryAndHolder = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -156,6 +159,7 @@ export const Beneficiary = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -192,6 +196,7 @@ export const Holder = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -228,6 +233,7 @@ export const HolderWithApprovedBeneficiaryAndApprovedHolder = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -264,6 +270,7 @@ export const SurrenderPending = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -300,6 +307,7 @@ export const Surrendered = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -336,6 +344,7 @@ export const TransferHolderError = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -372,6 +381,7 @@ export const TransferHolderPending = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -408,6 +418,7 @@ export const EndorseChangeBeneficiaryError = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -444,6 +455,7 @@ export const EndorseChangeBeneficiaryPending = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -480,6 +492,7 @@ export const NominateBeneficiaryAndHolderError = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -516,6 +529,7 @@ export const NominateBeneficiaryAndHolderPending = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -552,6 +566,7 @@ export const EndorseTransferHolderBeneficiary = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={true}
     />
   );
 };
@@ -588,6 +603,7 @@ export const EndorseTransferHolderBeneficiaryPending = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.PENDING_CONFIRMATION}
+      isTitleEscrow={true}
     />
   );
 };

--- a/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementForm.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementForm.tsx
@@ -30,6 +30,7 @@ interface AssetManagementFormProps {
   approveNewTransferTargetsState: string;
   transferToNewEscrowState: string;
   setShowEndorsementChain: (payload: boolean) => void;
+  isTitleEscrow: boolean;
 }
 
 export const AssetManagementForm = ({
@@ -54,6 +55,7 @@ export const AssetManagementForm = ({
   onTransferToNewEscrow,
   transferToNewEscrowState,
   setShowEndorsementChain,
+  isTitleEscrow,
 }: AssetManagementFormProps) => {
   const isHolder = account === holder;
   const isBeneficiary = account === beneficiary;
@@ -166,6 +168,7 @@ export const AssetManagementForm = ({
           canNominateBeneficiaryHolder={canNominateBeneficiaryHolder}
           canEndorseTransfer={canEndorseTransfer}
           setShowEndorsementChain={setShowEndorsementChain}
+          isTitleEscrow={isTitleEscrow}
         />
       );
   }

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.test.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.test.tsx
@@ -17,6 +17,7 @@ const defaultProps = {
   canNominateBeneficiaryHolder: false,
   isSurrendered: false,
   canEndorseTransfer: false,
+  isTitleEscrow: true,
 };
 
 describe("ActionSelectionForm", () => {
@@ -160,5 +161,12 @@ describe("ActionSelectionForm", () => {
 
       expect(mockOnSetFormAction).toHaveBeenCalled();
     });
+  });
+
+  it("should change the state of the action form to 'EndorseTransfer' when clicked on the dropdown", async () => {
+    const container = render(<ActionSelectionForm {...defaultProps} isTitleEscrow={false} />);
+    expect(
+      container.queryByText("At this point in time, direct interaction with Erc721 is not supported on tradetrust.io")
+    ).not.toBeNull();
   });
 });

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.tsx
@@ -25,6 +25,7 @@ interface ActionSelectionFormProps {
   canNominateBeneficiaryHolder: boolean;
   canEndorseTransfer: boolean;
   setShowEndorsementChain: (payload: boolean) => void;
+  isTitleEscrow: boolean;
 }
 
 export const ActionSelectionForm = ({
@@ -41,6 +42,7 @@ export const ActionSelectionForm = ({
   canNominateBeneficiaryHolder,
   canEndorseTransfer,
   setShowEndorsementChain,
+  isTitleEscrow,
 }: ActionSelectionFormProps) => {
   const canManage =
     canSurrender || canChangeHolder || canEndorseBeneficiary || canNominateBeneficiaryHolder || canEndorseTransfer;
@@ -68,7 +70,7 @@ export const ActionSelectionForm = ({
       handleMetamaskError(error.message, error.code);
     }
   };
-
+  console.log(isTitleEscrow);
   return (
     <div className="row">
       <div className="col-12">
@@ -79,46 +81,53 @@ export const ActionSelectionForm = ({
               setShowEndorsementChain={setShowEndorsementChain}
             />
           </div>
-          {isSurrendered ? (
+          {isSurrendered && (
             <div className="col-12 col-lg-auto align-self-end">
               <div className="py-3">
-                <TagBorderedRedLarge>Surrendered</TagBorderedRedLarge>
+                <TagBorderedRedLarge id="surrender-sign">Surrendered</TagBorderedRedLarge>
               </div>
             </div>
-          ) : (
-            <>
-              <div className="col-12 col-lg">
-                <EditableAssetTitle role="Owner" value={beneficiary} isEditable={false} />
-              </div>
-              <div className="col-12 col-lg">
-                <EditableAssetTitle role="Holder" value={holder} isEditable={false} />
-              </div>
-            </>
           )}
         </div>
-        {!isSurrendered && (
+        {!isSurrendered && isTitleEscrow ? (
+          <>
+            <div className="col-12 col-lg">
+              <EditableAssetTitle role="Owner" value={beneficiary} isEditable={false} />
+            </div>
+            <div className="col-12 col-lg">
+              <EditableAssetTitle role="Holder" value={holder} isEditable={false} />
+            </div>
+            <div className="row mb-3">
+              <div className="col-auto ml-lg-auto">
+                {account ? (
+                  <>
+                    {canManage ? (
+                      <AssetManagementDropdown
+                        onSetFormAction={onSetFormAction}
+                        canSurrender={canSurrender}
+                        canChangeHolder={canChangeHolder}
+                        canEndorseBeneficiary={canEndorseBeneficiary}
+                        canNominateBeneficiaryHolder={canNominateBeneficiaryHolder}
+                        canEndorseTransfer={canEndorseTransfer}
+                      />
+                    ) : (
+                      <ButtonSolidOrangeWhite onClick={handleNoAccess}>No Access</ButtonSolidOrangeWhite>
+                    )}
+                  </>
+                ) : (
+                  <ButtonSolidOrangeWhite data-testid={"connectToWallet"} onClick={handleConnectWallet}>
+                    Connect Wallet
+                  </ButtonSolidOrangeWhite>
+                )}
+              </div>
+            </div>
+          </>
+        ) : (
           <div className="row mb-3">
             <div className="col-auto ml-lg-auto">
-              {account ? (
-                <>
-                  {canManage ? (
-                    <AssetManagementDropdown
-                      onSetFormAction={onSetFormAction}
-                      canSurrender={canSurrender}
-                      canChangeHolder={canChangeHolder}
-                      canEndorseBeneficiary={canEndorseBeneficiary}
-                      canNominateBeneficiaryHolder={canNominateBeneficiaryHolder}
-                      canEndorseTransfer={canEndorseTransfer}
-                    />
-                  ) : (
-                    <ButtonSolidOrangeWhite onClick={handleNoAccess}>No Access</ButtonSolidOrangeWhite>
-                  )}
-                </>
-              ) : (
-                <ButtonSolidOrangeWhite data-testid={"connectToWallet"} onClick={handleConnectWallet}>
-                  Connect Wallet
-                </ButtonSolidOrangeWhite>
-              )}
+              <h5 id="interaction-unavailable-text" className="ml-auto">
+                At this point in time, direct interaction with Erc721 is not supported on tradetrust.io
+              </h5>
             </div>
           </div>
         )}

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.tsx
@@ -70,7 +70,6 @@ export const ActionSelectionForm = ({
       handleMetamaskError(error.message, error.code);
     }
   };
-  console.log(isTitleEscrow);
   return (
     <div className="row">
       <div className="col-12">

--- a/src/test/ebl-surrendered.spec.js
+++ b/src/test/ebl-surrendered.spec.js
@@ -1,0 +1,18 @@
+import { Selector } from "testcafe";
+
+fixture("Render red surrender sign if ebl is surrendered").page`http://localhost:3000`;
+
+const Document = "./fixture/ebl-surrendered.json";
+const DocumentStatus = Selector("#document-status");
+
+const SurrenderedSign = Selector("#surrender-sign");
+
+test("Displays surrender sign", async (t) => {
+  const container = Selector("#certificate-dropzone");
+  await container();
+  await t.setFilesToUpload("input[type=file]", [Document]);
+
+  await DocumentStatus.with({ visibilityCheck: true })();
+
+  await t.expect(SurrenderedSign.count).eql(0);
+});

--- a/src/test/ebl-surrendered.spec.js
+++ b/src/test/ebl-surrendered.spec.js
@@ -2,17 +2,35 @@ import { Selector } from "testcafe";
 
 fixture("Render red surrender sign if ebl is surrendered").page`http://localhost:3000`;
 
-const Document = "./fixture/ebl-surrendered.json";
+const SurrenderedDocument = "./fixture/ebl-surrendered.json";
+const NonSurrenderedDocument = "./fixture/ebl-wallet-owner.json";
 const DocumentStatus = Selector("#document-status");
 
 const SurrenderedSign = Selector("#surrender-sign");
+const InteractionUnavailableText = Selector("#interaction-unavailable-text");
 
-test("Displays surrender sign", async (t) => {
+const validateTextContent = async (t, component, texts) =>
+  texts.reduce(async (_prev, curr) => t.expect(component.textContent).contains(curr), Promise.resolve());
+
+test("should displays surrender sign when document is owned by token registry", async (t) => {
   const container = Selector("#certificate-dropzone");
   await container();
-  await t.setFilesToUpload("input[type=file]", [Document]);
+  await t.setFilesToUpload("input[type=file]", [SurrenderedDocument]);
+
+  await DocumentStatus.with({ visibilityCheck: true })();
+
+  await t.expect(SurrenderedSign.count).eql(1);
+});
+
+test("should not displays surrender sign when document is not owned by token registry", async (t) => {
+  const container = Selector("#certificate-dropzone");
+  await container();
+  await t.setFilesToUpload("input[type=file]", [NonSurrenderedDocument]);
 
   await DocumentStatus.with({ visibilityCheck: true })();
 
   await t.expect(SurrenderedSign.count).eql(0);
+  await validateTextContent(t, InteractionUnavailableText, [
+    "At this point in time, direct interaction with Erc721 is not supported on tradetrust.io",
+  ]);
 });

--- a/src/test/fixture/ebl-surrendered.json
+++ b/src/test/fixture/ebl-surrendered.json
@@ -1,0 +1,36 @@
+{
+  "version": "https://schema.openattestation.com/2.0/schema.json",
+  "data": {
+    "shipper": { "address": {} },
+    "consignee": {},
+    "notifyParty": {},
+    "$template": {
+      "type": "b6c34d02-9da5-4437-89cc-55e63298846f:string:EMBEDDED_RENDERER",
+      "name": "3be0993a-60a6-4fb0-b0a1-6ae6ca11bf7d:string:BILL_OF_LADING",
+      "url": "378f3c1d-5a7a-4658-82bd-178eddb70fc1:string:https://demo-cnm.openattestation.com"
+    },
+    "issuers": [
+      {
+        "identityProof": {
+          "type": "0761956c-ae2e-44a1-8eab-571ca7c7ea28:string:DNS-TXT",
+          "location": "4679d796-d582-4a34-a439-3ae01f4b9537:string:demo-tradetrust.openattestation.com"
+        },
+        "name": "d1aa9cd5-ca5f-4a36-a40e-ba590d195f60:string:DEMO STORE",
+        "tokenRegistry": "634d5f1d-8e64-487d-9ab4-960eba621dfb:string:0x10E936e6BA85dC92505760259881167141365821"
+      }
+    ],
+    "name": "bed0db4e-d229-4921-935d-cf4dfb18d67e:string:Maersk Bill of Lading",
+    "blNumber": "ec9abafd-aa8a-4aa4-8d4b-fd6ea2543acf:string:13",
+    "links": {
+      "self": {
+        "href": "e2d682fa-81cb-4d0c-b5f0-a8ba55608f1b:string:https://action.openattestation.com/?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fapi-ropsten.tradetrust.io%2Fstorage%2F5fe1aa69-01c0-4a6c-90c2-7c1efbbf0a94%22%2C%22key%22%3A%229e1c250eb47416a27991fcbd32b5ab62132facec9bb6145ed88904abe41f3be4%22%2C%22permittedActions%22%3A%5B%22STORE%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%2F%22%7D%7D"
+      }
+    }
+  },
+  "signature": {
+    "type": "SHA3MerkleProof",
+    "targetHash": "67356d75ddf481961e64bc2c259063051fc9dbb271adc764c23ffc671aa7f23b",
+    "proof": [],
+    "merkleRoot": "67356d75ddf481961e64bc2c259063051fc9dbb271adc764c23ffc671aa7f23b"
+  }
+}


### PR DESCRIPTION
This PR fixes the surrender sign not showing and added integration test and fixtures for a surrendered ebl.

To test the PR we can use these files:
Surrendered:
[ebl-surrendered.txt](https://github.com/TradeTrust/tradetrust-website/files/5199065/ebl-surrendered.txt)
Not Surrendered by Owned by Wallet:
[ebl-wallet-owner.txt](https://github.com/TradeTrust/tradetrust-website/files/5199067/ebl-wallet-owner.txt)

