### PR TITLE
chore: update decentralized renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1213,7 +1213,6 @@
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.15.4.tgz",
       "integrity": "sha512-lWcAqKeB624/twtTc3w6w/2o9RqJPaNBhPGK6DKLSiwuVWC7WFkypWyNg+CpZoyJH0jVzv1uMtXZ/5/lQOLtCg==",
-      "dev": true,
       "requires": {
         "core-js-pure": "^3.16.0",
         "regenerator-runtime": "^0.13.4"
@@ -2084,10 +2083,11 @@
       }
     },
     "@govtechsg/decentralized-renderer-react-components": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@govtechsg/decentralized-renderer-react-components/-/decentralized-renderer-react-components-3.5.2.tgz",
-      "integrity": "sha512-36mWzF2PbD9fQ2+X6It8UedLTj666H9asEkNQpuaeV+MCkiKJd4K3F6hHiZXgo9aAIc9rwb0dx8ezUcRC80xNw==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@govtechsg/decentralized-renderer-react-components/-/decentralized-renderer-react-components-3.5.3.tgz",
+      "integrity": "sha512-YiXTUIFMf8q/ZSAxheXspc6YiC6Zoag974apKmfh4jP2zvaBCE6GOvWR3yIBwuHz5G1BSs9lKZk7wqaSgNnh3Q==",
       "requires": {
+        "@babel/runtime-corejs3": "^7.15.4",
         "@emotion/react": "^11.1.5",
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
@@ -10233,8 +10233,7 @@
     "core-js-pure": {
       "version": "3.17.2",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.17.2.tgz",
-      "integrity": "sha512-2VV7DlIbooyTI7Bh+yzOOWL9tGwLnQKHno7qATE+fqZzDKYr6llVjVQOzpD/QLZFgXDPb8T71pJokHEZHEYJhQ==",
-      "dev": true
+      "integrity": "sha512-2VV7DlIbooyTI7Bh+yzOOWL9tGwLnQKHno7qATE+fqZzDKYr6llVjVQOzpD/QLZFgXDPb8T71pJokHEZHEYJhQ=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -19324,9 +19323,9 @@
       }
     },
     "make-cancellable-promise": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-1.0.0.tgz",
-      "integrity": "sha512-+YO6Grg2uy/z8Mv3uV90OP6yAUHIF43YGgEFbejmBrK9VWFsVO6DvzFMcopXr9wCNg3/QIltIKiSCROC7zFB2g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-cancellable-promise/-/make-cancellable-promise-1.1.0.tgz",
+      "integrity": "sha512-X5Opjm2xcZsOLuJ+Bnhb4t5yfu4ehlA3OKEYLtqUchgVzL/QaqW373ZUVxVHKwvJ38cmYuR4rAHD2yUvAIkTPA=="
     },
     "make-dir": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",
     "@govtechsg/address-identity-resolver": "^1.4.1",
-    "@govtechsg/decentralized-renderer-react-components": "^3.5.2",
+    "@govtechsg/decentralized-renderer-react-components": "^3.5.3",
     "@govtechsg/ethers-contract-hook": "^2.2.0",
     "@govtechsg/oa-encryption": "^1.3.3",
     "@govtechsg/oa-verify": "^7.5.0",


### PR DESCRIPTION
Updates the version of decentralised renderer to v3.5.3 which addresses an issue (https://github.com/Open-Attestation/decentralized-renderer-react-components/pull/62) where the renderer breaks in iOS13 and polyfill in other devices/browsers.