### PR TITLE
feat: update provider to use our common generateProvider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5241,215 +5241,49 @@
       }
     },
     "@ethersproject/abstract-provider": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.1.0.tgz",
-      "integrity": "sha512-8dJUnT8VNvPwWhYIau4dwp7qe1g+KgdRm4XTWvjkI9gAT2zZa90WF5ApdZ3vl1r6NDmnn6vUVvyphClRZRteTQ==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+      "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
       "requires": {
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/networks": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/transactions": "^5.1.0",
-        "@ethersproject/web": "^5.1.0"
-      },
-      "dependencies": {
-        "@ethersproject/address": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
-          "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.1.0",
-            "@ethersproject/bytes": "^5.1.0",
-            "@ethersproject/keccak256": "^5.1.0",
-            "@ethersproject/logger": "^5.1.0",
-            "@ethersproject/rlp": "^5.1.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.1.tgz",
-          "integrity": "sha512-AVz5iqz7+70RIqoQTznsdJ6DOVBYciNlvO+AlQmPTB6ofCvoihI9bQdr6wljsX+d5W7Yc4nyvQvP4JMzg0Agig==",
-          "requires": {
-            "@ethersproject/bytes": "^5.1.0",
-            "@ethersproject/logger": "^5.1.0",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
-          "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
-          "requires": {
-            "@ethersproject/logger": "^5.1.0"
-          }
-        },
-        "@ethersproject/constants": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.1.0.tgz",
-          "integrity": "sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.1.0"
-          }
-        },
-        "@ethersproject/keccak256": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.1.0.tgz",
-          "integrity": "sha512-vrTB1W6AEYoadww5c9UyVJ2YcSiyIUTNDRccZIgwTmFFoSHwBtcvG1hqy9RzJ1T0bMdATbM9Hfx2mJ6H0i7Hig==",
-          "requires": {
-            "@ethersproject/bytes": "^5.1.0",
-            "js-sha3": "0.5.7"
-          }
-        },
-        "@ethersproject/logger": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
-          "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
-        },
-        "@ethersproject/properties": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.1.0.tgz",
-          "integrity": "sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==",
-          "requires": {
-            "@ethersproject/logger": "^5.1.0"
-          }
-        },
-        "@ethersproject/rlp": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.1.0.tgz",
-          "integrity": "sha512-vDTyHIwNPrecy55gKGZ47eJZhBm8LLBxihzi5ou+zrSvYTpkSTWRcKUlXFDFQVwfWB+P5PGyERAdiDEI76clxw==",
-          "requires": {
-            "@ethersproject/bytes": "^5.1.0",
-            "@ethersproject/logger": "^5.1.0"
-          }
-        },
-        "@ethersproject/signing-key": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.1.0.tgz",
-          "integrity": "sha512-tE5LFlbmdObG8bY04NpuwPWSRPgEswfxweAI1sH7TbP0ml1elNfqcq7ii/3AvIN05i5U0Pkm3Tf8bramt8MmLw==",
-          "requires": {
-            "@ethersproject/bytes": "^5.1.0",
-            "@ethersproject/logger": "^5.1.0",
-            "@ethersproject/properties": "^5.1.0",
-            "bn.js": "^4.4.0",
-            "elliptic": "6.5.4"
-          }
-        },
-        "@ethersproject/transactions": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.1.1.tgz",
-          "integrity": "sha512-Nwgbp09ttIVN0OoUBatCXaHxR7grWPHbozJN8v7AXDLrl6nnOIBEMDh+yJTnosSQlFhcyjfTGGN+Mx6R8HdvMw==",
-          "requires": {
-            "@ethersproject/address": "^5.1.0",
-            "@ethersproject/bignumber": "^5.1.0",
-            "@ethersproject/bytes": "^5.1.0",
-            "@ethersproject/constants": "^5.1.0",
-            "@ethersproject/keccak256": "^5.1.0",
-            "@ethersproject/logger": "^5.1.0",
-            "@ethersproject/properties": "^5.1.0",
-            "@ethersproject/rlp": "^5.1.0",
-            "@ethersproject/signing-key": "^5.1.0"
-          }
-        },
-        "elliptic": {
-          "version": "6.5.4",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "brorand": "^1.1.0",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.1",
-            "inherits": "^2.0.4",
-            "minimalistic-assert": "^1.0.1",
-            "minimalistic-crypto-utils": "^1.0.1"
-          }
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        }
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/networks": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/transactions": "^5.4.0",
+        "@ethersproject/web": "^5.4.0"
       }
     },
     "@ethersproject/abstract-signer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.1.0.tgz",
