### PR TITLE
Feat/tt attachment link document

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47482,7 +47482,7 @@
       "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
     },
     "scrypt-shim": {
-      "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+      "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
       "from": "github:web3-js/scrypt-shim",
       "dev": true,
       "requires": {
@@ -55162,7 +55162,7 @@
       }
     },
     "websocket": {
-      "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+      "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
       "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
       "dev": true,
       "requires": {

--- a/src/components/UI/AttachmentLink/AttachmentLink.test.tsx
+++ b/src/components/UI/AttachmentLink/AttachmentLink.test.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { AttachmentLink } from "./AttachmentLink";
 
+const sampleData = `eyJ2ZXJzaW9uIjoiaHR0cHM6Ly9zY2hlbWEub3BlbmF0dGVzdGF0aW9uLmNvbS8yLjAvc2NoZW1hLmpzb24iLCJkYXRhIjp7InNoaXBwZXIiOnsiYWRkcmVzcyI6e319LCJjb25zaWduZWUiOnt9LCJub3RpZnlQYXJ0eSI6e30sIiR0ZW1wbGF0ZSI6eyJ0eXBlIjoiYzRkNDVkNTktZjJjOS00OGJhLWI2MzMtNzBiNTg0N2QzN2IzOnN0cmluZzpFTUJFRERFRF9SRU5ERVJFUiIsIm5hbWUiOiJlZmM0ZWQ3Zi05MDZmLTRkOWUtOTgxYi1mMmE3MThmZDExYzQ6c3RyaW5nOkJJTExfT0ZfTEFESU5HIiwidXJsIjoiODZmOGQzMWQtY2YxMC00N2RhLTg3NTYtZTNmZGRkNzkxZDYyOnN0cmluZzpodHRwczovL2RlbW8tY25tLm9wZW5hdHRlc3RhdGlvbi5jb20ifSwiaXNzdWVycyI6W3siaWRlbnRpdHlQcm9vZiI6eyJ0eXBlIjoiNmE3NzA1ZjMtMzBjZi00NjZhLTg1OTUtZmExMjk5ZjQ4Y2RlOnN0cmluZzpETlMtVFhUIiwibG9jYXRpb24iOiJiZmFlNGU2Ni1jZWZjLTRhYzgtODk1YS0zZWJjNzkxOWNhYzY6c3RyaW5nOmRlbW8tdHJhZGV0cnVzdC5vcGVuYXR0ZXN0YXRpb24uY29tIn0sIm5hbWUiOiJmYTNmMTc3MC05M2YzLTRlYTAtODczNC0wMGIwOWQxZDM5ODA6c3RyaW5nOkRFTU8gU1RPUkUiLCJ0b2tlblJlZ2lzdHJ5IjoiMjYxNWMzZTMtYWU4Ni00MjJlLTg0ZjQtZTNiYjhhMTFmYzZlOnN0cmluZzoweDU5YjY4MzgwRWY2MDRjMTFDNDkxMTVCNEU4MjkwQkM4YzM1NDQyNTQifV0sIm5hbWUiOiI1OGEyNzQxNC1lZWMzLTRkYzAtOTkzYi1mMWEyYjUxNDE4OTg6c3RyaW5nOk1hZXJzayBCaWxsIG9mIExhZGluZyIsImJsTnVtYmVyIjoiMzk4YTUwNjYtZGQ1Ni00ZmUzLWJkNzgtOGZhMGI4ZTliZDI5OnN0cmluZzoxMjMiLCJsaW5rcyI6eyJzZWxmIjp7ImhyZWYiOiIxNGQ0NTJjMi1hNDRiLTRkNDktOTI0ZS1iZDVkMTI0M2M2ODg6c3RyaW5nOmh0dHBzOi8vYWN0aW9uLm9wZW5hdHRlc3RhdGlvbi5jb20vP3E9JTdCJTIydHlwZSUyMiUzQSUyMkRPQ1VNRU5UJTIyJTJDJTIycGF5bG9hZCUyMiUzQSU3QiUyMnVyaSUyMiUzQSUyMmh0dHBzJTNBJTJGJTJGYXBpLXJvcHN0ZW4udHJhZGV0cnVzdC5pbyUyRnN0b3JhZ2UlMkYzYTgxZjM5OS1iZGU1LTRmMWYtYjM2MS00ZDEyN2FkZmYzYjMlMjIlMkMlMjJrZXklMjIlM0ElMjJkMTM5ZjE5NmQ3NjQ5MmExZTViMmI3MGQ3OTNlNTUyY2E0ZTRkMjgxZmY0YmQ4ZDQyNzg3NDE5NWQwMDg0ZTNkJTIyJTJDJTIycGVybWl0dGVkQWN0aW9ucyUyMiUzQSU1QiUyMlNUT1JFJTIyJTVEJTJDJTIycmVkaXJlY3QlMjIlM0ElMjJodHRwcyUzQSUyRiUyRmRldi50cmFkZXRydXN0LmlvJTJGJTIyJTdEJTdEIn19fSwic2lnbmF0dXJlIjp7InR5cGUiOiJTSEEzTWVya2xlUHJvb2YiLCJ0YXJnZXRIYXNoIjoiMmI2OGY5Y2Y2ZTYyNGJjYzQxODE4NTQxYWQwZDc4MTgzYTU3N2UyYTY3YTg0MDU3ZDU5MzZhMzU1MWIwNWFmNSIsInByb29mIjpbXSwibWVya2xlUm9vdCI6IjJiNjhmOWNmNmU2MjRiY2M0MTgxODU0MWFkMGQ3ODE4M2E1NzdlMmE2N2E4NDA1N2Q1OTM2YTM1NTFiMDVhZjUifX0=`;
+
 describe("AttachmentLink", () => {
   it("should render filename correctly", () => {
     const container = render(<AttachmentLink filename="TradeTrust Tech Webinar 2.pdf" />);
@@ -13,6 +15,14 @@ describe("AttachmentLink", () => {
       <AttachmentLink filename="TradeTrust Tech Webinar 2.pdf" data={`123`} type="application/pdf" />
     );
     expect(container.getByText("Download")).not.toBeNull();
+  });
+
+  it("should render open link with base64 correctly if tt file", () => {
+    const container = render(
+      <AttachmentLink filename="document.tt" data={sampleData} type="application/octet-stream" />
+    );
+    expect(container.getByText("Download")).not.toBeNull();
+    expect(container.getByText("Open")).not.toBeNull();
   });
 
   it("should render download link with direct asset correctly", () => {

--- a/src/components/UI/AttachmentLink/AttachmentLink.tsx
+++ b/src/components/UI/AttachmentLink/AttachmentLink.tsx
@@ -4,6 +4,9 @@ import prettyBytes from "pretty-bytes";
 import { mixin, vars } from "../../../styles";
 import { Paperclip } from "react-feather";
 import { getData, utils, WrappedDocument } from "@govtechsg/open-attestation";
+import { getLogger } from "../../../utils/logger";
+
+const { error } = getLogger("component:attachmentlink");
 
 export interface AttachmentLinkProps {
   className?: string;
@@ -22,11 +25,15 @@ export const AttachmentLinkUnStyled = ({ className, filename, data, type, path }
   if (data) {
     const decodedData = atob(data);
     filesize = prettyBytes(decodedData.length);
-    const decodedJson = JSON.parse(decodedData);
-    const isOpenAttestationSchema = utils.isWrappedV2Document(decodedJson);
-    if (isOpenAttestationSchema) {
-      const originalDocument = getData<WrappedDocument>(decodedJson);
-      redirectLink = originalDocument?.links?.self?.href ?? "";
+    try {
+      const decodedJson = JSON.parse(decodedData);
+      const isOpenAttestationSchema = utils.isWrappedV2Document(decodedJson);
+      if (isOpenAttestationSchema) {
+        const originalDocument = getData<WrappedDocument>(decodedJson);
+        redirectLink = originalDocument?.links?.self?.href ?? "";
+      }
+    } catch (e) {
+      error("decode data not json: " + e);
     }
   }
 

--- a/src/components/UI/AttachmentLink/AttachmentLink.tsx
+++ b/src/components/UI/AttachmentLink/AttachmentLink.tsx
@@ -56,13 +56,17 @@ export const AttachmentLinkUnStyled = ({ className, filename, data, type, path }
             {hasBase64 && <span className="filesize">({filesize})</span>}
           </p>
           <div className="row no-gutters">
-            <a href={downloadHref} download={`${filename}`} className="downloadtext" data-testid="attachment-link">
-              Download
-            </a>
-            {redirectLink && (
-              <a href={redirectLink} target="_blank" rel="noopener noreferrer" className="downloadtext mb-0 ml-2">
-                Open
+            <div className="col-12 col-md-auto">
+              <a href={downloadHref} download={`${filename}`} className="downloadtext" data-testid="attachment-link">
+                Download
               </a>
+            </div>
+            {redirectLink && (
+              <div className="col-12 col-md-auto ml-0 ml-md-2">
+                <a href={redirectLink} target="_blank" rel="noopener noreferrer" className="downloadtext">
+                  Open
+                </a>
+              </div>
             )}
           </div>
         </div>

--- a/src/components/UI/AttachmentLink/AttachmentLink.tsx
+++ b/src/components/UI/AttachmentLink/AttachmentLink.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled";
 import prettyBytes from "pretty-bytes";
 import { mixin, vars } from "../../../styles";
 import { Paperclip } from "react-feather";
+import { getData, utils, WrappedDocument } from "@govtechsg/open-attestation";
 
 export interface AttachmentLinkProps {
   className?: string;
@@ -14,12 +15,19 @@ export interface AttachmentLinkProps {
 
 export const AttachmentLinkUnStyled = ({ className, filename, data, type, path }: AttachmentLinkProps) => {
   let filesize = "0";
+  let redirectLink = "";
   const hasBase64 = !!(data && type);
   const downloadHref = hasBase64 ? `data:${type};base64,${data}` : path || "javascript:void(0)";
 
   if (data) {
     const decodedData = atob(data);
     filesize = prettyBytes(decodedData.length);
+    const decodedJson = JSON.parse(decodedData);
+    const isOpenAttestationSchema = utils.isWrappedV2Document(decodedJson);
+    if (isOpenAttestationSchema) {
+      const originalDocument = getData<WrappedDocument>(decodedJson);
+      redirectLink = originalDocument?.links?.self?.href ?? "";
+    }
   }
 
   return (
@@ -35,7 +43,14 @@ export const AttachmentLinkUnStyled = ({ className, filename, data, type, path }
             <span className="filename">{filename}</span>
             {hasBase64 && <span className="filesize">({filesize})</span>}
           </p>
-          <p className="downloadtext mb-0">Download</p>
+          <div className="row no-gutters">
+            <p className="downloadtext mb-0">Download</p>
+            {redirectLink && (
+              <a href={redirectLink} target="_blank" rel="noopener noreferrer" className="downloadtext mb-0 ml-2">
+                Open
+              </a>
+            )}
+          </div>
         </div>
       </div>
     </a>


### PR DESCRIPTION
This PR adds the open link beside a tt attachment to view  `.tt` file on another tab.

This file can be used for testing:
[test-open-ropsten.txt](https://github.com/TradeTrust/tradetrust-website/files/5260141/test-open-ropsten.txt)

https://www.pivotaltracker.com/n/projects/2424361