### PR TITLE
feat: relax strict constraint of 0

### DIFF
--- a/src/components/Demo/DemoCreate/DemoCreateStart/index.tsx
+++ b/src/components/Demo/DemoCreate/DemoCreateStart/index.tsx
@@ -1,9 +1,9 @@
 import { Button, LoaderSpinner } from "@govtechsg/tradetrust-ui-components";
 import React, { FunctionComponent, useContext, useState } from "react";
 import { ethers } from "ethers";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { ProviderContext } from "../../../../common/contexts/provider";
-import { deployingDocStore } from "../../../../reducers/demo-create";
+import { deployingDocStore, getDocumentStoreStatus } from "../../../../reducers/demo-create";
 import { getFunds } from "../../../../services/create";
 import { DemoCreateContext } from "../contexts/DemoCreateContext";
 
@@ -14,6 +14,7 @@ export const DemoCreateStart: FunctionComponent = () => {
   const [error, setError] = useState("");
 
   const dispatch = useDispatch();
+  const deployedDocStoreStatus = useSelector(getDocumentStoreStatus);
 
   const handleStart = async () => {
     setLoading(true);
@@ -22,13 +23,11 @@ export const DemoCreateStart: FunctionComponent = () => {
       const balance = await provider.getBalance("latest");
       const formattedBalance = Number(ethers.utils.formatEther(balance));
 
-      if (formattedBalance === 0) {
+      if (formattedBalance <= 1) {
         await getFunds(account as string);
       }
 
       dispatch(deployingDocStore(provider));
-      setActiveStep("form");
-      setLoading(false);
     } catch (e) {
       setLoading(false);
       if (e instanceof Error) {
@@ -36,6 +35,13 @@ export const DemoCreateStart: FunctionComponent = () => {
       }
     }
   };
+
+  React.useEffect(() => {
+    if (deployedDocStoreStatus === "success") {
+      setLoading(false);
+      setActiveStep("form");
+    }
+  }, [deployedDocStoreStatus, setActiveStep]);
 
   return (
     <>

--- a/src/reducers/demo-create.ts
+++ b/src/reducers/demo-create.ts
@@ -1,5 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { WrappedDocument } from "@govtechsg/open-attestation/dist/types/3.0/types";
+import { RootState } from "./";
 
 type Status = "failure" | "success" | "pending";
 interface DemoCreateState {
@@ -101,30 +102,25 @@ const demoCreateSlice = createSlice({
   },
 });
 
-export const getDocumentStoreAddress = (store: { demoCreate: { documentStoreAddress: string } }): string => {
+export const getDocumentStoreStatus = (store: RootState): string => store.demoCreate.deploymentDocStoreStatus;
+
+export const getDocumentStoreAddress = (store: RootState): string => {
   return store.demoCreate.documentStoreAddress;
 };
 
-export const getTempDns = (store: { demoCreate: { tempDns: string } }): string => {
+export const getTempDns = (store: RootState): string => {
   return store.demoCreate.tempDns;
 };
 
-export const getWrappedDocument = (store: {
-  demoCreate: { wrappedDocument: WrappedDocument<any> };
-}): WrappedDocument<any> => {
+export const getWrappedDocument = (store: RootState): WrappedDocument<any> => {
   return store.demoCreate.wrappedDocument;
 };
 
-export const getWrappedDocumentStatus = (store: { demoCreate: { wrapDocumentStatus: Status } }): Status => {
+export const getWrappedDocumentStatus = (store: RootState): Status => {
   return store.demoCreate.wrapDocumentStatus;
 };
 
-export const getDocumentPrepared = (store: {
-  demoCreate: {
-    createTempDnsStatus: Status;
-    deploymentDocStoreStatus: Status;
-  };
-}): { prepared: boolean; error: boolean } => {
+export const getDocumentPrepared = (store: RootState): { prepared: boolean; error: boolean } => {
   const { createTempDnsStatus, deploymentDocStoreStatus } = store.demoCreate;
 
   return {
@@ -133,12 +129,7 @@ export const getDocumentPrepared = (store: {
   };
 };
 
-export const getDocumentIssued = (store: {
-  demoCreate: {
-    wrapDocumentStatus: Status;
-    issueDocumentStatus: Status;
-  };
-}): { issued: boolean; error: boolean } => {
+export const getDocumentIssued = (store: RootState): { issued: boolean; error: boolean } => {
   const { wrapDocumentStatus, issueDocumentStatus } = store.demoCreate;
 
   return {


### PR DESCRIPTION
feat: add blocking ui for deployment of docStore

## Summary
- this pr relaxes the constraint for adding funds from oa-ropsten (from strict 0 to <= 1)
- it also blocks the ui from proceeding if docStore is not deployed properly (probably need to handle displayed UI when error) to prevent any weird behavior for the flow (when the client goes through the flow quickly, and issues it before the docStore is deployed, will blow up)
- misc reducing of code