-      "integrity": "sha512-qQDMkjGZSSJSKl6AnfTgmz9FSnzq3iEoEbHTYwjDlEAv+LNP7zd4ixCcVWlWyk+2siud856M5CRhAmPdupeN9w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz",
+      "integrity": "sha512-SkkFL5HVq1k4/25dM+NWP9MILgohJCgGv5xT5AcRruGz4ILpfHeBtO/y6j+Z3UN/PAjDeb4P7E51Yh8wcGNLGA==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.1.0",
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0"
-      },
-      "dependencies": {
-        "@ethersproject/bignumber": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.1.tgz",
-          "integrity": "sha512-AVz5iqz7+70RIqoQTznsdJ6DOVBYciNlvO+AlQmPTB6ofCvoihI9bQdr6wljsX+d5W7Yc4nyvQvP4JMzg0Agig==",
-          "requires": {
-            "@ethersproject/bytes": "^5.1.0",
-            "@ethersproject/logger": "^5.1.0",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
-          "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
-          "requires": {
-            "@ethersproject/logger": "^5.1.0"
-          }
-        },
-        "@ethersproject/logger": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
-          "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
-        },
-        "@ethersproject/properties": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.1.0.tgz",
-          "integrity": "sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==",
-          "requires": {
-            "@ethersproject/logger": "^5.1.0"
-          }
-        }
+        "@ethersproject/abstract-provider": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0"
       }
     },
     "@ethersproject/address": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.1.0.tgz",
-      "integrity": "sha512-rfWQR12eHn2cpstCFS4RF7oGjfbkZb0oqep+BfrT+gWEGWG2IowJvIsacPOvzyS1jhNF4MQ4BS59B04Mbovteg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.4.0.tgz",
+      "integrity": "sha512-SD0VgOEkcACEG/C6xavlU1Hy3m5DGSXW3CUHkaaEHbAPPsgi0coP5oNPsxau8eTlZOk/bpa/hKeCNoK5IzVI2Q==",
       "requires": {
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/keccak256": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/rlp": "^5.1.0"
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0"
       }
     },
     "@ethersproject/base64": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.1.0.tgz",
-      "integrity": "sha512-npD1bLvK4Bcxz+m4EMkx+F8Rd7CnqS9DYnhNu0/GlQBXhWjvfoAZzk5HJ0f1qeyp8d+A86PTuzLOGOXf4/CN8g==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.4.0.tgz",
+      "integrity": "sha512-CjQw6E17QDSSC5jiM9YpF7N1aSCHmYGMt9bWD8PWv6YPMxjsys2/Q8xLrROKI3IWJ7sFfZ8B3flKDTM5wlWuZQ==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0"
-      },
-      "dependencies": {
-        "@ethersproject/bytes": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
-          "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
-          "requires": {
-            "@ethersproject/logger": "^5.1.0"
-          }
-        },
-        "@ethersproject/logger": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
-          "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
-        }
+        "@ethersproject/bytes": "^5.4.0"
       }
     },
     "@ethersproject/basex": {
@@ -5485,29 +5319,29 @@
       }
     },
     "@ethersproject/bignumber": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.1.tgz",
