### PR TITLE
fix: endpoint url

### DIFF
--- a/src/common/hooks/useThirdPartyAPIEndpoints.ts
+++ b/src/common/hooks/useThirdPartyAPIEndpoints.ts
@@ -29,8 +29,8 @@ export const useThirdPartyAPIEndpoints = () => {
   };
 
   const getFeature = (feature: "ADDRESS_RESOLUTION" | "ENTITY_LOOKUP", index: number) => {
-    if (feature === "ADDRESS_RESOLUTION") return thirdPartyAPIEndpoints[index].path.addressResolution;
-    if (feature === "ENTITY_LOOKUP") return thirdPartyAPIEndpoints[index].path.entityLookup;
+    if (feature === "ADDRESS_RESOLUTION") return thirdPartyAPIEndpoints[index]?.path.addressResolution;
+    if (feature === "ENTITY_LOOKUP") return thirdPartyAPIEndpoints[index]?.path.entityLookup;
   };
 
   return {

--- a/src/common/hooks/useThirdPartyAPIEndpoints.ts
+++ b/src/common/hooks/useThirdPartyAPIEndpoints.ts
@@ -28,5 +28,16 @@ export const useThirdPartyAPIEndpoints = () => {
     setThirdPartyAPIEndpoints(filtered);
   };
 
-  return { thirdPartyAPIEndpoints, setThirdPartyAPIEndpoints, addThirdPartyAPIEndpoint, removeThirdPartyAPIEndpoint };
+  const getFeature = (feature: "ADDRESS_RESOLUTION" | "ENTITY_LOOKUP", index: number) => {
+    if (feature === "ADDRESS_RESOLUTION") return thirdPartyAPIEndpoints[index].path.addressResolution;
+    if (feature === "ENTITY_LOOKUP") return thirdPartyAPIEndpoints[index].path.entityLookup;
+  };
+
+  return {
+    thirdPartyAPIEndpoints,
+    setThirdPartyAPIEndpoints,
+    addThirdPartyAPIEndpoint,
+    removeThirdPartyAPIEndpoint,
+    getFeature,
+  };
 };

--- a/src/common/hooks/useThirdPartyAPIEndpoints.ts
+++ b/src/common/hooks/useThirdPartyAPIEndpoints.ts
@@ -28,7 +28,7 @@ export const useThirdPartyAPIEndpoints = () => {
     setThirdPartyAPIEndpoints(filtered);
   };
 
-  const getFeature = (feature: "ADDRESS_RESOLUTION" | "ENTITY_LOOKUP", index: number) => {
+  const getFeatureEndpoint = (feature: "ADDRESS_RESOLUTION" | "ENTITY_LOOKUP", index: number) => {
     if (feature === "ADDRESS_RESOLUTION") return thirdPartyAPIEndpoints[index]?.path.addressResolution;
     if (feature === "ENTITY_LOOKUP") return thirdPartyAPIEndpoints[index]?.path.entityLookup;
   };
@@ -38,6 +38,6 @@ export const useThirdPartyAPIEndpoints = () => {
     setThirdPartyAPIEndpoints,
     addThirdPartyAPIEndpoint,
     removeThirdPartyAPIEndpoint,
-    getFeature,
+    getFeatureEndpoint,
   };
 };

