### PR TITLE
feat: obtain key from anchor

### DIFF
--- a/src/components/HomePageContent/HomePageContainer.tsx
+++ b/src/components/HomePageContent/HomePageContainer.tsx
@@ -38,10 +38,12 @@ export const HomePageContainer = (): React.ReactElement => {
   React.useEffect(() => {
     if (location.search !== "") {
       const queryParams = queryString.parse(location.search);
+      const anchorStr = decodeURIComponent(location.hash.substr(1));
+      const anchor = anchorStr ? JSON.parse(anchorStr) : {};
       dispatch(resetCertificateState());
       const action = JSON.parse(queryParams.q as string);
       if (action.type === "DOCUMENT") {
-        dispatch(retrieveCertificateByAction(action.payload));
+        dispatch(retrieveCertificateByAction(action.payload, anchor));
       } else {
         dispatch(
           retrieveCertificateByActionFailure(`The type ${action.type} provided from the action is not supported`)

--- a/src/reducers/certificate.js
+++ b/src/reducers/certificate.js
@@ -139,10 +139,11 @@ export const verifyingCertificateFailure = (payload) => ({
   payload,
 });
 
-export function retrieveCertificateByAction(payload) {
+export function retrieveCertificateByAction(payload, anchor) {
   return {
     type: types.RETRIEVE_CERTIFICATE_BY_ACTION,
     payload,
+    anchor,
   };
 }
 

--- a/src/sagas/certificate.js
+++ b/src/sagas/certificate.js
@@ -50,12 +50,14 @@ export function* handleQrScanned({ payload: qrCode }) {
   }
 }
 
-export function* retrieveCertificateByAction({ payload: { uri, key } }) {
+export function* retrieveCertificateByAction({ payload: { uri, key: payloadKey }, anchor: { key: anchorKey } }) {
   try {
     yield put({
       type: types.RETRIEVE_CERTIFICATE_BY_ACTION_PENDING,
     });
 
+    const key = anchorKey || payloadKey;
+    console.log("KEY: ", key);
     // if a key has been provided, let's assume
     let certificate = yield window.fetch(uri).then((response) => {
       if (response.status >= 400 && response.status < 600) {

--- a/src/sagas/certificate.js
+++ b/src/sagas/certificate.js
@@ -58,7 +58,7 @@ export function* retrieveCertificateByAction({ payload: { uri, key: payloadKey }
     });
 
     const key = anchorKey || payloadKey;
-    console.log("KEY: ", key);
+
     // if a key has been provided, let's assume
     let certificate = yield window.fetch(uri).then((response) => {
       if (response.status >= 400 && response.status < 600) {

--- a/src/sagas/certificate.js
+++ b/src/sagas/certificate.js
@@ -39,11 +39,12 @@ export function* verifyCertificate() {
 
 export function* handleQrScanned({ payload: qrCode }) {
   try {
-    const actionPayload = yield processQrCode(qrCode);
+    const { payload, anchor } = yield processQrCode(qrCode);
 
     yield put({
       type: types.RETRIEVE_CERTIFICATE_BY_ACTION,
-      payload: actionPayload,
+      payload,
+      anchor,
     });
   } catch (e) {
     yield put(verifyingCertificateFailure(e.message));

--- a/src/services/qrProcessor/index.js
+++ b/src/services/qrProcessor/index.js
@@ -3,20 +3,25 @@ import { getLogger } from "../../utils/logger";
 const { error } = getLogger("services:qrProcessor");
 
 export const decodeQrCode = (qrCode) => {
-  const openAttestationActionRegex = /https:\/\/action.openattestation.com\/?\?q=(.*)/;
-  if (!openAttestationActionRegex.test(qrCode))
+  const url = new URL(qrCode);
+  const actionStr = url.searchParams.get("q");
+  const anchorStr = decodeURIComponent(url.hash.substr(1));
+
+  if (url.origin !== "https://action.openattestation.com" || !actionStr)
     throw new Error("QR Code is not formatted to TradeTrust specifications");
-  const [, encodedPayload] = openAttestationActionRegex.exec(qrCode);
-  const decodedPayload = JSON.parse(decodeURIComponent(encodedPayload));
-  return decodedPayload;
+
+  const action = JSON.parse(actionStr);
+  const anchor = anchorStr ? JSON.parse(anchorStr) : {};
+
+  return { action, anchor };
 };
 
 export const processQrCode = async (qrCode) => {
   try {
-    const action = decodeQrCode(qrCode);
+    const { action, anchor } = decodeQrCode(qrCode);
     if (action.type !== "DOCUMENT")
       throw new Error(`The type ${action.type} provided from the action is not supported`);
-    return action.payload;
+    return { payload: action.payload, anchor };
   } catch (e) {
     error(e.message);
     throw new Error(e.message);

--- a/src/services/qrProcessor/qrProcessor.test.js
+++ b/src/services/qrProcessor/qrProcessor.test.js
@@ -13,7 +13,7 @@ describe("decodeQrCode", () => {
     };
 
     const { action, anchor } = decodeQrCode(encodeQrCode(sampleAction));
-    expect(action).toStrictEqual(action);
+    expect(action).toStrictEqual(sampleAction);
     expect(anchor).toStrictEqual({});
   });
 
@@ -24,8 +24,8 @@ describe("decodeQrCode", () => {
     const sampleAnchor = { key: "secret" };
 
     const { action, anchor } = decodeQrCode(encodeQrCodeWithAnchor(sampleAction, sampleAnchor));
-    expect(action).toStrictEqual(action);
-    expect(anchor).toStrictEqual(anchor);
+    expect(action).toStrictEqual(sampleAction);
+    expect(anchor).toStrictEqual(sampleAnchor);
   });
 
   it("throws error when qr code is malformed", () => {

--- a/src/services/qrProcessor/qrProcessor.test.js
+++ b/src/services/qrProcessor/qrProcessor.test.js
@@ -1,39 +1,64 @@
 import { decodeQrCode, processQrCode } from "./index";
 
 const encodeQrCode = (payload) => `https://action.openattestation.com?q=${encodeURIComponent(JSON.stringify(payload))}`;
+const encodeQrCodeWithAnchor = (payload, anchor) =>
+  `https://action.openattestation.com?q=${encodeURIComponent(JSON.stringify(payload))}#${encodeURIComponent(
+    JSON.stringify(anchor)
+  )}`;
 
 describe("decodeQrCode", () => {
   it("decodes an action correctly", () => {
-    const encodedQrCode =
-      "https://action.openattestation.com?q=%7B%22uri%22%3A%22https%3A%2F%2Fsample.domain%2Fdocument%2Fid%3Fq%3Dabc%23123%22%7D";
-
-    const action = decodeQrCode(encodedQrCode);
-    expect(action).toStrictEqual({
+    const sampleAction = {
       uri: "https://sample.domain/document/id?q=abc#123",
-    });
+    };
+
+    const { action, anchor } = decodeQrCode(encodeQrCode(sampleAction));
+    expect(action).toStrictEqual(action);
+    expect(anchor).toStrictEqual({});
   });
 
-  it("throws when qr code is malformed", () => {
+  it("decodes an action and anchor correctly", () => {
+    const sampleAction = {
+      uri: "https://sample.domain/document/id?q=abc#123",
+    };
+    const sampleAnchor = { key: "secret" };
+
+    const { action, anchor } = decodeQrCode(encodeQrCodeWithAnchor(sampleAction, sampleAnchor));
+    expect(action).toStrictEqual(action);
+    expect(anchor).toStrictEqual(anchor);
+  });
+
+  it("throws error when qr code is malformed", () => {
     const encodedQrCode = "http://%7B%22uri%22%3A%22https%3A%2F%2Fsample.domain%2Fdocument%2Fid%3Fq%3Dabc%23123%22%7D";
-    expect(() => decodeQrCode(encodedQrCode)).toThrow("not formatted");
+    expect(() => decodeQrCode(encodedQrCode)).toThrow(`Invalid URL: ${encodedQrCode}`);
   });
 });
 
 describe("processQrCode", () => {
-  it("throws error when uri is not document", async () => {
+  it("throws error when action type is not supported", async () => {
     const document = { name: "foo" };
     const type = "MANY_DOCUMENT";
-    // const { key } = await encryptString(JSON.stringify(document));
     const actionUri = { payload: document, type };
+
     await expect(() => processQrCode(encodeQrCode(actionUri))).rejects.toThrow(
       `The type ${type} provided from the action is not supported`
     );
   });
 
-  it("fetches calls get with the right parameter when a QR code is scanned", async () => {
+  it("extracts the correct payload from a QR code", async () => {
     const document = { name: "foo" };
-    const actionUri = { payload: document, type: "DOCUMENT" };
-    const results = await processQrCode(encodeQrCode(actionUri));
-    expect(results).toStrictEqual(document);
+    const sampleAction = { payload: document, type: "DOCUMENT" };
+
+    const results = await processQrCode(encodeQrCode(sampleAction));
+    expect(results).toStrictEqual({ payload: document, anchor: {} });
+  });
+
+  it("extracts the correct payload and anchor from a QR code", async () => {
+    const document = { name: "foo" };
+    const sampleAction = { payload: document, type: "DOCUMENT" };
+    const sampleAnchor = { key: "secret" };
+
+    const results = await processQrCode(`${encodeQrCodeWithAnchor(sampleAction, sampleAnchor)}`);
+    expect(results).toStrictEqual({ payload: document, anchor: sampleAnchor });
   });
 });


### PR DESCRIPTION
In order to keep secrets on the client side, this PR adds the ability to obtain the `key` from the anchor in URLs.

The verifier will now attempt to extract the `key` in the following order:
1. Anchor: `Anchor.key`
2. Query params: `Action.payload.key`

For future extensibility, `Anchor` is an object that will be safely encoded and appended as a string in the URL:
```javascript
{
  key?: string;
}
```
```text
# Decoded example
https://www.opencerts.io/verify?q={"query":"params"}#{"key":"secret"}

# Encoded example
https://www.opencerts.io/verify?q=%7B%22query%22%3A%22params%22%7D%23%7B%22key%22%3A%22secret%22%7D
```

**Other Changes**
- Update QR processor implementation to be able to obtain key from anchor as well
- Update relevant QR processor tests