-      "integrity": "sha512-AVz5iqz7+70RIqoQTznsdJ6DOVBYciNlvO+AlQmPTB6ofCvoihI9bQdr6wljsX+d5W7Yc4nyvQvP4JMzg0Agig==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.1.tgz",
+      "integrity": "sha512-fJhdxqoQNuDOk6epfM7yD6J8Pol4NUCy1vkaGAkuujZm0+lNow//MKu1hLhRiYV4BsOHyBv5/lsTjF+7hWwhJg==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "bn.js": "^4.4.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "bn.js": "^4.11.9"
       }
     },
     "@ethersproject/bytes": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
-      "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
+      "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
       "requires": {
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/constants": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.1.0.tgz",
-      "integrity": "sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.4.0.tgz",
+      "integrity": "sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==",
       "requires": {
-        "@ethersproject/bignumber": "^5.1.0"
+        "@ethersproject/bignumber": "^5.4.0"
       }
     },
     "@ethersproject/contracts": {
@@ -6106,11 +5940,11 @@
       }
     },
     "@ethersproject/keccak256": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.1.0.tgz",
-      "integrity": "sha512-vrTB1W6AEYoadww5c9UyVJ2YcSiyIUTNDRccZIgwTmFFoSHwBtcvG1hqy9RzJ1T0bMdATbM9Hfx2mJ6H0i7Hig==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz",
+      "integrity": "sha512-FBI1plWet+dPUvAzPAeHzRKiPpETQzqSUWR1wXJGHVWi4i8bOSrpC3NwpkPjgeXG7MnugVc1B42VbfnQikyC/A==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
+        "@ethersproject/bytes": "^5.4.0",
         "js-sha3": "0.5.7"
       },
       "dependencies": {
@@ -6122,23 +5956,16 @@
       }
     },
     "@ethersproject/logger": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
-      "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz",
+      "integrity": "sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ=="
     },
     "@ethersproject/networks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.1.0.tgz",
-      "integrity": "sha512-A/NIrIED/G/IgU1XUukOA3WcFRxn2I4O5GxsYGA5nFlIi+UZWdGojs85I1VXkR1gX9eFnDXzjE6OtbgZHjFhIA==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
+      "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
       "requires": {
-        "@ethersproject/logger": "^5.1.0"
-      },
-      "dependencies": {
-        "@ethersproject/logger": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
-          "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
-        }
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/pbkdf2": {
@@ -6166,11 +5993,11 @@
       }
     },
     "@ethersproject/properties": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.1.0.tgz",
-      "integrity": "sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.0.tgz",
+      "integrity": "sha512-7jczalGVRAJ+XSRvNA6D5sAwT4gavLq3OXPuV/74o3Rd2wuzSL035IMpIMgei4CYyBdialJMrTqkOnzccLHn4A==",
       "requires": {
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/providers": {
@@ -6417,12 +6244,12 @@
       }
     },
     "@ethersproject/rlp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.1.0.tgz",
-      "integrity": "sha512-vDTyHIwNPrecy55gKGZ47eJZhBm8LLBxihzi5ou+zrSvYTpkSTWRcKUlXFDFQVwfWB+P5PGyERAdiDEI76clxw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.4.0.tgz",
+      "integrity": "sha512-0I7MZKfi+T5+G8atId9QaQKHRvvasM/kqLyAH4XxBCBchAooH2EX5rL9kYZWwcm3awYV+XC7VF6nLhfeQFKVPg==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
       }
     },
     "@ethersproject/sha2": {
@@ -6460,29 +6287,25 @@
       }
     },
     "@ethersproject/signing-key": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.1.0.tgz",
-      "integrity": "sha512-tE5LFlbmdObG8bY04NpuwPWSRPgEswfxweAI1sH7TbP0ml1elNfqcq7ii/3AvIN05i5U0Pkm3Tf8bramt8MmLw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.4.0.tgz",
+      "integrity": "sha512-q8POUeywx6AKg2/jX9qBYZIAmKSB4ubGXdQ88l40hmATj29JnG5pp331nAWwwxPn2Qao4JpWHNZsQN+bPiSW9A==",
       "requires": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "bn.js": "^4.4.0",
