### PR TITLE
fix: clean up action.openattestation trailing slash and git repository warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,5 +274,9 @@
   },
   "prettier": {
     "printWidth": 120
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TradeTrust/tradetrust-website.git"
   }
 }

--- a/src/components/QrReader/Scanner.js
+++ b/src/components/QrReader/Scanner.js
@@ -1,7 +1,7 @@
 import { useLayoutEffect } from "react";
 import QrScanner from "qr-scanner";
-import QrScannerWorkerPath from "!!file-loader!../../../node_modules/qr-scanner/qr-scanner-worker.min.js";
 // `!!file-loader!` explicitly instruct webpack to import file with file-loader overwriting global config
+import QrScannerWorkerPath from "!!file-loader!../../../node_modules/qr-scanner/qr-scanner-worker.min.js";
 QrScanner.WORKER_PATH = QrScannerWorkerPath;
 
 export const useScanner = ({ onDetected, scannerRef }) => {

--- a/src/components/QrReader/Scanner.js
+++ b/src/components/QrReader/Scanner.js
@@ -1,6 +1,7 @@
 import { useLayoutEffect } from "react";
 import QrScanner from "qr-scanner";
 import QrScannerWorkerPath from "!!file-loader!../../../node_modules/qr-scanner/qr-scanner-worker.min.js";
+// `!!file-loader!` explicitly instruct webpack to import file with file-loader overwriting global config
 QrScanner.WORKER_PATH = QrScannerWorkerPath;
 
 export const useScanner = ({ onDetected, scannerRef }) => {

--- a/src/services/qrProcessor/index.js
+++ b/src/services/qrProcessor/index.js
@@ -3,7 +3,7 @@ import { getLogger } from "../../utils/logger";
 const { error } = getLogger("services:qrProcessor");
 
 export const decodeQrCode = (qrCode) => {
-  const openAttestationActionRegex = /https:\/\/action.openattestation.com\/\?q=(.*)/;
+  const openAttestationActionRegex = /https:\/\/action.openattestation.com\/?\?q=(.*)/;
   if (!openAttestationActionRegex.test(qrCode))
     throw new Error("QR Code is not formatted to TradeTrust specifications");
   const [, encodedPayload] = openAttestationActionRegex.exec(qrCode);

--- a/src/services/qrProcessor/qrProcessor.test.js
+++ b/src/services/qrProcessor/qrProcessor.test.js
@@ -1,12 +1,11 @@
 import { decodeQrCode, processQrCode } from "./index";
 
-const encodeQrCode = (payload) =>
-  `https://action.openattestation.com/?q=${encodeURIComponent(JSON.stringify(payload))}`;
+const encodeQrCode = (payload) => `https://action.openattestation.com?q=${encodeURIComponent(JSON.stringify(payload))}`;
 
 describe("decodeQrCode", () => {
   it("decodes an action correctly", () => {
     const encodedQrCode =
-      "https://action.openattestation.com/?q=%7B%22uri%22%3A%22https%3A%2F%2Fsample.domain%2Fdocument%2Fid%3Fq%3Dabc%23123%22%7D";
+      "https://action.openattestation.com?q=%7B%22uri%22%3A%22https%3A%2F%2Fsample.domain%2Fdocument%2Fid%3Fq%3Dabc%23123%22%7D";
 
     const action = decodeQrCode(encodedQrCode);
     expect(action).toStrictEqual({


### PR DESCRIPTION
This PR fixes:
1. QR code uri has inconsistent standards with trailing slashes, removed all trailing slash! (regex test still makes it compatible with past standards)
1. also add repository field in package.json to remove warning
