### PR TITLE
feat: refactor handle surrender into 2 forms

### DIFF
--- a/src/components/AssetManagementPanel/AssetManagementActions/index.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementActions/index.tsx
@@ -3,7 +3,8 @@ export enum AssetManagementActions {
   TransferHolder = "TransferHolder",
   EndorseBeneficiary = "EndorseBeneficiary",
   Surrender = "Surrender",
-  HandleSurrendered = "HandleSurrendered",
+  AcceptSurrendered = "AcceptSurrendered",
+  RejectSurrendered = "RejectSurrendered",
   NominateBeneficiaryHolder = "NominateBeneficiaryHolder",
   EndorseTransfer = "EndorseTransfer",
 }

--- a/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementDropdown/AssetManagementDropdown.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementDropdown/AssetManagementDropdown.tsx
@@ -65,23 +65,24 @@ export const AssetManagementDropdown = ({
         </DropdownItem>
       )}
       {canHandleSurrender && (
-        <DropdownItem
-          className="active:bg-orange-dark active:text-white"
-          data-testid={"acceptSurrenderDropdown"}
-          onClick={() => onSetFormAction(AssetManagementActions.AcceptSurrendered)}
-        >
-          Accept surrender of document
-        </DropdownItem>
+        <>
+          <DropdownItem
+            className="active:bg-orange-dark active:text-white"
+            data-testid={"acceptSurrenderDropdown"}
+            onClick={() => onSetFormAction(AssetManagementActions.AcceptSurrendered)}
+          >
+            Accept surrender of document
+          </DropdownItem>
+          <DropdownItem
+            className="active:bg-orange-dark active:text-white"
+            data-testid={"rejectSurrenderDropdown"}
+            onClick={() => onSetFormAction(AssetManagementActions.RejectSurrendered)}
+          >
+            Reject surrender of document
+          </DropdownItem>
+        </>
       )}
