### PR TITLE
feat: upgrade oa verify and dns-did

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2015,9 +2015,9 @@
       }
     },
     "@govtechsg/oa-verify": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@govtechsg/oa-verify/-/oa-verify-5.1.0.tgz",
-      "integrity": "sha512-BqPjgcdSlrmGvkKNpdBfGBidFPgjY8HyotmjVktJhqEOq7WUQMoXYbSULLV2ToSSNFtRgFxIy76efmv+sQaxaA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@govtechsg/oa-verify/-/oa-verify-6.0.0.tgz",
+      "integrity": "sha512-ABVOcfi+2/xktuj8mnDCkmv4u1YRdf6zf9FGyBs21rhXfbVGsmCAmMCMLQgN+rmJ6N2qNLoSOpcUwuBhheG3fA==",
       "requires": {
         "@govtechsg/dnsprove": "^2.0.9",
         "@govtechsg/document-store": "^2.0.0",
@@ -2034,9 +2034,9 @@
       },
       "dependencies": {
         "@govtechsg/dnsprove": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.1.0.tgz",
-          "integrity": "sha512-9sO5b4U1qbWo7yfgXK77875E2VTLu12pCt8gzYscj0bLv/gqxnjrRPYiSYqh18uBeQQKCTo+/HYNBSxlqPd/7A==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.1.1.tgz",
+          "integrity": "sha512-RHUgoO2PY/Zo+4PEZcwlKlGO5x9n/3CJHxPYDmGUggBeNgcXhIDCWnjArVC5ZH2nCsN1K7+1sWpOtUwbUZ3AqQ==",
           "requires": {
             "axios": "0.20.0",
             "debug": "4.1.1",
@@ -15989,9 +15989,9 @@
       "integrity": "sha512-4BPvMGkxAK9vTduCq6D5b8ZqjteD2cvDIPPriXP6nnmPhWKFSxypo+AFvyQ0omJGa0cGTR+dkdI/8jiF7U/qaw=="
     },
     "ethr-did-resolver": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-3.0.0.tgz",
-      "integrity": "sha512-o400l9p8ee6W09fZLMX2BERcyFRrebE7DCjb46Rzgypb7QzX1rBOzHJ0PorWRINXFqoPMoxR7OeIrD17obIbng==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-3.0.1.tgz",
+      "integrity": "sha512-3OkALz3ovPZwKdHyP1FWvRA/6EVRH9lq4zR6bKKcPPGFQJRKBdxw//qxtaq+XHYziIrlKz/P8ANqd/K+sIjFhg==",
       "requires": {
         "buffer": "^5.1.0",
         "did-resolver": "2.1.1",
@@ -25375,9 +25375,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          },
           "dependencies": {
             "is-buffer": {
               "version": "1.1.6",
@@ -25427,9 +25424,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "requires": {
-            "kind-of": "^6.0.0"
-          },
           "dependencies": {
             "is-buffer": {
               "version": "1.1.6",
@@ -25457,8 +25451,7 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-data-descriptor": "^1.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -25993,7 +25986,6 @@
           "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
           "requires": {
             "inherits": "^2.0.1",
-            "readable-stream": "^2.0.5",
             "xtend": "^4.0.0"
           },
           "dependencies": {
@@ -26186,44 +26178,32 @@
             "xtend": "^4.0.1"
           },
           "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            },
-            "object-keys": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-              "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-              "dev": true
-            },
             "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "version": "2.3.7",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+              "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
                 "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "dev": true
             },
             "xtend": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-              "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-              "dev": true,
-              "requires": {
-                "object-keys": "~0.4.0"
-              }
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+              "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+              "dev": true
             }
           }
         },
@@ -26890,10 +26870,13 @@
               }
             },
             "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-              "dev": true
+              "version": "2.6.3",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+              "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+              "dev": true,
+              "requires": {
+                "lodash": "^4.17.14"
+              }
             },
             "ethereumjs-util": {
               "version": "5.2.1",
@@ -27966,12 +27949,35 @@
           "requires": {
             "define-properties": "^1.1.3",
             "es-abstract": "^1.18.0-next.1"
+          },
+          "dependencies": {
+            "es-abstract": {
+              "version": "1.18.0-next.1",
+              "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+              "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+              "dev": true,
+              "requires": {
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.0",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.1",
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
+              }
+            }
           }
         },
         "object-keys": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
         },
         "object-visit": {
           "version": "1.0.1",
@@ -29885,6 +29891,13 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
           }
         },
         "stringify-object": {
@@ -40947,8 +40960,7 @@
     "nan": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-      "dev": true
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "nano-json-stream-parser": {
       "version": "0.1.2",
@@ -54687,9 +54699,9 @@
       }
     },
     "web-did-resolver": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/web-did-resolver/-/web-did-resolver-1.3.3.tgz",