-        "elliptic": "6.5.4"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "bn.js": "^4.11.9",
+        "elliptic": "6.5.4",
+        "hash.js": "1.1.7"
       },
       "dependencies": {
-        "elliptic": {
-          "version": "6.5.4",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+        "hash.js": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+          "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
           "requires": {
-            "bn.js": "^4.11.9",
-            "brorand": "^1.1.0",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.1",
-            "inherits": "^2.0.4",
-            "minimalistic-assert": "^1.0.1",
-            "minimalistic-crypto-utils": "^1.0.1"
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.1"
           }
         }
       }
@@ -6556,20 +6379,30 @@
         }
       }
     },
-    "@ethersproject/transactions": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.1.1.tgz",
-      "integrity": "sha512-Nwgbp09ttIVN0OoUBatCXaHxR7grWPHbozJN8v7AXDLrl6nnOIBEMDh+yJTnosSQlFhcyjfTGGN+Mx6R8HdvMw==",
+    "@ethersproject/strings": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.4.0.tgz",
+      "integrity": "sha512-k/9DkH5UGDhv7aReXLluFG5ExurwtIpUfnDNhQA29w896Dw3i4uDTz01Quaptbks1Uj9kI8wo9tmW73wcIEaWA==",
       "requires": {
-        "@ethersproject/address": "^5.1.0",
-        "@ethersproject/bignumber": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/constants": "^5.1.0",
-        "@ethersproject/keccak256": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/rlp": "^5.1.0",
-        "@ethersproject/signing-key": "^5.1.0"
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0"
+      }
+    },
+    "@ethersproject/transactions": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
+      "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
+      "requires": {
+        "@ethersproject/address": "^5.4.0",
+        "@ethersproject/bignumber": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/constants": "^5.4.0",
+        "@ethersproject/keccak256": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/rlp": "^5.4.0",
+        "@ethersproject/signing-key": "^5.4.0"
       }
     },
     "@ethersproject/units": {
@@ -6831,66 +6664,15 @@
       }
     },
     "@ethersproject/web": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.1.0.tgz",
-      "integrity": "sha512-LTeluWgTq04+RNqAkVhpydPcRZK/kKxD2Vy7PYGrAD27ABO9kTqTBKwiOuzTyAHKUQHfnvZbXmxBXJAGViSDcA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
+      "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
       "requires": {
-        "@ethersproject/base64": "^5.1.0",
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "@ethersproject/properties": "^5.1.0",
-        "@ethersproject/strings": "^5.1.0"
-      },
-      "dependencies": {
-        "@ethersproject/bignumber": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.1.tgz",
-          "integrity": "sha512-AVz5iqz7+70RIqoQTznsdJ6DOVBYciNlvO+AlQmPTB6ofCvoihI9bQdr6wljsX+d5W7Yc4nyvQvP4JMzg0Agig==",
-          "requires": {
-            "@ethersproject/bytes": "^5.1.0",
-            "@ethersproject/logger": "^5.1.0",
-            "bn.js": "^4.4.0"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
-          "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
-          "requires": {
-            "@ethersproject/logger": "^5.1.0"
-          }
-        },
-        "@ethersproject/constants": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.1.0.tgz",
-          "integrity": "sha512-0/SuHrxc8R8k+JiLmJymxHJbojUDWBQqO+b+XFdwaP0jGzqC09YDy/CAlSZB6qHsBifY8X3I89HcK/oMqxRdBw==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.1.0"
-          }
-        },
-        "@ethersproject/logger": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
-          "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw=="
-        },
-        "@ethersproject/properties": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.1.0.tgz",
-          "integrity": "sha512-519KKTwgmH42AQL3+GFV3SX6khYEfHsvI6v8HYejlkigSDuqttdgVygFTDsGlofNFchhDwuclrxQnD5B0YLNMg==",
-          "requires": {
-            "@ethersproject/logger": "^5.1.0"
-          }
-        },
-        "@ethersproject/strings": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.1.0.tgz",
-          "integrity": "sha512-perBZy0RrmmL0ejiFGUOlBVjMsUceqLut3OBP3zP96LhiJWWbS8u1NqQVgN4/Gyrbziuda66DxiQocXhsvx+Sw==",
-          "requires": {
-            "@ethersproject/bytes": "^5.1.0",
-            "@ethersproject/constants": "^5.1.0",
-            "@ethersproject/logger": "^5.1.0"
-          }
-        }
+        "@ethersproject/base64": "^5.4.0",
+        "@ethersproject/bytes": "^5.4.0",
+        "@ethersproject/logger": "^5.4.0",
+        "@ethersproject/properties": "^5.4.0",
+        "@ethersproject/strings": "^5.4.0"
       }
     },
     "@ethersproject/wordlists": {
@@ -7260,9 +7042,9 @@
       }
     },
     "@govtechsg/oa-verify": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@govtechsg/oa-verify/-/oa-verify-7.4.4.tgz",