-      {canHandleSurrender && (
-        <DropdownItem
-          className="active:bg-orange-dark active:text-white"
-          data-testid={"rejectSurrenderDropdown"}
-          onClick={() => onSetFormAction(AssetManagementActions.RejectSurrendered)}
-        >
-          Reject surrender of document
-        </DropdownItem>
-      )}
+
       {canEndorseTransfer && (
         <DropdownItem
           className="active:bg-orange-dark active:text-white"

--- a/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementDropdown/AssetManagementDropdown.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementDropdown/AssetManagementDropdown.tsx
@@ -5,7 +5,7 @@ import { AssetManagementActions } from "./../../AssetManagementActions";
 interface AssetManagementDropdownProps {
   onSetFormAction: (nextFormAction: AssetManagementActions) => void;
   canSurrender: boolean;
-  canAcceptSurrender?: boolean;
+  canHandleSurrender?: boolean;
   canChangeHolder: boolean;
   canEndorseBeneficiary: boolean;
   canNominateBeneficiaryHolder: boolean;
@@ -15,7 +15,7 @@ interface AssetManagementDropdownProps {
 export const AssetManagementDropdown = ({
   onSetFormAction,
   canSurrender,
-  canAcceptSurrender,
+  canHandleSurrender,
   canChangeHolder,
   canEndorseBeneficiary,
   canNominateBeneficiaryHolder,
@@ -64,13 +64,22 @@ export const AssetManagementDropdown = ({
           Surrender document
         </DropdownItem>
       )}
-      {canAcceptSurrender && (
+      {canHandleSurrender && (
         <DropdownItem
           className="active:bg-orange-dark active:text-white"
           data-testid={"acceptSurrenderDropdown"}
-          onClick={() => onSetFormAction(AssetManagementActions.HandleSurrendered)}
+          onClick={() => onSetFormAction(AssetManagementActions.AcceptSurrendered)}
         >
           Accept surrender of document
+        </DropdownItem>
+      )}
+      {canHandleSurrender && (
+        <DropdownItem
+          className="active:bg-orange-dark active:text-white"
+          data-testid={"rejectSurrenderDropdown"}
+          onClick={() => onSetFormAction(AssetManagementActions.RejectSurrendered)}
+        >
+          Reject surrender of document
         </DropdownItem>
       )}
       {canEndorseTransfer && (

--- a/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementForm.stories.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementForm.stories.tsx
@@ -317,7 +317,7 @@ export const SurrenderPending = () => {
   );
 };
 
-export const Surrendered = () => {
+export const SurrenderedIsMinter = () => {
   const [assetManagementAction, setAssetManagementAction] = useState(AssetManagementActions.None);
 
   return (
@@ -331,6 +331,7 @@ export const Surrendered = () => {
       approvedHolder=""
       formAction={assetManagementAction}
       tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
+      documentOwner="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
       onSetFormAction={setAssetManagementAction}
       isSurrendered={true}
       onSurrender={() => alert("Surrender document")}
@@ -349,14 +350,153 @@ export const Surrendered = () => {
         alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
       }
       transferToNewEscrowState={FormState.UNINITIALIZED}
-      isTitleEscrow={true}
+      isTitleEscrow={false}
       onDestroyToken={() => alert("Accept document surrender")}
       destroyTokenState={FormState.UNINITIALIZED}
       isTokenBurnt={false}
       onRestoreToken={() => alert("Reject document surrender")}
       restoreTokenState={FormState.UNINITIALIZED}
       tokenId=""
+      isMinter={true}
     />
+  );
+};
+
+export const SurrenderedNotMinter = () => {
+  const [assetManagementAction, setAssetManagementAction] = useState(AssetManagementActions.None);
+
+  return (
+    <AssetManagementForm
+      setShowEndorsementChain={() => {}}
+      account="0xa61B056dA0084a5f391EC137583073096880C2e3"
+      onConnectToWallet={() => alert("Login to Metamask")}
+      beneficiary="0xa61B056dA0084a5f391EC137583073096880C2e3"
+      approvedBeneficiary=""
+      holder="0xa61B056dA0084a5f391EC137583073096880C2e3"
+      approvedHolder=""
+      formAction={assetManagementAction}
+      tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
+      documentOwner="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
+      onSetFormAction={setAssetManagementAction}
+      isSurrendered={true}
+      onSurrender={() => alert("Surrender document")}
+      surrenderingState={FormState.UNINITIALIZED}
+      onTransferHolder={(newHolder) => alert(`Transfer holder to ${newHolder}`)}
+      holderTransferringState={FormState.UNINITIALIZED}
+      onEndorseBeneficiary={(newBeneficiary, newHolder) =>
+        alert(`Change Owner: ${newBeneficiary}, Holder: ${newHolder}`)
+      }
+      beneficiaryEndorseState={FormState.UNINITIALIZED}
+      onApproveNewTransferTargets={(newBeneficiary, newHolder) =>
+        alert(`Nominate Owner: ${newBeneficiary}, Holder: ${newHolder}`)
+      }
+      approveNewTransferTargetsState={FormState.UNINITIALIZED}
+      onTransferToNewEscrow={(approvedBeneficiary, approvedHolder) =>
+        alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
+      }
+      transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={false}
+      onDestroyToken={() => alert("Accept document surrender")}
+      destroyTokenState={FormState.UNINITIALIZED}
+      isTokenBurnt={false}
+      onRestoreToken={() => alert("Reject document surrender")}
+      restoreTokenState={FormState.UNINITIALIZED}
+      tokenId=""
+      isMinter={false}
+    />
+  );
+};
+
+export const SurrenderedAcceptForm = () => {
+  const [assetManagementAction, setAssetManagementAction] = useState(AssetManagementActions.AcceptSurrendered);
+
+  return (
+    <AssetManagementForm
+      setShowEndorsementChain={() => {}}
+      account="0xa61B056dA0084a5f391EC137583073096880C2e3"
+      onConnectToWallet={() => alert("Login to Metamask")}
+      beneficiary="0xa61B056dA0084a5f391EC137583073096880C2e3"
+      approvedBeneficiary=""
+      holder="0xa61B056dA0084a5f391EC137583073096880C2e3"
+      approvedHolder=""
+      formAction={assetManagementAction}
+      tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
+      documentOwner="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
+      onSetFormAction={setAssetManagementAction}
+      isSurrendered={true}
+      onSurrender={() => alert("Surrender document")}
+      surrenderingState={FormState.UNINITIALIZED}
+      onTransferHolder={(newHolder) => alert(`Transfer holder to ${newHolder}`)}
+      holderTransferringState={FormState.UNINITIALIZED}
+      onEndorseBeneficiary={(newBeneficiary, newHolder) =>
+        alert(`Change Owner: ${newBeneficiary}, Holder: ${newHolder}`)
+      }
+      beneficiaryEndorseState={FormState.UNINITIALIZED}
+      onApproveNewTransferTargets={(newBeneficiary, newHolder) =>
+        alert(`Nominate Owner: ${newBeneficiary}, Holder: ${newHolder}`)
+      }
+      approveNewTransferTargetsState={FormState.UNINITIALIZED}
+      onTransferToNewEscrow={(approvedBeneficiary, approvedHolder) =>
+        alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
+      }
+      transferToNewEscrowState={FormState.UNINITIALIZED}
+      isTitleEscrow={false}
+      onDestroyToken={() => alert("Accept document surrender")}
+      destroyTokenState={FormState.UNINITIALIZED}
+      isTokenBurnt={false}
+      onRestoreToken={() => alert("Reject document surrender")}
+      restoreTokenState={FormState.UNINITIALIZED}
+      tokenId=""
+      isMinter={true}
+    />
+  );
+};
+
+export const SurrenderedRejectForm = () => {
+  const [assetManagementAction, setAssetManagementAction] = useState(AssetManagementActions.RejectSurrendered);
+
+  return (
+    <OverlayContextProvider>
+      <Overlay />
+      <AssetManagementForm
+        setShowEndorsementChain={() => {}}
+        account="0xa61B056dA0084a5f391EC137583073096880C2e3"
+        onConnectToWallet={() => alert("Login to Metamask")}
+        beneficiary="0xa61B056dA0084a5f391EC137583073096880C2e3"
+        approvedBeneficiary=""
+        holder="0xa61B056dA0084a5f391EC137583073096880C2e3"
+        approvedHolder=""
+        formAction={assetManagementAction}
+        tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
+        documentOwner="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
+        onSetFormAction={setAssetManagementAction}
+        isSurrendered={true}
+        onSurrender={() => alert("Surrender document")}
+        surrenderingState={FormState.UNINITIALIZED}
+        onTransferHolder={(newHolder) => alert(`Transfer holder to ${newHolder}`)}
+        holderTransferringState={FormState.UNINITIALIZED}
+        onEndorseBeneficiary={(newBeneficiary, newHolder) =>
+          alert(`Change Owner: ${newBeneficiary}, Holder: ${newHolder}`)
+        }
+        beneficiaryEndorseState={FormState.UNINITIALIZED}
+        onApproveNewTransferTargets={(newBeneficiary, newHolder) =>
+          alert(`Nominate Owner: ${newBeneficiary}, Holder: ${newHolder}`)
+        }
+        approveNewTransferTargetsState={FormState.UNINITIALIZED}
+        onTransferToNewEscrow={(approvedBeneficiary, approvedHolder) =>
+          alert(`Endorse Owner: ${approvedBeneficiary}, Holder: ${approvedHolder}`)
+        }
+        transferToNewEscrowState={FormState.UNINITIALIZED}
+        isTitleEscrow={false}
+        onDestroyToken={() => alert("Accept document surrender")}
+        destroyTokenState={FormState.UNINITIALIZED}
+        isTokenBurnt={false}
+        onRestoreToken={() => alert("Reject document surrender")}
+        restoreTokenState={FormState.UNINITIALIZED}
+        tokenId=""
+        isMinter={true}
+      />
+    </OverlayContextProvider>
   );
 };
 

--- a/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementForm.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementForm.tsx
@@ -7,7 +7,8 @@ import { EndorseTransferForm } from "./FormVariants/EndorseTransferForm";
 import { NominateBeneficiaryHolderForm } from "./FormVariants/NominateBeneficiaryHolder";
 import { SurrenderForm } from "./FormVariants/SurrenderForm";
 import { TransferHolderForm } from "./FormVariants/TransferHolderForm";
-import { HandleSurrenderedForm } from "./FormVariants/HandleSurrenderedForm";
+import { AcceptSurrenderedForm } from "./FormVariants/AcceptSurrenderedForm";
+import { RejectSurrenderedForm } from "./FormVariants/RejectSurrenderedForm";
 
 interface AssetManagementFormProps {
   beneficiary?: string;
@@ -83,7 +84,7 @@ export const AssetManagementForm = ({
     - documentOwner is the tokenRegistry
     -  currentUser === tokenRegistryMinter
   */
-  const canAcceptSurrender =
+  const canHandleSurrender =
     isSurrendered && isTitleEscrow === false && documentOwner === tokenRegistryAddress && isMinter;
   const canEndorseBeneficiary = isTitleEscrow && isBeneficiary && isHolder;
   const canNominateBeneficiaryHolder = isTitleEscrow && isBeneficiary && !isHolder;
@@ -123,16 +124,26 @@ export const AssetManagementForm = ({
         />
       );
 
-    case AssetManagementActions.HandleSurrendered:
+    case AssetManagementActions.AcceptSurrendered:
       return (
-        <HandleSurrenderedForm
+        <AcceptSurrenderedForm
+          formAction={formAction}
+          tokenRegistryAddress={tokenRegistryAddress}
+          handleDestroyToken={onDestroyToken}
+          destroyTokenState={destroyTokenState}
+          setFormActionNone={setFormActionNone}
+          setShowEndorsementChain={setShowEndorsementChain}
+        />
+      );
+
+    case AssetManagementActions.RejectSurrendered:
+      return (
+        <RejectSurrenderedForm
           tokenId={tokenId}
           formAction={formAction}
           tokenRegistryAddress={tokenRegistryAddress}
           beneficiary={beneficiary}
           holder={holder}
-          handleDestroyToken={onDestroyToken}
-          destroyTokenState={destroyTokenState}
           setFormActionNone={setFormActionNone}
           setShowEndorsementChain={setShowEndorsementChain}
           handleRestoreToken={onRestoreToken}
@@ -205,7 +216,7 @@ export const AssetManagementForm = ({
           holder={holder}
           account={account}
           canSurrender={canSurrender}
-          canAcceptSurrender={canAcceptSurrender}
+          canHandleSurrender={canHandleSurrender}
           onConnectToWallet={onConnectToWallet}
           canChangeHolder={isHolder}
           canEndorseBeneficiary={canEndorseBeneficiary}

--- a/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementTitle/AssetManagementTitle.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementTitle/AssetManagementTitle.tsx
@@ -26,7 +26,8 @@ export const AssetManagementTitle = styled(
           </div>
           <h3 className="action-title">
             {formAction === AssetManagementActions.Surrender && <>Surrender Document</>}
-            {formAction === AssetManagementActions.HandleSurrendered && <>Accept Surrender of Document</>}
+            {formAction === AssetManagementActions.AcceptSurrendered && <>Accept Surrender of Document</>}
+            {formAction === AssetManagementActions.RejectSurrendered && <>Reject Surrender of Document</>}
             {formAction === AssetManagementActions.TransferHolder && <>Transfer Holdership</>}
             {formAction === AssetManagementActions.EndorseBeneficiary && <>Endorse Change of Ownership</>}
             {formAction === AssetManagementActions.NominateBeneficiaryHolder && <>Nominate Change of Ownership</>}

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/AcceptSurrenderedForm/AcceptSurrenderedForm.test.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/AcceptSurrenderedForm/AcceptSurrenderedForm.test.tsx
@@ -1,0 +1,107 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render } from "@testing-library/react";
+import React from "react";
+import { FormState } from "../../../../../constants/FormState";
+import { AssetManagementActions } from "../../../AssetManagementActions";
+import { AcceptSurrenderedForm } from "./AcceptSurrenderedForm";
+import { act } from "react-dom/test-utils";
+import { useEndorsementChain } from "../../../../../common/hooks/useEndorsementChain";
+
+jest.mock("../../../../../common/hooks/useEndorsementChain");
+
+const mockUseFeatureFlagOverride = useEndorsementChain as jest.Mock;
+const sampleEndorsementChain = [
+  {
+    eventType: "Transfer",
+    documentOwner: "0x07117cCE985E750D1709191BC2a345AbA85b6993",
+    beneficiary: "0x1245e5B64D785b25057f7438F715f4aA5D965733",
+    holderChangeEvents: [
+      { blockNumber: 8829273, holder: "0x1245e5B64D785b25057f7438F715f4aA5D965733", timestamp: 1602050689000 },
+    ],
+  },
+];
+
+describe("AcceptSurrenderedForm", () => {
+  beforeEach(() => {
+    jest.resetModules(); // this is important - it clears the cache
+    mockUseFeatureFlagOverride.mockReturnValue({
+      endorsementChain: sampleEndorsementChain,
+    });
+  });
+  it("should have the accept surrender button and cancel button", async () => {
+    await act(async () => {
+      const container = render(
+        <AcceptSurrenderedForm
+          setShowEndorsementChain={() => {}}
+          formAction={AssetManagementActions.Surrender}
+          setFormActionNone={() => {}}
+          tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
+          destroyTokenState={FormState.UNINITIALIZED}
+          handleDestroyToken={() => {}}
+        />
+      );
+      expect(container.queryByTestId("cancelSurrenderBtn")).not.toBeNull();
+      expect(container.queryByTestId("acceptSurrenderBtn")).not.toBeNull();
+    });
+  });
+
+  it("should change the state of the application to Confirmed when we clicked on accept surrender", async () => {
+    await act(async () => {
+      const mockHandleDestroyToken = jest.fn();
+
+      const container = render(
+        <AcceptSurrenderedForm
+          setShowEndorsementChain={() => {}}
+          formAction={AssetManagementActions.Surrender}
+          setFormActionNone={() => {}}
+          tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
+          destroyTokenState={FormState.UNINITIALIZED}
+          handleDestroyToken={mockHandleDestroyToken}
+        />
+      );
+
+      fireEvent.click(container.getByTestId("acceptSurrenderBtn"));
+      expect(mockHandleDestroyToken).toHaveBeenCalled();
+    });
+  });
+
+  it("should show a loader when the accept surrender state is in PENDING_CONFIRMATION", async () => {
+    await act(async () => {
+      const container = render(
+        <AcceptSurrenderedForm
+          setShowEndorsementChain={() => {}}
+          formAction={AssetManagementActions.Surrender}
+          setFormActionNone={() => {}}
+          tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
+          destroyTokenState={FormState.PENDING_CONFIRMATION}
+          handleDestroyToken={() => {}}
+        />
+      );
+
+      expect(container.queryByTestId("accept-loader")).not.toBeNull();
+    });
+  });
+
+  it("should disable accept surrender and cancel button when the accept surrender state is in PENDING_CONFIRMATION", async () => {
+    await act(async () => {
+      const mockHandleDestroyToken = jest.fn();
+      const mockHandleRestoreToken = jest.fn();
+
+      const container = render(
+        <AcceptSurrenderedForm
+          setShowEndorsementChain={() => {}}
+          formAction={AssetManagementActions.Surrender}
+          setFormActionNone={() => {}}
+          tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
+          destroyTokenState={FormState.PENDING_CONFIRMATION}
+          handleDestroyToken={mockHandleDestroyToken}
+        />
+      );
+
+      fireEvent.click(container.getByTestId("acceptSurrenderBtn"));
+      expect(mockHandleDestroyToken).not.toHaveBeenCalled();
+      fireEvent.click(container.getByTestId("cancelSurrenderBtn"));
+      expect(mockHandleRestoreToken).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/AcceptSurrenderedForm/AcceptSurrenderedForm.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/AcceptSurrenderedForm/AcceptSurrenderedForm.tsx
@@ -50,7 +50,7 @@ export const AcceptSurrenderedForm = ({
           disabled={isDestroyTokenPendingConfirmation}
         />
         <div className="flex flex-wrap mb-4">
-          <div className="w-full lg:flex-grow">
+          <div className="w-full lg:flex-grow lg:w-auto">
             <AssetInformationPanel
               setShowEndorsementChain={setShowEndorsementChain}
               tokenRegistryAddress={tokenRegistryAddress}

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/AcceptSurrenderedForm/index.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/AcceptSurrenderedForm/index.tsx
@@ -1,0 +1,1 @@
+export * from "./AcceptSurrenderedForm";

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.test.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.test.tsx
@@ -11,7 +11,7 @@ const defaultProps = {
   holder: "0xa61B056dA0084a5f391EC137583073096880C2e3",
   account: "0xa61B056dA0084a5f391EC137583073096880C2e3",
   canSurrender: false,
-  canAcceptSurrender: false,
+  canHandleSurrender: false,
   onConnectToWallet: () => alert("Login to Metamask"),
   canChangeHolder: false,
   canEndorseBeneficiary: false,
@@ -181,7 +181,7 @@ describe("ActionSelectionForm", () => {
         {...defaultProps}
         onSetFormAction={mockOnSetFormAction}
         isTitleEscrow={false}
-        canAcceptSurrender={true}
+        canHandleSurrender={true}
       />
     );
 
@@ -191,6 +191,29 @@ describe("ActionSelectionForm", () => {
 
     await act(async () => {
       fireEvent.click(container.getByTestId("acceptSurrenderDropdown"));
+    });
+
+    expect(mockOnSetFormAction).toHaveBeenCalled();
+  });
+
+  it("should change the state of the action form to 'Reject Surrender' when clicked on the dropdown", async () => {
+    const mockOnSetFormAction = jest.fn();
+
+    const container = render(
+      <ActionSelectionForm
+        {...defaultProps}
+        onSetFormAction={mockOnSetFormAction}
+        isTitleEscrow={false}
+        canHandleSurrender={true}
+      />
+    );
+
+    await act(async () => {
+      fireEvent.click(container.getByTestId("manageAssetDropdown"));
+    });
+
+    await act(async () => {
+      fireEvent.click(container.getByTestId("rejectSurrenderDropdown"));
     });
 
     expect(mockOnSetFormAction).toHaveBeenCalled();

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.tsx
@@ -18,7 +18,7 @@ interface ActionSelectionFormProps {
   holder?: string;
   account?: string;
   canSurrender: boolean;
-  canAcceptSurrender?: boolean;
+  canHandleSurrender?: boolean;
   onConnectToWallet: () => void;
   canChangeHolder: boolean;
   canEndorseBeneficiary: boolean;
@@ -37,7 +37,7 @@ export const ActionSelectionForm = ({
   holder,
   account,
   canSurrender,
-  canAcceptSurrender,
+  canHandleSurrender,
   onConnectToWallet,
   canChangeHolder,
   canEndorseBeneficiary,
@@ -49,7 +49,7 @@ export const ActionSelectionForm = ({
   isTitleEscrow,
 }: ActionSelectionFormProps) => {
   const canManage =
-    canAcceptSurrender ||
+    canHandleSurrender ||
     canSurrender ||
     canChangeHolder ||
     canEndorseBeneficiary ||
@@ -126,7 +126,7 @@ export const ActionSelectionForm = ({
                     canEndorseBeneficiary={canEndorseBeneficiary}
                     canNominateBeneficiaryHolder={canNominateBeneficiaryHolder}
                     canEndorseTransfer={canEndorseTransfer}
-                    canAcceptSurrender={canAcceptSurrender}
+                    canHandleSurrender={canHandleSurrender}
                   />
                 ) : (
                   <ButtonSolidOrangeWhite onClick={handleNoAccess}>No Access</ButtonSolidOrangeWhite>

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/HandleSurrenderedForm/index.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/HandleSurrenderedForm/index.tsx
@@ -1,1 +1,0 @@
-export * from "./HandleSurrenderedForm";

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/RejectSurrenderedForm/RejectSurrenderedForm.test.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/RejectSurrenderedForm/RejectSurrenderedForm.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render } from "@testing-library/react";
 import React from "react";
 import { FormState } from "../../../../../constants/FormState";
 import { AssetManagementActions } from "../../../AssetManagementActions";
-import { HandleSurrenderedForm } from "./HandleSurrenderedForm";
+import { RejectSurrenderedForm } from "./RejectSurrenderedForm";
 import { act } from "react-dom/test-utils";
 import { OverlayContext } from "../../../../../common/contexts/OverlayContext";
 import { useEndorsementChain } from "../../../../../common/hooks/useEndorsementChain";
@@ -22,57 +22,30 @@ const sampleEndorsementChain = [
   },
 ];
 
-describe("Handle surrendered", () => {
+describe("RejectSurrenderedForm", () => {
   beforeEach(() => {
     jest.resetModules(); // this is important - it clears the cache
     mockUseFeatureFlagOverride.mockReturnValue({
       endorsementChain: sampleEndorsementChain,
     });
   });
-  it("should have the accept surrender button and accept surrender button", async () => {
+  it("should have the cancel button and reject surrender button", async () => {
     await act(async () => {
       const container = render(
-        <HandleSurrenderedForm
+        <RejectSurrenderedForm
           setShowEndorsementChain={() => {}}
           formAction={AssetManagementActions.Surrender}
           setFormActionNone={() => {}}
           tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
           beneficiary="0xE94E4f16ad40ADc90C29Dc85b42F1213E034947C"
           holder="0xa61B056dA0084a5f391EC137583073096880C2e3"
-          destroyTokenState={FormState.UNINITIALIZED}
-          handleDestroyToken={() => {}}
           restoreTokenState={FormState.UNINITIALIZED}
           handleRestoreToken={() => {}}
           tokenId="0x33430b8a069f6f9115fe9403889162d6c779cccde4db8df04faaf09d6dc739ba"
         />
       );
       expect(container.queryByTestId("rejectSurrenderBtn")).not.toBeNull();
-      expect(container.queryByTestId("acceptSurrenderBtn")).not.toBeNull();
-    });
-  });
-
-  it("should change the state of the application to Confirmed when we clicked on accept surrender", async () => {
-    await act(async () => {
-      const mockHandleDestroyToken = jest.fn();
-
-      const container = render(
-        <HandleSurrenderedForm
-          setShowEndorsementChain={() => {}}
-          formAction={AssetManagementActions.Surrender}
-          setFormActionNone={() => {}}
-          tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
-          beneficiary="0xE94E4f16ad40ADc90C29Dc85b42F1213E034947C"
-          holder="0xa61B056dA0084a5f391EC137583073096880C2e3"
-          destroyTokenState={FormState.UNINITIALIZED}
-          handleDestroyToken={mockHandleDestroyToken}
-          restoreTokenState={FormState.UNINITIALIZED}
-          handleRestoreToken={() => {}}
-          tokenId="0x33430b8a069f6f9115fe9403889162d6c779cccde4db8df04faaf09d6dc739ba"
-        />
-      );
-
-      fireEvent.click(container.getByTestId("acceptSurrenderBtn"));
-      expect(mockHandleDestroyToken).toHaveBeenCalled();
+      expect(container.queryByTestId("cancelSurrenderBtn")).not.toBeNull();
     });
   });
 
@@ -89,15 +62,13 @@ describe("Handle surrendered", () => {
             setOverlayVisible: () => {},
           }}
         >
-          <HandleSurrenderedForm
+          <RejectSurrenderedForm
             setShowEndorsementChain={() => {}}
             formAction={AssetManagementActions.Surrender}
             setFormActionNone={() => {}}
             tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
             beneficiary="0xE94E4f16ad40ADc90C29Dc85b42F1213E034947C"
             holder="0xa61B056dA0084a5f391EC137583073096880C2e3"
-            destroyTokenState={FormState.UNINITIALIZED}
-            handleDestroyToken={() => {}}
             restoreTokenState={FormState.UNINITIALIZED}
             handleRestoreToken={() => {}}
             tokenId="0x33430b8a069f6f9115fe9403889162d6c779cccde4db8df04faaf09d6dc739ba"
@@ -110,40 +81,16 @@ describe("Handle surrendered", () => {
     });
   });
 
-  it("should show a loader when the accept surrender state is in PENDING_CONFIRMATION", async () => {
-    await act(async () => {
-      const container = render(
-        <HandleSurrenderedForm
-          setShowEndorsementChain={() => {}}
-          formAction={AssetManagementActions.Surrender}
-          setFormActionNone={() => {}}
-          tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
-          beneficiary="0xE94E4f16ad40ADc90C29Dc85b42F1213E034947C"
-          holder="0xa61B056dA0084a5f391EC137583073096880C2e3"
-          destroyTokenState={FormState.PENDING_CONFIRMATION}
-          handleDestroyToken={() => {}}
-          restoreTokenState={FormState.UNINITIALIZED}
-          handleRestoreToken={() => {}}
-          tokenId="0x33430b8a069f6f9115fe9403889162d6c779cccde4db8df04faaf09d6dc739ba"
-        />
-      );
-
-      expect(container.queryByTestId("accept-loader")).not.toBeNull();
-    });
-  });
-
   it("should show a loader when the reject surrender state is in PENDING_CONFIRMATION", async () => {
     await act(async () => {
       const container = render(
-        <HandleSurrenderedForm
+        <RejectSurrenderedForm
           setShowEndorsementChain={() => {}}
           formAction={AssetManagementActions.Surrender}
           setFormActionNone={() => {}}
           tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
           beneficiary="0xE94E4f16ad40ADc90C29Dc85b42F1213E034947C"
           holder="0xa61B056dA0084a5f391EC137583073096880C2e3"
-          destroyTokenState={FormState.UNINITIALIZED}
-          handleDestroyToken={() => {}}
           restoreTokenState={FormState.PENDING_CONFIRMATION}
           handleRestoreToken={() => {}}
           tokenId="0x33430b8a069f6f9115fe9403889162d6c779cccde4db8df04faaf09d6dc739ba"
@@ -154,57 +101,27 @@ describe("Handle surrendered", () => {
     });
   });
 
-  it("should disable accept surrender and reject button when the accept surrender state is in PENDING_CONFIRMATION", async () => {
+  it("should disable cancel and reject surrender button when the reject surrender state is in PENDING_CONFIRMATION", async () => {
     await act(async () => {
-      const mockHandleDestroyToken = jest.fn();
+      const mockFormActionNone = jest.fn();
       const mockHandleRestoreToken = jest.fn();
 
       const container = render(
-        <HandleSurrenderedForm
+        <RejectSurrenderedForm
           setShowEndorsementChain={() => {}}
           formAction={AssetManagementActions.Surrender}
-          setFormActionNone={() => {}}
+          setFormActionNone={mockFormActionNone}
           tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
           beneficiary="0xE94E4f16ad40ADc90C29Dc85b42F1213E034947C"
           holder="0xa61B056dA0084a5f391EC137583073096880C2e3"
-          destroyTokenState={FormState.PENDING_CONFIRMATION}
-          handleDestroyToken={mockHandleDestroyToken}
-          restoreTokenState={FormState.UNINITIALIZED}
-          handleRestoreToken={mockHandleRestoreToken}
-          tokenId="0x33430b8a069f6f9115fe9403889162d6c779cccde4db8df04faaf09d6dc739ba"
-        />
-      );
-
-      fireEvent.click(container.getByTestId("acceptSurrenderBtn"));
-      expect(mockHandleDestroyToken).not.toHaveBeenCalled();
-      fireEvent.click(container.getByTestId("rejectSurrenderBtn"));
-      expect(mockHandleRestoreToken).not.toHaveBeenCalled();
-    });
-  });
-
-  it("should disable accept surrender and reject button when the reject surrender state is in PENDING_CONFIRMATION", async () => {
-    await act(async () => {
-      const mockHandleDestroyToken = jest.fn();
-      const mockHandleRestoreToken = jest.fn();
-
-      const container = render(
-        <HandleSurrenderedForm
-          setShowEndorsementChain={() => {}}
-          formAction={AssetManagementActions.Surrender}
-          setFormActionNone={() => {}}
-          tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
-          beneficiary="0xE94E4f16ad40ADc90C29Dc85b42F1213E034947C"
-          holder="0xa61B056dA0084a5f391EC137583073096880C2e3"
-          destroyTokenState={FormState.UNINITIALIZED}
-          handleDestroyToken={mockHandleDestroyToken}
           restoreTokenState={FormState.PENDING_CONFIRMATION}
           handleRestoreToken={mockHandleRestoreToken}
           tokenId="0x33430b8a069f6f9115fe9403889162d6c779cccde4db8df04faaf09d6dc739ba"
         />
       );
 
-      fireEvent.click(container.getByTestId("acceptSurrenderBtn"));
-      expect(mockHandleDestroyToken).not.toHaveBeenCalled();
+      fireEvent.click(container.getByTestId("cancelSurrenderBtn"));
+      expect(mockFormActionNone).not.toHaveBeenCalled();
       fireEvent.click(container.getByTestId("rejectSurrenderBtn"));
       expect(mockHandleRestoreToken).not.toHaveBeenCalled();
     });

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/RejectSurrenderedForm/RejectSurrenderedForm.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/RejectSurrenderedForm/RejectSurrenderedForm.tsx
@@ -76,7 +76,7 @@ export const RejectSurrenderedForm = ({
           disabled={isRestoreTokenPendingConfirmation}
         />
         <div className="flex flex-wrap mb-4">
-          <div className="w-full lg:flex-grow">
+          <div className="w-full lg:flex-grow lg:w-auto">
             <AssetInformationPanel
               setShowEndorsementChain={setShowEndorsementChain}
               tokenRegistryAddress={tokenRegistryAddress}

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/RejectSurrenderedForm/RejectSurrenderedForm.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/RejectSurrenderedForm/RejectSurrenderedForm.tsx
@@ -1,0 +1,122 @@
+import React, { useContext, useEffect } from "react";
+import { OverlayContext } from "../../../../../common/contexts/OverlayContext";
+import { useEndorsementChain } from "../../../../../common/hooks/useEndorsementChain";
+import { FormState } from "../../../../../constants/FormState";
+import { TitleEscrowEvent } from "../../../../../types";
+import { ButtonSolidRedWhite, ButtonSolidWhiteGrey } from "../../../../UI/Button";
+import { LoaderSpinner } from "../../../../UI/Loader";
+import {
+  MessageTitle,
+  showDocumentTransferMessage,
+} from "../../../../UI/Overlay/OverlayContent/DocumentTransferMessage";
+import { TagBorderedRedLarge } from "../../../../UI/Tag";
+import { AssetInformationPanel } from "../../../AssetInformationPanel";
+import { AssetManagementActions } from "../../../AssetManagementActions";
+import { AssetManagementTitle } from "../../AssetManagementTitle";
+
+interface RejectSurrenderedFormProps {
+  tokenId: string;
+  formAction: AssetManagementActions;
+  tokenRegistryAddress: string;
+  beneficiary?: string;
+  holder?: string;
+  setFormActionNone: () => void;
+  setShowEndorsementChain: (payload: boolean) => void;
+  handleRestoreToken: (lastBeneficiary?: string, lastHolder?: string) => void;
+  restoreTokenState: string;
+}
+
+export const RejectSurrenderedForm = ({
+  tokenId,
+  formAction,
+  tokenRegistryAddress,
+  setFormActionNone,
+  setShowEndorsementChain,
+  handleRestoreToken,
+  restoreTokenState,
+}: RejectSurrenderedFormProps) => {
+  const { showOverlay } = useContext(OverlayContext);
+  const { endorsementChain, pending } = useEndorsementChain(tokenRegistryAddress, tokenId);
+
+  const lastTransferEvent = endorsementChain
+    ?.filter(({ eventType }) => eventType === "Transfer")
+    .reverse()[0] as TitleEscrowEvent;
+  const lastBeneficiary = lastTransferEvent?.beneficiary;
+  const lastHolderEvent = lastTransferEvent?.holderChangeEvents.reverse()[0];
+  const lastHolder = lastHolderEvent?.holder;
+
+  const isRestoreTokenPendingConfirmation = restoreTokenState === FormState.PENDING_CONFIRMATION;
+  const isRestoreTokenConfirmed = restoreTokenState === FormState.CONFIRMED;
+
+  const onClickRejectSurrender = () => {
+    showOverlay(
+      showDocumentTransferMessage(MessageTitle.CONFIRM_REJECT_SURRENDER_DOCUMENT, {
+        isSuccess: true,
+        beneficiaryAddress: lastBeneficiary || "Loading...",
+        holderAddress: lastHolder || "Loading...",
+        isConfirmationMessage: true,
+        onConfirmationAction: () => handleRestoreToken(lastBeneficiary, lastHolder),
+      })
+    );
+  };
+
+  useEffect(() => {
+    if (isRestoreTokenConfirmed) {
+      showOverlay(showDocumentTransferMessage(MessageTitle.REJECT_SURRENDER_DOCUMENT, { isSuccess: true }));
+      setFormActionNone();
+    }
+  }, [showOverlay, setFormActionNone, isRestoreTokenConfirmed]);
+
+  return (
+    <div className="flex flex-wrap py-4">
+      <div className="w-full">
+        <AssetManagementTitle
+          setFormActionNone={setFormActionNone}
+          formAction={formAction}
+          disabled={isRestoreTokenPendingConfirmation}
+        />
+        <div className="flex flex-wrap mb-4">
+          <div className="w-full lg:flex-grow">
+            <AssetInformationPanel
+              setShowEndorsementChain={setShowEndorsementChain}
+              tokenRegistryAddress={tokenRegistryAddress}
+            />
+          </div>
+          <div className="w-full lg:w-auto self-end">
+            <div className="py-4">
+              <TagBorderedRedLarge id="surrender-sign">Surrendered To Issuer</TagBorderedRedLarge>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap mb-4">
+          <div className="w-auto ml-auto">
+            <div className="flex flex-wrap">
+              <div className="w-auto">
+                <ButtonSolidWhiteGrey
+                  onClick={setFormActionNone}
+                  disabled={isRestoreTokenPendingConfirmation}
+                  data-testid={"cancelSurrenderBtn"}
+                >
+                  Cancel
+                </ButtonSolidWhiteGrey>
+              </div>
+              <div className="w-auto ml-2">
+                <ButtonSolidRedWhite
+                  onClick={onClickRejectSurrender}
+                  disabled={isRestoreTokenPendingConfirmation || pending}
+                  data-testid={"rejectSurrenderBtn"}
+                >
+                  {isRestoreTokenPendingConfirmation || pending ? (
+                    <LoaderSpinner data-testid={"reject-loader"} />
+                  ) : (
+                    <>Reject Document</>
+                  )}
+                </ButtonSolidRedWhite>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/RejectSurrenderedForm/index.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/RejectSurrenderedForm/index.tsx
@@ -1,0 +1,1 @@
+export * from "./RejectSurrenderedForm";


### PR DESCRIPTION
This PR splits handle surrendered form into 2 components the accept and surrender. 

Refer to images below for change:
- After
<img width="1332" alt="Screenshot 2020-11-27 at 2 48 19 PM" src="https://user-images.githubusercontent.com/45728710/100419479-99abec00-30bf-11eb-90b4-74ffaec9b8ea.png">

- Before
<img width="1332" alt="Screenshot 2020-11-27 at 2 49 43 PM" src="https://user-images.githubusercontent.com/45728710/100419582-cb24b780-30bf-11eb-945b-eb806b95c526.png">

Testing File
[Document-1-ropsten -surrendered.txt](https://github.com/TradeTrust/tradetrust-website/files/5606353/Document-1-ropsten.-surrendered.txt)

Pivotal Link:
https://www.pivotaltracker.com/story/show/175348069