### PR TITLE
feat: added error message when scanning qrcode

### DIFF
--- a/src/components/CertificateDropZone/CertificateDropZone.js
+++ b/src/components/CertificateDropZone/CertificateDropZone.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Dropzone from "react-dropzone";
 import { DefaultView } from "./Views/DefaultView";
 import { RetrievalErrorView } from "./Views/RetrievalErrorView";
@@ -17,12 +17,30 @@ export const DropzoneContent = ({
   verificationStatus,
   toggleQrReaderVisible,
   retrieveCertificateByActionError,
+  verificationError,
 }) => {
   // isDragReject is checking for mimetype (but we skipped it)
   // fileError is when the file is not in JSON format and threw when deserilising
   // valid JSON files will be handled by handleCertificateChange()
+
+  // change in prop does not update state, needs to update state
+  const [verificationErrorMessage, setVerificationError] = useState(verificationError);
+  useEffect(() => {
+    setVerificationError(verificationError);
+  }, [verificationError]);
+
   if (isDragReject || fileError) {
     return <DefaultView hover={true} accept={false} toggleQrReaderVisible={toggleQrReaderVisible} />;
+  }
+  if (verificationError) {
+    return (
+      <DefaultView
+        hover={true}
+        accept={true}
+        toggleQrReaderVisible={toggleQrReaderVisible}
+        verificationError={verificationErrorMessage}
+      />
+    );
   }
   if (isDragAccept) {
     return <DefaultView hover={true} accept={true} toggleQrReaderVisible={toggleQrReaderVisible} />;
@@ -79,6 +97,7 @@ const CertificateDropzone = ({
   verificationStatus,
   toggleQrReaderVisible,
   retrieveCertificateByActionError,
+  verificationError,
 }) => (
   <div className="padding-dropzone-boxshadow">
     <Dropzone
@@ -95,6 +114,7 @@ const CertificateDropzone = ({
         verificationStatus,
         toggleQrReaderVisible,
         retrieveCertificateByActionError,
+        verificationError,
       })}
     </Dropzone>
   </div>
@@ -112,6 +132,7 @@ CertificateDropzone.propTypes = {
   toggleQrReaderVisible: PropTypes.func,
   verificationStatus: PropTypes.array,
   retrieveCertificateByActionError: PropTypes.string,
+  verificationError: PropTypes.string,
 };
 
 DropzoneContent.propTypes = {
@@ -126,6 +147,7 @@ DropzoneContent.propTypes = {
   toggleQrReaderVisible: PropTypes.func,
   verificationStatus: PropTypes.array,
   retrieveCertificateByActionError: PropTypes.string,
+  verificationError: PropTypes.string,
 };
 
 export default CertificateDropzone;

--- a/src/components/CertificateDropZone/CertificateDropZone.stories.tsx
+++ b/src/components/CertificateDropZone/CertificateDropZone.stories.tsx
@@ -72,3 +72,15 @@ export const FileError = () => {
     </Router>
   );
 };
+
+export const QrCodeError = () => {
+  return (
+    <Router>
+      <CertificateDropZone
+        verifying={false}
+        fileError={false}
+        verificationError={"QR Code is not formatted to TradeTrust specifications"}
+      />
+    </Router>
+  );
+};

--- a/src/components/CertificateDropZone/CertificateDropZoneContainer.js
+++ b/src/components/CertificateDropZone/CertificateDropZoneContainer.js
@@ -4,6 +4,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import {
   getCertificateByActionError,
+  getVerifyingCertificateFailure,
   getVerificationStatus,
   getVerifying,
   processQrCode,
@@ -75,6 +76,7 @@ export class CertificateDropZoneContainer extends Component {
         resetData={this.resetData.bind(this)}
         toggleQrReaderVisible={this.toggleQrReaderVisible}
         retrieveCertificateByActionError={this.props.retrieveCertificateByActionError}
+        verificationError={this.props.verificationError}
       />
     );
   }
@@ -84,6 +86,7 @@ const mapStateToProps = (store) => ({
   verifying: getVerifying(store),
   verificationStatus: getVerificationStatus(store),
   retrieveCertificateByActionError: getCertificateByActionError(store),
+  verificationError: getVerifyingCertificateFailure(store),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/components/CertificateDropZone/Views/DefaultView.js
+++ b/src/components/CertificateDropZone/Views/DefaultView.js
@@ -2,8 +2,11 @@ import PropTypes from "prop-types";
 import React from "react";
 import { ViewerButton, ViewerContainer } from "./SharedViewerStyledComponents";
 
-export const DefaultView = ({ hover, accept, toggleQrReaderVisible }) => (
-  <ViewerContainer data-id="viewer-container" className={`${hover ? (accept ? "accept" : "invalid") : "default"}`}>
+export const DefaultView = ({ hover, accept, toggleQrReaderVisible, verificationError }) => (
+  <ViewerContainer
+    data-id="viewer-container"
+    className={`${hover ? (accept || !verificationErrorMessage ? "invalid" : "accept") : "default"}`}
+  >
     <div className="mb-4">
       <img
         className="mx-auto"
@@ -13,6 +16,7 @@ export const DefaultView = ({ hover, accept, toggleQrReaderVisible }) => (
       />
     </div>
     {accept ? null : <div>File cannot be read. Please check that you have a valid .tt or .json file</div>}
+    {verificationError ? <div>{verificationError}</div> : null}
     <div className="text-brand-navy" style={{ fontSize: "1.375rem", fontWeight: 500 }}>
       Drag and drop your tradetrust file
     </div>
@@ -49,4 +53,5 @@ DefaultView.propTypes = {
   hover: PropTypes.bool,
   accept: PropTypes.bool,
   toggleQrReaderVisible: PropTypes.func,
+  verificationError: PropTypes.string,
 };

--- a/src/components/CertificateDropZone/Views/DefaultView.js
+++ b/src/components/CertificateDropZone/Views/DefaultView.js
@@ -5,7 +5,7 @@ import { ViewerButton, ViewerContainer } from "./SharedViewerStyledComponents";
 export const DefaultView = ({ hover, accept, toggleQrReaderVisible, verificationError }) => (
   <ViewerContainer
     data-id="viewer-container"
-    className={`${hover ? (accept || !verificationErrorMessage ? "invalid" : "accept") : "default"}`}
+    className={`${hover ? (accept || !verificationError ? "invalid" : "accept") : "default"}`}
   >
     <div className="mb-4">
       <img

--- a/src/components/CertificateDropZone/Views/DefaultView.test.js
+++ b/src/components/CertificateDropZone/Views/DefaultView.test.js
@@ -25,4 +25,13 @@ describe("defaultView", () => {
     });
     expect(toggleQrReaderVisible).toHaveBeenCalledTimes(1);
   });
+
+  it("displays error if given verification error", () => {
+    const sampleErrorMessage = "QR Code is not formatted to TradeTrust specifications";
+    const wrapper = shallow(
+      <DefaultView hover={true} accept={true} toggleQrReaderVisible={() => {}} verificationError={sampleErrorMessage} />
+    );
+    const viewerContainerElm = wrapper.find("[data-id='viewer-container']");
+    expect(viewerContainerElm.text()).toContain(sampleErrorMessage);
+  });
 });

--- a/src/reducers/certificate.js
+++ b/src/reducers/certificate.js
@@ -208,6 +208,10 @@ export function getVerifying(store) {
   return get(store, "certificate.verificationPending");
 }
 
+export function getVerifyingCertificateFailure(store) {
+  return store.certificate.verificationError;
+}
+
 export function getVerificationStatus(store) {
   return store.certificate.verificationStatus;
 }


### PR DESCRIPTION
This PR adds functionality to show an overlay popup when an error occurs.

example:
- modified QRcode to use wrong tt universal action schema
<img width="203" alt="Screenshot 2020-11-25 at 5 28 12 PM" src="https://user-images.githubusercontent.com/45728710/100208352-9986e180-2f43-11eb-9fe7-d82d202370bc.png">

https://action.openattestation.com/?a=%22&q=%7B%22type%22:%22DOCUMENT%22,%22payload%22:%7B%22uri%22:%22https://gallery.openattestation.com/static/documents/ebl.tt%22,%22permittedActions%22:%5B%22VIEW%22,%22STORE%22%5D,%22redirect%22:%22https://dev.tradetrust.io%22%7D%7D


- wrong document type
<img width="203" alt="Screenshot 2020-11-25 at 5 22 10 PM" src="https://user-images.githubusercontent.com/45728710/100207626-c25aa700-2f42-11eb-85a7-f86d36ea6204.png">

https://action.openattestation.com/?q=%7B%22type%22:%22EBL%22,%22payload%22:%7B%22uri%22:%22https://gallery.openattestation.com/static/documents/ebl.tt%22,%22permittedActions%22:%5B%22VIEW%22,%22STORE%22%5D,%22redirect%22:%22https://dev.tradetrust.io%22%7D%7D