-      "integrity": "sha512-MxRsUjI8Gk+yCgfSW0kR0UNzpGsTYu676HQ3KdgJYR6eh/7z1xOebefk2gUm9EYKaoLwLeHNKJGuFizONar3Uw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@govtechsg/oa-verify/-/oa-verify-7.5.0.tgz",
+      "integrity": "sha512-GQShYI3nDx9r1kUNWRL7gIkqUwXN8j23yBgc7EMXaTUzEk58fd9nO5hn8sMaqwx9s7mtIruzX5DczQeQqTBjig==",
       "requires": {
         "@govtechsg/dnsprove": "^2.1.3",
         "@govtechsg/document-store": "^2.2.1",
@@ -22999,9 +22781,9 @@
       "integrity": "sha512-4BPvMGkxAK9vTduCq6D5b8ZqjteD2cvDIPPriXP6nnmPhWKFSxypo+AFvyQ0omJGa0cGTR+dkdI/8jiF7U/qaw=="
     },
     "ethr-did-resolver": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-4.3.3.tgz",
-      "integrity": "sha512-2rzWKw0NCRkk6tw2bj+CVcmBYlmWxL7LaLpt+GxKINqvUW5Z/UZyD0YvYvAD67xw03N4bd736LU2p2e/Qpw00g==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/ethr-did-resolver/-/ethr-did-resolver-4.3.4.tgz",
+      "integrity": "sha512-xx9rjjBf8t2pSUyciDDXv99D66YIpKH29bufbEYyOds6IJSa5C7xeql4MSYz6zNtAAtvNoj9AYhg6FbBkeQmxg==",
       "requires": {
         "@ethersproject/abi": "^5.1.0",
         "@ethersproject/abstract-signer": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@govtechsg/decentralized-renderer-react-components": "^3.5.2",
     "@govtechsg/ethers-contract-hook": "^2.2.0",
     "@govtechsg/oa-encryption": "^1.3.3",
-    "@govtechsg/oa-verify": "^7.4.4",
+    "@govtechsg/oa-verify": "^7.5.0",
     "@govtechsg/open-attestation": "^5.3.2",
     "@govtechsg/open-attestation-cli": "^1.40.4",
     "@govtechsg/token-registry": "2.5.1",

--- a/src/common/contexts/provider.tsx
+++ b/src/common/contexts/provider.tsx
@@ -2,11 +2,12 @@ import { MessageTitle } from "@govtechsg/tradetrust-ui-components";
 import { ethers, providers, Signer } from "ethers";
 import React, { createContext, FunctionComponent, useContext, useEffect, useState } from "react";
 import { INFURA_API_KEY, NETWORK_NAME } from "../../config";
+import { utils } from "@govtechsg/oa-verify";
 
 const getProvider =
   NETWORK_NAME === "local"
     ? new providers.JsonRpcProvider()
-    : new ethers.providers.InfuraProvider(NETWORK_NAME, INFURA_API_KEY);
+    : utils.generateProvider({ network: NETWORK_NAME, providerType: "infura", apiKey: INFURA_API_KEY });
 
 interface ProviderContextProps {
   isUpgraded: boolean;


### PR DESCRIPTION
# In this PR:
- Update provider to use the common one we have in our oa-verify library, `generateProvider()`