-      "integrity": "sha512-CL/pBC/vatndMU84eaWA7QHRgwN2Op3hAhxTcBs7VMmqoNGmZXmW1/x3FU0w8kLhRRJae2XFUkkxHQfN1wJtTw==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/web-did-resolver/-/web-did-resolver-1.3.5.tgz",
+      "integrity": "sha512-k+32CvrguvAwgvppYH0geMsmKJL1akuyWa3p5ArVON5swYvMb72e1yayM7XuPMwUW/6aZ2Z0HL14QkfvcIJRQw==",
       "requires": {
         "cross-fetch": "^3.0.4",
         "did-resolver": "2.1.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@govtechsg/decentralized-renderer-react-components": "^3.0.0",
     "@govtechsg/ethers-contract-hook": "^2.2.0",
     "@govtechsg/oa-encryption": "^1.3.2",
-    "@govtechsg/oa-verify": "^5.1.0",
+    "@govtechsg/oa-verify": "^6.0.0",
     "@govtechsg/open-attestation": "^4.0.0",
     "@govtechsg/token-registry": "^2.4.0",
     "@hot-loader/react-dom": "^16.9.0",

--- a/src/components/CertificateDropZone/CertificateDropZone.js
+++ b/src/components/CertificateDropZone/CertificateDropZone.js
@@ -5,7 +5,7 @@ import { DefaultView } from "./Views/DefaultView";
 import { VerifyingView } from "./Views/VerifyingView";
 import { UnverifiedView } from "./Views/UnverifiedView";
 import { RetrievalErrorView } from "./Views/RetrievalErrorView";
-import { isValid } from "../../services/verify/fragments";
+import { isValid } from "@govtechsg/oa-verify";
 
 export const DropzoneContent = ({
   handleRenderOverwrite,

--- a/src/components/CertificateDropZone/CertificateDropZone.stories.tsx
+++ b/src/components/CertificateDropZone/CertificateDropZone.stories.tsx
@@ -5,7 +5,7 @@ import {
   whenDocumentHashInvalid,
   whenDocumentRevoked,
   whenDocumentNotIssued,
-  whenDocumentIssuerIdentityInvalid,
+  whenDocumentIssuerIdentityInvalidDnsTxt,
   whenDocumentHashInvalidAndNotIssued,
 } from "../../test/fixture/verifier-responses";
 
@@ -60,7 +60,7 @@ export const Revoked = () => {
 export const IssuerIdentityInvalid = () => {
   return (
     <Router>
-      <CertificateDropZone verifying={false} verificationStatus={whenDocumentIssuerIdentityInvalid} />
+      <CertificateDropZone verifying={false} verificationStatus={whenDocumentIssuerIdentityInvalidDnsTxt} />
     </Router>
   );
 };

--- a/src/components/CertificateDropZone/Views/UnverifiedView.test.js
+++ b/src/components/CertificateDropZone/Views/UnverifiedView.test.js
@@ -6,7 +6,7 @@ import { TYPES, MESSAGES } from "../../../constants/VerificationErrorMessages";
 import {
   whenDocumentHashInvalid,
   whenDocumentNotIssued,
-  whenDocumentIssuerIdentityInvalid,
+  whenDocumentIssuerIdentityInvalidDnsTxt,
 } from "../../../test/fixture/verifier-responses";
 
 describe("unverifiedView", () => {
@@ -45,7 +45,7 @@ describe("unverifiedView", () => {
       <MemoryRouter>
         <UnverifiedView
           handleRenderOverwrite={() => {}}
-          verificationStatus={whenDocumentIssuerIdentityInvalid}
+          verificationStatus={whenDocumentIssuerIdentityInvalidDnsTxt}
           resetData={() => {}}
         />
       </MemoryRouter>

--- a/src/components/DocumentStatus/DocumentStatus.stories.tsx
+++ b/src/components/DocumentStatus/DocumentStatus.stories.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import { DocumentStatus, DocumentStatusUnStyled } from "./DocumentStatus";
 import {
-  whenDocumentValidAndIssued,
+  whenDocumentValidAndIssuedByDns,
   whenDocumentHashInvalid,
   whenDocumentNotIssued,
   whenDocumentRevoked,
-  whenDocumentIssuerIdentityInvalid,
+  whenDocumentIssuerIdentityInvalidDnsTxt,
   whenDocumentHashInvalidAndNotIssued,
   whenTransferableDocumentVerified,
 } from "../../test/fixture/verifier-responses";
@@ -19,7 +19,7 @@ export default {
 };
 
 export const DocumentValid = () => {
-  return <DocumentStatus verificationStatus={whenDocumentValidAndIssued as []} />;
+  return <DocumentStatus verificationStatus={whenDocumentValidAndIssuedByDns as []} />;
 };
 
 export const DocumentValidTransferable = () => {
@@ -39,7 +39,7 @@ export const DocumentRevoked = () => {
 };
 
 export const DocumentIssuerIdentityInvalid = () => {
-  return <DocumentStatus verificationStatus={whenDocumentIssuerIdentityInvalid as []} />;
+  return <DocumentStatus verificationStatus={whenDocumentIssuerIdentityInvalidDnsTxt as []} />;
 };
 
 export const DocumentAllVerificationFail = () => {

--- a/src/components/DocumentStatus/DocumentStatus.test.tsx
+++ b/src/components/DocumentStatus/DocumentStatus.test.tsx
@@ -5,8 +5,9 @@ import { DocumentStatus, IssuedBy } from "./DocumentStatus";
 import {
   whenDocumentHashInvalid,
   whenDocumentNotIssued,
-  whenDocumentIssuerIdentityInvalid,
+  whenDocumentIssuerIdentityInvalidDnsTxt,
   whenDocumentHashInvalidAndNotIssued,
+  whenDocumentIssuerIdentityInvalidDid,
 } from "../../test/fixture/verifier-responses";
 import { MESSAGES } from "../../constants/VerificationErrorMessages";
 
@@ -14,7 +15,7 @@ describe("IssuedBy", () => {
   it("should return appropriate display text when single dns is verified", () => {
     const fragments = [
       {
-        name: "OpenAttestationDnsTxt",
+        name: "OpenAttestationDnsTxtIdentityProof",
         type: "ISSUER_IDENTITY",
         status: "VALID",
         data: [
@@ -32,7 +33,7 @@ describe("IssuedBy", () => {
   it("should return appropriate display text when multiple dns is verified", () => {
     const fragments = [
       {
-        name: "OpenAttestationDnsTxt",
+        name: "OpenAttestationDnsTxtIdentityProof",
         type: "ISSUER_IDENTITY",
         status: "VALID",
         data: [
@@ -54,6 +55,43 @@ describe("IssuedBy", () => {
     const container = render(<IssuedBy verificationStatus={fragments} />);
     expect(container.queryByText("ABC.COM, XYZ.COM and DEMO.COM")).not.toBeNull();
   });
+
+  it("should return did identity if is verified with did", () => {
+    const fragments = [
+      {
+        name: "OpenAttestationDnsDidIdentityProof",
+        type: "ISSUER_IDENTITY",
+        status: "VALID",
+        data: [
+          {
+            status: "VALID",
+            location: "abc.com",
+          },
+        ],
+      },
+    ] as VerificationFragment[];
+    const container = render(<IssuedBy verificationStatus={fragments} />);
+    expect(container.queryByText("ABC.COM")).not.toBeNull();
+  });
+
+  it("should return did identity if is verified with did", () => {
+    const sampleDidIdentity = "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89";
+    const fragments = [
+      {
+        name: "OpenAttestationDidIdentityProof",
+        type: "ISSUER_IDENTITY",
+        status: "VALID",
+        data: [
+          {
+            status: "VALID",
+            did: sampleDidIdentity,
+          },
+        ],
+      },
+    ] as VerificationFragment[];
+    const container = render(<IssuedBy verificationStatus={fragments} />);
+    expect(container.queryByText(sampleDidIdentity.toUpperCase())).not.toBeNull();
+  });
 });
 
 describe("DocumentStatus", () => {
@@ -71,9 +109,18 @@ describe("DocumentStatus", () => {
     expect(container.queryByText(MESSAGES["IDENTITY"]["failureTitle"])).toBeNull();
   });
 
-  it("displays identity error if the identity is not verified", () => {
+  it("displays identity error if the dns txt identity is not verified", () => {
     const container = render(
-      <DocumentStatus verificationStatus={whenDocumentIssuerIdentityInvalid as VerificationFragment[]} />
+      <DocumentStatus verificationStatus={whenDocumentIssuerIdentityInvalidDnsTxt as VerificationFragment[]} />
+    );
+    expect(container.queryByText(MESSAGES["HASH"]["failureTitle"])).toBeNull();
+    expect(container.queryByText(MESSAGES["ISSUED"]["failureTitle"])).toBeNull();
+    expect(container.queryByText(MESSAGES["IDENTITY"]["failureTitle"])).not.toBeNull();
+  });
+
+  it("displays identity error if the did identity is not verified", () => {
+    const container = render(
+      <DocumentStatus verificationStatus={whenDocumentIssuerIdentityInvalidDid as VerificationFragment[]} />
     );
     expect(container.queryByText(MESSAGES["HASH"]["failureTitle"])).toBeNull();
     expect(container.queryByText(MESSAGES["ISSUED"]["failureTitle"])).toBeNull();

--- a/src/components/DocumentStatus/DocumentStatus.test.tsx
+++ b/src/components/DocumentStatus/DocumentStatus.test.tsx
@@ -56,7 +56,7 @@ describe("IssuedBy", () => {
     expect(container.queryByText("ABC.COM, XYZ.COM and DEMO.COM")).not.toBeNull();
   });
 
-  it("should return did identity if is verified with did", () => {
+  it("should return domain if is verified with DNS-DID", () => {
     const fragments = [
       {
         name: "OpenAttestationDnsDidIdentityProof",
@@ -74,7 +74,7 @@ describe("IssuedBy", () => {
     expect(container.queryByText("ABC.COM")).not.toBeNull();
   });
 
-  it("should return did identity if is verified with did", () => {
+  it("should return did if is verified with DID", () => {
     const sampleDidIdentity = "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89";
     const fragments = [
       {

--- a/src/components/DocumentStatus/DocumentStatus.tsx
+++ b/src/components/DocumentStatus/DocumentStatus.tsx
@@ -17,7 +17,7 @@ interface VerificationFragmentData {
 }
 
 export const IssuedBy = ({ verificationStatus }: DocumentStatusProps) => {
-  const formatDomainNames = (fragment: VerificationFragment<VerificationFragmentData[]>): string | undefined => {
+  const formatIdentifier = (fragment: VerificationFragment<VerificationFragmentData[]>): string | undefined => {
     switch (fragment.name) {
       case "OpenAttestationDnsTxtIdentityProof":
       // using fall through to get both cases
@@ -37,7 +37,7 @@ export const IssuedBy = ({ verificationStatus }: DocumentStatusProps) => {
   ) as VerificationFragment;
   const dataFragment = identityProofFragment?.data;
   const fragmentValidity = dataFragment?.every((issuer: { status: string }) => issuer.status === "VALID");
-  const formattedDomainNames = fragmentValidity ? formatDomainNames(identityProofFragment) : "Unknown";
+  const formattedDomainNames = fragmentValidity ? formatIdentifier(identityProofFragment) : "Unknown";
 
   return (
     <h3 id="issuedby" className={`mb-0 issuedby`}>

--- a/src/components/DocumentStatus/DocumentStatus.tsx
+++ b/src/components/DocumentStatus/DocumentStatus.tsx
@@ -17,16 +17,19 @@ interface VerificationFragmentData {
 }
 
 export const IssuedBy = ({ verificationStatus }: DocumentStatusProps) => {
+  const joinIssuers = (issuers: string[] | undefined): string => {
+    if (!issuers) return "Unknown";
+    const issuerNames = issuers.join(", ");
+    return issuerNames?.replace(/,(?=[^,]*$)/, " and"); // regex to find last comma, replace with and
+  };
   const formatIdentifier = (fragment: VerificationFragment<VerificationFragmentData[]>): string | undefined => {
     switch (fragment.name) {
       case "OpenAttestationDnsTxtIdentityProof":
       // using fall through to get both cases
       case "OpenAttestationDnsDidIdentityProof":
-        const domainNames = fragment.data?.map((issuer) => issuer.location.toUpperCase()).join(", ");
-        return domainNames?.replace(/,(?=[^,]*$)/, " and"); // regex to find last comma, replace with and
+        return joinIssuers(fragment.data?.map((issuer) => issuer.location.toUpperCase()));
       case "OpenAttestationDidIdentityProof":
-        const didNames = fragment.data?.map((issuer) => issuer.did.toUpperCase()).join(", ");
-        return didNames?.replace(/,(?=[^,]*$)/, " and"); // regex to find last comma, replace with and
+        return joinIssuers(fragment.data?.map((issuer) => issuer.did.toUpperCase()));
       default:
         return "Unknown";
     }

--- a/src/sagas/certificate.js
+++ b/src/sagas/certificate.js
@@ -10,7 +10,7 @@ import {
 import { sendEmail } from "../services/email/sendEmail";
 import { processQrCode } from "../services/qrProcessor";
 import { verifyDocument } from "../services/verify";
-import { isValid } from "../services/verify/fragments";
+import { isValid } from "@govtechsg/oa-verify";
 import { decryptString } from "@govtechsg/oa-encryption";
 import { NETWORK_NAME } from "./../config";
 
@@ -26,7 +26,6 @@ export function* verifyCertificate() {
 
     const certificate = yield select(getCertificate);
     const verificationStatus = yield verifyDocument(certificate);
-    console.log(verificationStatus);
     trace(`Verification Status: ${JSON.stringify(verificationStatus)}`);
 
     // Instead of success/failure, report completeness

--- a/src/sagas/certificate.js
+++ b/src/sagas/certificate.js
@@ -26,6 +26,7 @@ export function* verifyCertificate() {
 
     const certificate = yield select(getCertificate);
     const verificationStatus = yield verifyDocument(certificate);
+    console.log(verificationStatus);
     trace(`Verification Status: ${JSON.stringify(verificationStatus)}`);
 
     // Instead of success/failure, report completeness

--- a/src/sagas/certificate.test.js
+++ b/src/sagas/certificate.test.js
@@ -4,7 +4,10 @@ import { types, getCertificate } from "../reducers/certificate";
 import { sendCertificate, verifyCertificate } from "./certificate";
 import { MakeCertUtil } from "./testutils";
 import * as emailService from "../services/email/sendEmail";
-import { whenDocumentValidAndIssued, whenDocumentHashInvalidAndNotIssued } from "../test/fixture/verifier-responses";
+import {
+  whenDocumentValidAndIssuedByDns,
+  whenDocumentHashInvalidAndNotIssued,
+} from "../test/fixture/verifier-responses";
 
 jest.mock("../services/verify", () => ({ verifyDocument: () => {} }));
 
@@ -113,11 +116,11 @@ describe("verifyCertificate", () => {
     generator.next("CERTIFICATE_OBJECT");
 
     // Should mark verification as completed and report the payload
-    const verificationCompletionAction = generator.next(whenDocumentValidAndIssued).value;
+    const verificationCompletionAction = generator.next(whenDocumentValidAndIssuedByDns).value;
     expect(verificationCompletionAction).toStrictEqual(
       put({
         type: types.VERIFYING_CERTIFICATE_COMPLETED,
-        payload: whenDocumentValidAndIssued,
+        payload: whenDocumentValidAndIssuedByDns,
       })
     );
 

--- a/src/services/verify/fragments.test.tsx
+++ b/src/services/verify/fragments.test.tsx
@@ -3,10 +3,12 @@ import { interpretFragments } from "./fragments";
 import {
   whenDocumentHashInvalidAndNotIssued,
   whenDocumentNotIssued,
-  whenDocumentValidAndIssued,
+  whenDocumentValidAndIssuedByDns,
+  whenDocumentValidAndIssuedByDid,
   whenDocumentHashInvalid,
   whenDocumentRevoked,
-  whenDocumentIssuerIdentityInvalid,
+  whenDocumentIssuerIdentityInvalidDnsTxt,
+  whenDocumentIssuerIdentityInvalidDid,
   whenTransferableDocumentVerified,
 } from "../../test/fixture/verifier-responses";
 
@@ -27,8 +29,16 @@ describe("interpretFragments", () => {
       revokedValid: true,
     });
   });
-  it("should interpret whenDocumentValidAndIssued correctly", () => {
-    expect(interpretFragments(whenDocumentValidAndIssued as VerificationFragment[])).toEqual({
+  it("should interpret whenDocumentValidAndIssuedByDns correctly", () => {
+    expect(interpretFragments(whenDocumentValidAndIssuedByDns as VerificationFragment[])).toEqual({
+      hashValid: true,
+      issuedValid: true,
+      identityValid: true,
+      revokedValid: true,
+    });
+  });
+  it("should interpret whenDocumentValidAndIssuedByDid correctly", () => {
+    expect(interpretFragments(whenDocumentValidAndIssuedByDid as VerificationFragment[])).toEqual({
       hashValid: true,
       issuedValid: true,
       identityValid: true,
@@ -51,8 +61,16 @@ describe("interpretFragments", () => {
       revokedValid: false,
     });
   });
-  it("should interpret whenDocumentIssuerIdentityInvalid correctly", () => {
-    expect(interpretFragments(whenDocumentIssuerIdentityInvalid as VerificationFragment[])).toEqual({
+  it("should interpret whenDocumentIssuerIdentityInvalidDnsTxt correctly", () => {
+    expect(interpretFragments(whenDocumentIssuerIdentityInvalidDnsTxt as VerificationFragment[])).toEqual({
+      hashValid: true,
+      issuedValid: true,
+      identityValid: false,
+      revokedValid: true,
+    });
+  });
+  it("should interpret whenDocumentIssuerIdentityInvalidDid correctly", () => {
+    expect(interpretFragments(whenDocumentIssuerIdentityInvalidDid as VerificationFragment[])).toEqual({
       hashValid: true,
       issuedValid: true,
       identityValid: false,

--- a/src/services/verify/fragments.tsx
+++ b/src/services/verify/fragments.tsx
@@ -1,4 +1,4 @@
-import { isValid as isValidFromUpstream, VerificationFragment, VerificationFragmentType } from "@govtechsg/oa-verify";
+import { isValid, VerificationFragment } from "@govtechsg/oa-verify";
 const getFirstFragmentFor = (fragments: VerificationFragment[], name: string) =>
   fragments.filter((status) => status.name === name)[0];
 
@@ -14,28 +14,6 @@ export const addressInvalid = (fragments: VerificationFragment[]) => {
   const tokenRegistryMintedFragment = getFirstFragmentFor(fragments, "OpenAttestationEthereumTokenRegistryMinted");
   // 2 is the error code used by oa-verify in case of invalid address
   return documentStoreIssuedFragment?.reason?.code === 2 || tokenRegistryMintedFragment?.reason?.code === 2;
-};
-
-// using a custom isValid because @govtechsg/oa-verify will NOT throw an error when there are 2 identities
-// with one skipped and one valid.
-// in the case of Tradetrust, we want to make sure all identities are valid
-export const isValid = (
-  verificationFragments: VerificationFragment[],
-  types: VerificationFragmentType[] = ["DOCUMENT_STATUS", "DOCUMENT_INTEGRITY", "ISSUER_IDENTITY"]
-) => {
-  if (types.includes("ISSUER_IDENTITY")) {
-    const dnsFragment = getFirstFragmentFor(verificationFragments, "OpenAttestationDnsTxtIdentityProof");
-    const dnsDidFragment = getFirstFragmentFor(verificationFragments, "OpenAttestationDnsDidIdentityProof");
-    const didFragment = getFirstFragmentFor(verificationFragments, "OpenAttestationDidIdentityProof");
-    return (
-      isValidFromUpstream(verificationFragments, types) &&
-      (dnsFragment?.data?.every((issuer: VerificationFragment) => issuer.status === "VALID") ||
-        didFragment?.data?.every((issuer: VerificationFragment) => issuer.status === "VALID") ||
-        dnsDidFragment?.data?.every((issuer: VerificationFragment) => issuer.status === "VALID"))
-    );
-  } else {
-    return isValidFromUpstream(verificationFragments, types);
-  }
 };
 
 // this function check if the reason of the error is that the document store or token has not been issued

--- a/src/services/verify/fragments.tsx
+++ b/src/services/verify/fragments.tsx
@@ -24,10 +24,14 @@ export const isValid = (
   types: VerificationFragmentType[] = ["DOCUMENT_STATUS", "DOCUMENT_INTEGRITY", "ISSUER_IDENTITY"]
 ) => {
   if (types.includes("ISSUER_IDENTITY")) {
-    const dnsFragment = getFirstFragmentFor(verificationFragments, "OpenAttestationDnsTxt");
+    const dnsFragment = getFirstFragmentFor(verificationFragments, "OpenAttestationDnsTxtIdentityProof");
+    const dnsDidFragment = getFirstFragmentFor(verificationFragments, "OpenAttestationDnsDidIdentityProof");
+    const didFragment = getFirstFragmentFor(verificationFragments, "OpenAttestationDidIdentityProof");
     return (
       isValidFromUpstream(verificationFragments, types) &&
-      dnsFragment?.data?.every((issuer: VerificationFragment) => issuer.status === "VALID")
+      (dnsFragment?.data?.every((issuer: VerificationFragment) => issuer.status === "VALID") ||
+        didFragment?.data?.every((issuer: VerificationFragment) => issuer.status === "VALID") ||
+        dnsDidFragment?.data?.every((issuer: VerificationFragment) => issuer.status === "VALID"))
     );
   } else {
     return isValidFromUpstream(verificationFragments, types);

--- a/src/services/verify/index.tsx
+++ b/src/services/verify/index.tsx
@@ -1,9 +1,13 @@
 import { WrappedDocument, v2, v3 } from "@govtechsg/open-attestation";
-import { verify } from "@govtechsg/oa-verify";
+import { verificationBuilder, openAttestationVerifiers, openAttestationDidIdentityProof } from "@govtechsg/oa-verify";
 import { NETWORK_NAME } from "../../config";
+
+const customVerify = verificationBuilder([...openAttestationVerifiers, openAttestationDidIdentityProof]);
 
 export const verifyDocument = async (
   document: WrappedDocument<v3.OpenAttestationDocument> | WrappedDocument<v2.OpenAttestationDocument>
 ) => {
-  return verify(document, { network: NETWORK_NAME });
+  return customVerify(document, {
+    network: NETWORK_NAME,
+  });
 };

--- a/src/test/did-verified.spec.js
+++ b/src/test/did-verified.spec.js
@@ -1,0 +1,16 @@
+import { uploadDocument, validateIframeTexts, validateIssuerTexts } from "./helper";
+
+fixture("DID Certificate Rendering").page`http://localhost:3000`;
+
+test("sample document is rendered correctly when dns is verified", async () => {
+  await uploadDocument("./fixture/sample-did-verified.json");
+  await validateIssuerTexts(["ETHR:0XE712878F6E8D5D4F9E87E10DA604F9CB564C9A89"]);
+
+  await validateIframeTexts([
+    "Name & Address of Shipping Agent/Freight Forwarder",
+    "CERTIFICATE OF NON-MANIPULATION",
+    "DEMO CUSTOMS",
+    "Certification by Singapore Customs",
+    "AQSIQ170923130",
+  ]);
+});

--- a/src/test/dns-did-verified.spec.js
+++ b/src/test/dns-did-verified.spec.js
@@ -1,0 +1,16 @@
+import { uploadDocument, validateIframeTexts, validateIssuerTexts } from "./helper";
+
+fixture("DNS DID Certificate Rendering").page`http://localhost:3000`;
+
+test("sample document is rendered correctly when dns did is verified", async () => {
+  await uploadDocument("./fixture/sample-dns-did-verified.json");
+  await validateIssuerTexts(["EXAMPLE.TRADETRUST.IO"]);
+
+  await validateIframeTexts([
+    "Name & Address of Shipping Agent/Freight Forwarder",
+    "CERTIFICATE OF NON-MANIPULATION",
+    "DEMO CUSTOMS",
+    "Certification by Singapore Customs",
+    "AQSIQ170923130",
+  ]);
+});

--- a/src/test/fixture/sample-did-verified.json
+++ b/src/test/fixture/sample-did-verified.json
@@ -1,0 +1,63 @@
+{
+  "version": "https://schema.openattestation.com/2.0/schema.json",
+  "data": {
+    "id": "e1917cfe-70fa-4187-ac6d-ccc57c0d4645:string:SGCNM21566325",
+    "$template": {
+      "name": "95b39779-f300-43b7-9010-1eb96eafc6b5:string:CERTIFICATE_OF_NON_MANIPULATION",
+      "type": "43e9f19d-1ebd-485d-8cbf-2726c1f7c755:string:EMBEDDED_RENDERER",
+      "url": "7b0602b0-5e55-42de-813a-27c4f2b54d20:string:https://demo-cnm.openattestation.com"
+    },
+    "issuers": [
+      {
+        "id": "6002d4ab-d1a6-447e-9f86-945ee220fedb:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+        "name": "f46a0b69-983b-4b5e-83f6-aebe14625810:string:DEMO STORE",
+        "revocation": {
+          "type": "bcd9fe64-1b8a-41d3-a176-5d750b4a6cef:string:NONE"
+        },
+        "identityProof": {
+          "type": "c2990f33-814c-4c7f-a14c-8cef4b1aa8ad:string:DID",
+          "key": "4ef2653f-7fb5-409b-acc1-a76344ff2de0:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller"
+        }
+      }
+    ],
+    "recipient": {
+      "name": "a5bcf044-94e4-421e-a0d6-960546dc3b41:string:SG FREIGHT",
+      "address": {
+        "street": "1b8dc011-05e0-405e-a687-4b2292a9455a:string:101 ORCHARD ROAD",
+        "country": "39f0508c-637c-407f-9087-c0d1239c9407:string:SINGAPORE"
+      }
+    },
+    "consignment": {
+      "description": "6819ad4b-ffb2-427c-ac5a-6b812cbefff9:string:16667 CARTONS OF RED WINE",
+      "quantity": {
+        "value": "fb57e16f-d2f4-4caa-8c37-86514695a3ac:number:5000",
+        "unit": "b4259694-628d-4dc0-bce1-f7d34bab8a75:string:LITRES"
+      },
+      "countryOfOrigin": "68c4b3bf-6ecf-4b55-894b-3def8c287c6f:string:AUSTRALIA",
+      "outwardBillNo": "2f5b4abf-47d8-4530-8e13-0f78688637e5:string:AQSIQ170923130",
+      "dateOfDischarge": "5dde46da-25cb-4721-96c8-a8f7fee4789a:string:2018-01-26",
+      "dateOfDeparture": "6cc4d4bd-52a4-4998-9cf7-c32a86e78fb0:string:2018-01-30",
+      "countryOfFinalDestination": "054ea1a5-37ae-4625-b8bf-d2ac43ddfcf2:string:CHINA",
+      "outgoingVehicleNo": "11ac7f5b-2839-4d27-b4fb-7ac77acb36c7:string:COSCO JAPAN 074E/30-JAN"
+    },
+    "declaration": {
+      "name": "1954f051-1fde-4288-8468-5020dcc883a6:string:PETER LEE",
+      "designation": "07ff6d5c-40e5-496d-86fd-704866dc8e06:string:SHIPPING MANAGER",
+      "date": "3873ff50-223f-41d0-b37c-6572328594ae:string:2018-01-28"
+    }
+  },
+  "signature": {
+    "type": "SHA3MerkleProof",
+    "targetHash": "cce7bd33bd80b746b71e943e23ddc88fcb99c9011becdd1b4d8b7ab9567d2adb",
+    "proof": [],
+    "merkleRoot": "cce7bd33bd80b746b71e943e23ddc88fcb99c9011becdd1b4d8b7ab9567d2adb"
+  },
+  "proof": [
+    {
+      "type": "OpenAttestationSignature2018",
+      "proofPurpose": "assertionMethod",
+      "verificationMethod": "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
+      "signature": "0xff0227ce8400a17a2d80073a95fd895f4fed0011954c90eef389bc618087a4b36ed958775420d122e9a6764c6ffe9d3302d4f45fb065d5e962c3572d3872f31a1b"
+    }
+  ]
+}

--- a/src/test/fixture/sample-dns-did-verified.json
+++ b/src/test/fixture/sample-dns-did-verified.json
@@ -1,0 +1,64 @@
+{
+  "version": "https://schema.openattestation.com/2.0/schema.json",
+  "data": {
+    "id": "9a472a0a-42db-4559-baf2-90d6fcc2b113:string:SGCNM21566325",
+    "$template": {
+      "name": "e2da3963-d070-43e0-9cce-888886cd3173:string:CERTIFICATE_OF_NON_MANIPULATION",
+      "type": "f6b1b012-7dcb-4725-952d-228708746a21:string:EMBEDDED_RENDERER",
+      "url": "f64728c6-b985-465c-a31c-d2c98d5e055a:string:https://demo-cnm.openattestation.com"
+    },
+    "issuers": [
+      {
+        "id": "27f71dea-839c-4484-8a72-72f974a3c093:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+        "name": "cc8465bc-4432-47cf-94bf-0ee0c8c49c22:string:DEMO STORE",
+        "revocation": {
+          "type": "85debc04-1698-4a1b-b6ac-7ef7e8f9d4b4:string:NONE"
+        },
+        "identityProof": {
+          "type": "767bd2d0-f1e4-4471-81a0-c4056d42f592:string:DNS-DID",
+          "key": "5edf0191-5492-4659-891b-84e68793c9be:string:did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
+          "location": "ad412e6a-a9b6-40e6-bb17-18b097d86833:string:example.tradetrust.io"
+        }
+      }
+    ],
+    "recipient": {
+      "name": "243cdac1-8d75-47ca-a4f3-b9e305f16f50:string:SG FREIGHT",
+      "address": {
+        "street": "241f4d4f-ddeb-4344-a0e5-6a766b664c38:string:101 ORCHARD ROAD",
+        "country": "b66e2078-1bb2-41e3-b60b-0a16b6b79639:string:SINGAPORE"
+      }
+    },
+    "consignment": {
+      "description": "77d0a5c6-e383-485c-b0bf-1439a1f67ae4:string:16667 CARTONS OF RED WINE",
+      "quantity": {
+        "value": "cd54295b-e569-4461-8b3d-5eae4f12f86d:number:5000",
+        "unit": "c4f4b1b4-3f05-469c-9f79-8eea65cfb9e1:string:LITRES"
+      },
+      "countryOfOrigin": "89377474-29b7-44eb-8a2e-d2d8f4c2ba25:string:AUSTRALIA",
+      "outwardBillNo": "8c8e7f1b-6ec0-429f-8536-739b149507f9:string:AQSIQ170923130",
+      "dateOfDischarge": "32ef239d-d98a-4712-a40a-330d39d4db16:string:2018-01-26",
+      "dateOfDeparture": "a068e31d-9f2b-4698-b4d0-69bf9181d1d6:string:2018-01-30",
+      "countryOfFinalDestination": "2ef9d520-dd2c-4076-a2af-bf1e6bd9bd61:string:CHINA",
+      "outgoingVehicleNo": "099c443a-c51e-4446-ae2c-0ba90d6d2510:string:COSCO JAPAN 074E/30-JAN"
+    },
+    "declaration": {
+      "name": "b9915d76-bf07-427d-952d-2c77eca55cc3:string:PETER LEE",
+      "designation": "d04e3577-515c-4fad-aa66-47319ce3b970:string:SHIPPING MANAGER",
+      "date": "ffd492e3-88f6-4803-a2eb-1a6395197909:string:2018-01-28"
+    }
+  },
+  "signature": {
+    "type": "SHA3MerkleProof",
+    "targetHash": "d0ebc96b62001b10348d3f9931f91b3c7aa421445f9719a984d67c22465a86c5",
+    "proof": [],
+    "merkleRoot": "d0ebc96b62001b10348d3f9931f91b3c7aa421445f9719a984d67c22465a86c5"
+  },
+  "proof": [
+    {
+      "type": "OpenAttestationSignature2018",
+      "proofPurpose": "assertionMethod",
+      "verificationMethod": "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
+      "signature": "0xd05bb71bdb6f78451e2d12851825421666c6c5e355f516325ce5002a0586f89f6ebbd465227bec59c745dd26918dd8dab9122dcd398256d8e487e0ecf82a53421b"
+    }
+  ]
+}

--- a/src/test/fixture/verifier-responses.js
+++ b/src/test/fixture/verifier-responses.js
@@ -77,7 +77,27 @@ export const whenDocumentHashInvalidAndNotIssued = [
       message: `Document issuers doesn't have "documentStore" / "tokenRegistry" property or doesn't use DNS-TXT type`,
     },
     status: "SKIPPED",
-    name: "OpenAttestationDnsTxt",
+    name: "OpenAttestationDnsTxtIdentityProof",
+    type: "ISSUER_IDENTITY",
+  },
+  {
+    reason: {
+      code: 0,
+      codeString: "SKIPPED",
+      message: `Document was not issued using DNS-DID`,
+    },
+    status: "SKIPPED",
+    name: "OpenAttestationDnsDidIdentityProof",
+    type: "ISSUER_IDENTITY",
+  },
+  {
+    reason: {
+      code: 0,
+      codeString: "SKIPPED",
+      message: `Document is not using DID as top level identifier`,
+    },
+    status: "SKIPPED",
+    name: "OpenAttestationDidIdentityProof",
     type: "ISSUER_IDENTITY",
   },
 ];
@@ -140,7 +160,7 @@ export const whenDocumentNotIssued = [
     type: "DOCUMENT_STATUS",
   },
   {
-    name: "OpenAttestationDnsTxt",
+    name: "OpenAttestationDnsTxtIdentityProof",
     type: "ISSUER_IDENTITY",
     data: [
       {
@@ -152,8 +172,7 @@ export const whenDocumentNotIssued = [
     status: "VALID",
   },
 ];
-
-export const whenDocumentValidAndIssued = [
+export const whenDocumentValidAndIssuedByDns = [
   {
     data: true,
     status: "VALID",
@@ -199,7 +218,7 @@ export const whenDocumentValidAndIssued = [
     type: "DOCUMENT_STATUS",
   },
   {
-    name: "OpenAttestationDnsTxt",
+    name: "OpenAttestationDnsTxtIdentityProof",
     type: "ISSUER_IDENTITY",
     data: [
       {
@@ -211,8 +230,65 @@ export const whenDocumentValidAndIssued = [
     status: "VALID",
   },
 ];
+export const whenDocumentValidAndIssuedByDid = [
+  {
+    data: true,
+    status: "VALID",
+    name: "OpenAttestationHash",
+    type: "DOCUMENT_INTEGRITY",
+  },
+  {
+    data: {
+      details: [
+        {
+          address: "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
+          issued: true,
+        },
+      ],
+      issuedOnAll: true,
+    },
+    status: "VALID",
+    name: "OpenAttestationEthereumDocumentStoreIssued",
+    type: "DOCUMENT_STATUS",
+  },
+  {
+    reason: {
+      code: 4,
+      codeString: "SKIPPED",
+      message: 'Document issuers doesn\'t have "tokenRegistry" property or TOKEN_REGISTRY method',
+    },
+    name: "OpenAttestationEthereumTokenRegistryMinted",
+    status: "SKIPPED",
+    type: "DOCUMENT_STATUS",
+  },
+  {
+    data: {
+      details: [
+        {
+          address: "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
+          revoked: false,
+        },
+      ],
+      revokedOnAny: false,
+    },
+    status: "VALID",
+    name: "OpenAttestationEthereumDocumentStoreRevoked",
+    type: "DOCUMENT_STATUS",
+  },
+  {
+    name: "OpenAttestationDidIdentityProof",
+    type: "ISSUER_IDENTITY",
+    data: [
+      {
+        status: "VALID",
+        did: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+      },
+    ],
+    status: "VALID",
+  },
+];
 export const whenDocumentHashInvalid = [
-  ...whenDocumentValidAndIssued.filter((fragment) => fragment.type !== "DOCUMENT_INTEGRITY"),
+  ...whenDocumentValidAndIssuedByDns.filter((fragment) => fragment.type !== "DOCUMENT_INTEGRITY"),
   {
     data: false,
     reason: {
@@ -283,7 +359,7 @@ export const whenDocumentRevoked = [
     status: "INVALID",
   },
   {
-    name: "OpenAttestationDnsTxt",
+    name: "OpenAttestationDnsTxtIdentityProof",
     type: "ISSUER_IDENTITY",
     data: [
       {
@@ -296,7 +372,7 @@ export const whenDocumentRevoked = [
   },
 ];
 
-export const whenDocumentIssuerIdentityInvalid = [
+export const whenDocumentIssuerIdentityInvalidDnsTxt = [
   {
     data: true,
     status: "VALID",
@@ -348,7 +424,64 @@ export const whenDocumentIssuerIdentityInvalid = [
       message: `Document issuers doesn't have "documentStore" / "tokenRegistry" property or doesn't use DNS-TXT type`,
     },
     status: "SKIPPED",
-    name: "OpenAttestationDnsTxt",
+    name: "OpenAttestationDnsTxtIdentityProof",
+    type: "ISSUER_IDENTITY",
+  },
+];
+
+export const whenDocumentIssuerIdentityInvalidDid = [
+  {
+    data: true,
+    status: "VALID",
+    name: "OpenAttestationHash",
+    type: "DOCUMENT_INTEGRITY",
+  },
+  {
+    data: {
+      details: [
+        {
+          address: "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
+          issued: true,
+        },
+      ],
+      issuedOnAll: true,
+    },
+    status: "VALID",
+    name: "OpenAttestationEthereumDocumentStoreIssued",
+    type: "DOCUMENT_STATUS",
+  },
+  {
+    reason: {
+      code: 4,
+      codeString: "SKIPPED",
+      message: 'Document issuers doesn\'t have "tokenRegistry" property or TOKEN_REGISTRY method',
+    },
+    name: "OpenAttestationEthereumTokenRegistryMinted",
+    status: "SKIPPED",
+    type: "DOCUMENT_STATUS",
+  },
+  {
+    data: {
+      details: [
+        {
+          address: "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
+          revoked: false,
+        },
+      ],
+      revokedOnAny: false,
+    },
+    status: "VALID",
+    name: "OpenAttestationEthereumDocumentStoreRevoked",
+    type: "DOCUMENT_STATUS",
+  },
+  {
+    reason: {
+      code: 2,
+      codeString: "SKIPPED",
+      message: `Document is not using DID as top level identifier`,
+    },
+    status: "SKIPPED",
+    name: "OpenAttestationDidIdentityProof",
     type: "ISSUER_IDENTITY",
   },
 ];
@@ -382,7 +515,7 @@ export const whenTransferableDocumentVerified = [
     },
   },
   {
-    name: "OpenAttestationDnsTxt",
+    name: "OpenAttestationDnsTxtIdentityProof",
     type: "ISSUER_IDENTITY",
     data: [
       {


### PR DESCRIPTION
This PR adds the ability to verify documents issued by DNS-DID and DID:
- Able to verify a document signed with DID directly
- Verification view to show "Issued by DID:ETHR:0x1234...1234"

Testing files:
[sample-did-verified.txt](https://github.com/TradeTrust/tradetrust-website/files/5581075/sample-did-verified.txt)
[sample-dns-did-verified.txt](https://github.com/TradeTrust/tradetrust-website/files/5581078/sample-dns-did-verified.txt)