--- a/src/components/UI/Overlay/OverlayContent/AddressBook.tsx
+++ b/src/components/UI/Overlay/OverlayContent/AddressBook.tsx
@@ -59,7 +59,7 @@ const StyledDropdownItem = styled(Dropdown.Item)`
 
 export const AddressBook = styled(({ onAddressSelected, ...props }: AddressBookProps) => {
   const { setOverlayVisible } = useContext(OverlayContext);
-  const { thirdPartyAPIEndpoints } = useThirdPartyAPIEndpoints();
+  const { thirdPartyAPIEndpoints, getFeature } = useThirdPartyAPIEndpoints();
   const [searchTerm, setSearchTerm] = useState("");
 
   const [isLocal, setIsLocal] = useState(true);
@@ -69,7 +69,7 @@ export const AddressBook = styled(({ onAddressSelected, ...props }: AddressBookP
     []
   );
   const { name, endpoint, apiHeader, apiKey } = thirdPartyAPIEndpoints[remoteEndpointIndex] ?? {};
-  const [entityLookupPath, setEntityLookupPath] = useState<string>();
+  const entityLookupPath = getFeature("ENTITY_LOOKUP", remoteEndpointIndex);
 
   const onAddressSelect = (address: string) => {
     if (onAddressSelected) {
@@ -78,18 +78,9 @@ export const AddressBook = styled(({ onAddressSelected, ...props }: AddressBookP
     }
   };
 
-  const queryFeatures = async () => {
-    try {
-      const { features } = await getFeatures(endpoint, apiHeader, apiKey);
-      setEntityLookupPath(features.entityLookup?.location);
-    } catch (e) {
-      setEntityLookupPath(undefined);
-      console.log(e, "error");
-    }
-  };
-
   const queryEndpoint = useCallback(
     debounce(async (search) => {
+      if (!entityLookupPath) throw new Error(`entityLookup feature is not available`);
       setIsPendingRemoteResults(true);
 
       try {
@@ -109,7 +100,7 @@ export const AddressBook = styled(({ onAddressSelected, ...props }: AddressBookP
 
       setIsPendingRemoteResults(false);
     }, 1000),
-    [entityLookupPath]
+    []
   );
 
   const onSearchTermChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -142,7 +133,6 @@ export const AddressBook = styled(({ onAddressSelected, ...props }: AddressBookP
                   onClick={() => {
                     setIsLocal(false);
                     setSearchTerm("");
-                    queryFeatures();
                     setRemoteEndpointIndex(index);
                   }}
                 >

--- a/src/components/UI/Overlay/OverlayContent/AddressBook.tsx
+++ b/src/components/UI/Overlay/OverlayContent/AddressBook.tsx
@@ -83,6 +83,7 @@ export const AddressBook = styled(({ onAddressSelected, ...props }: AddressBookP
       const { features } = await getFeatures(endpoint, apiHeader, apiKey);
       setEntityLookupPath(features.entityLookup?.location);
     } catch (e) {
+      setEntityLookupPath(undefined);
       console.log(e, "error");
     }
   };
@@ -130,7 +131,6 @@ export const AddressBook = styled(({ onAddressSelected, ...props }: AddressBookP
               onClick={() => {
                 setIsLocal(true);
                 setSearchTerm("");
-                setEntityLookupPath(undefined);
               }}
             >
               Local
@@ -140,9 +140,9 @@ export const AddressBook = styled(({ onAddressSelected, ...props }: AddressBookP
                 <StyledDropdownItem
                   key={index}
                   onClick={() => {
-                    queryFeatures();
                     setIsLocal(false);
                     setSearchTerm("");
+                    queryFeatures();
                     setRemoteEndpointIndex(index);
                   }}
                 >

--- a/src/components/UI/Overlay/OverlayContent/AddressBook.tsx
+++ b/src/components/UI/Overlay/OverlayContent/AddressBook.tsx
@@ -14,7 +14,6 @@ import { debounce } from "lodash";
 import { AddressBookLocal } from "./AddressBookLocal";
 import { AddressBookThirdParty } from "./AddressBookThirdParty";
 import { entityLookup, AddressBookThirdPartyResultsProps } from "../../../../services/addressResolver";
-import { getFeatures } from "../../../../services/addressResolver";
 
 export interface AddressBookDropdownProps {
   name: string;

--- a/src/components/UI/Overlay/OverlayContent/AddressBook.tsx
+++ b/src/components/UI/Overlay/OverlayContent/AddressBook.tsx
@@ -58,7 +58,7 @@ const StyledDropdownItem = styled(Dropdown.Item)`
 
 export const AddressBook = styled(({ onAddressSelected, ...props }: AddressBookProps) => {
   const { setOverlayVisible } = useContext(OverlayContext);
-  const { thirdPartyAPIEndpoints, getFeature } = useThirdPartyAPIEndpoints();
+  const { thirdPartyAPIEndpoints, getFeatureEndpoint } = useThirdPartyAPIEndpoints();
   const [searchTerm, setSearchTerm] = useState("");
 
   const [isLocal, setIsLocal] = useState(true);
@@ -68,7 +68,7 @@ export const AddressBook = styled(({ onAddressSelected, ...props }: AddressBookP
     []
   );
   const { name, endpoint, apiHeader, apiKey } = thirdPartyAPIEndpoints[remoteEndpointIndex] ?? {};
-  const entityLookupPath = getFeature("ENTITY_LOOKUP", remoteEndpointIndex);
+  const entityLookupPath = getFeatureEndpoint("ENTITY_LOOKUP", remoteEndpointIndex);
 
   const onAddressSelect = (address: string) => {
     if (onAddressSelected) {

--- a/src/services/addressResolver/index.ts
+++ b/src/services/addressResolver/index.ts
@@ -26,7 +26,7 @@ interface EntityLookupProps {
   endpoint: string;
   apiHeader?: string;
   apiKey?: string;
-  path: string | undefined;
+  path: string;
 }
 
 const get = async ({
@@ -57,7 +57,6 @@ export const entityLookup = async ({
   apiKey,
   path,
 }: EntityLookupProps): Promise<AddressBookThirdPartyResultsProps[]> => {
-  if (path === undefined) return Promise.reject("entityLookup feature is not available");
   const url = join(endpoint, path, `?q=${query}`);
   const response = await get({ url, apiHeader, apiKey });
   return response.data.identities;

--- a/src/services/addressResolver/index.ts
+++ b/src/services/addressResolver/index.ts
@@ -26,6 +26,7 @@ interface EntityLookupProps {
   endpoint: string;
   apiHeader?: string;
   apiKey?: string;
+  path: string | undefined;
 }
 
 const get = async ({
@@ -54,8 +55,10 @@ export const entityLookup = async ({
   endpoint,
   apiHeader,
   apiKey,
+  path,
 }: EntityLookupProps): Promise<AddressBookThirdPartyResultsProps[]> => {
-  const url = `${endpoint}search?q=${query}`;
+  if (path === undefined) return Promise.reject("entityLookup feature is not available");
+  const url = join(endpoint, path, `?q=${query}`);
   const response = await get({ url, apiHeader, apiKey });
   return response.data.identities;
 };


### PR DESCRIPTION
### updates
- queryFeatures for `entityLookup.location` path
- url reconstructed using `endpoint`, `entityLookupPath`, `query` by normalizing with `join` = this will allow with or without trailing slash

### user story
- https://www.pivotaltracker.com/story/show/175279557