### PR TITLE
fix: typo in homepage

### DIFF
--- a/src/components/HomePageContent/DocumentationSection.tsx
+++ b/src/components/HomePageContent/DocumentationSection.tsx
@@ -62,7 +62,7 @@ export const DocumentationSection = () => {
     <SectionDocumentation id="integrate" className="bg-grey-lightest">
       <div className="row mb-5">
         <div className="col-12">
-          <h1 className="mb-3">Integrate Tradetust into your platform?</h1>
+          <h1 className="mb-3">Integrate TradeTrust into your platform?</h1>
           <p>Get started today! Browse the Documentation or download the source code.</p>
         </div>
       </div>


### PR DESCRIPTION
Was referring to TradeTrust for a school project and noticed the typo. 😛 

![image](https://user-images.githubusercontent.com/506667/97798679-200d1380-1c63-11eb-9ef5-3cde400964cb.png)

Changed `Tradetust` to `TradeTrust`.