### PR TITLE
fix: support for xlms and xlsx

### DIFF
--- a/src/components/UI/AttachmentLink/AttachmentLink.test.tsx
+++ b/src/components/UI/AttachmentLink/AttachmentLink.test.tsx
@@ -49,6 +49,13 @@ describe("AttachmentLink", () => {
       <>
         <AttachmentLink className="h-100" filename="asdfdfs.pdf" data="asdfasdf" type="application/pdf" />
         <AttachmentLink className="h-100" filename="asdfdfs.csv" data="asdfasdf" type="text/csv" />
+        <AttachmentLink className="h-100" filename="asdfdfs.xls" data="asdfasdf" type="application/vnd.ms-excel" />
+        <AttachmentLink
+          className="h-100"
+          filename="asdfdfs.xlsx"
+          data="asdfasdf"
+          type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        />
         <AttachmentLink className="h-100" filename="asdfdfs.txt" data="asdfasdf" type="text/plain" />
         <AttachmentLink
           className="h-100"
@@ -63,7 +70,7 @@ describe("AttachmentLink", () => {
       </>
     );
     expect(container.queryByTestId("attachment-icon-pdf")).not.toBeNull();
-    expect(container.queryByTestId("attachment-icon-csv")).not.toBeNull();
+    expect(container.getAllByTestId("attachment-icon-csv")).toHaveLength(3);
     expect(container.queryByTestId("attachment-icon-txt")).not.toBeNull();
     expect(container.getAllByTestId("attachment-icon-doc")).toHaveLength(2);
     expect(container.queryByTestId("attachment-icon-jpg")).not.toBeNull();

--- a/src/components/UI/AttachmentLink/AttachmentLink.test.tsx
+++ b/src/components/UI/AttachmentLink/AttachmentLink.test.tsx
@@ -47,26 +47,24 @@ describe("AttachmentLink", () => {
   it("should render a uploaded file icons correctly", () => {
     const container = render(
       <>
-        <AttachmentLink className="h-100" filename="asdfdfs.pdf" data="asdfasdf" type="application/pdf" />
-        <AttachmentLink className="h-100" filename="asdfdfs.csv" data="asdfasdf" type="text/csv" />
-        <AttachmentLink className="h-100" filename="asdfdfs.xls" data="asdfasdf" type="application/vnd.ms-excel" />
+        <AttachmentLink filename="asdfdfs.pdf" data="asdfasdf" type="application/pdf" />
+        <AttachmentLink filename="asdfdfs.csv" data="asdfasdf" type="text/csv" />
+        <AttachmentLink filename="asdfdfs.xls" data="asdfasdf" type="application/vnd.ms-excel" />
         <AttachmentLink
-          className="h-100"
           filename="asdfdfs.xlsx"
           data="asdfasdf"
           type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         />
         <AttachmentLink className="h-100" filename="asdfdfs.txt" data="asdfasdf" type="text/plain" />
         <AttachmentLink
-          className="h-100"
           filename="asdfdfs.docx"
           data="asdfasdf"
           type="application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         />
-        <AttachmentLink className="h-100" filename="asdfdfs.doc" data="asdfasdf" type="application/msword" />
-        <AttachmentLink className="h-100" filename="asdfdfs.jpg" data="asdfasdf" type="image/jpeg" />
-        <AttachmentLink className="h-100" filename="asdfdfs.png" data="asdfasdf" type="image/png" />
-        <AttachmentLink className="h-100" filename="asdfdfs.json" data="asdfasdf" type="application/json" />
+        <AttachmentLink filename="asdfdfs.doc" data="asdfasdf" type="application/msword" />
+        <AttachmentLink filename="asdfdfs.jpg" data="asdfasdf" type="image/jpeg" />
+        <AttachmentLink filename="asdfdfs.png" data="asdfasdf" type="image/png" />
+        <AttachmentLink filename="asdfdfs.json" data="asdfasdf" type="application/json" />
       </>
     );
     expect(container.queryByTestId("attachment-icon-pdf")).not.toBeNull();

--- a/src/components/UI/AttachmentLink/AttachmentLink.tsx
+++ b/src/components/UI/AttachmentLink/AttachmentLink.tsx
@@ -34,7 +34,9 @@ const ExtensionIcon: FunctionComponent<ExtensionIconProps> = ({ ...props }) => {
 
 export const getExtension = (mimeType: string | undefined): React.ReactNode => {
   switch (true) {
-    case mimeType === "text/csv":
+    case mimeType === "text/csv" ||
+      mimeType === "application/vnd.ms-excel" ||
+      mimeType === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
       return <ExtensionIcon src="/static/images/fileicons/csv.svg" data-testid="attachment-icon-csv" />;
     case mimeType === "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
       mimeType === "application/msword":


### PR DESCRIPTION
This PR contains a fix for .csv/ .xlms/ .xlsx files to have a file icon.