### PR TITLE
feat: cms skip ci

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -3,11 +3,11 @@ backend:
   branch: master
   squash_merges: true
   commit_messages:
-    create: "feat: Create {{collection}} “{{slug}}” {{author-name}}"
-    update: "chore: Update {{collection}} “{{slug}}” {{author-name}}"
-    delete: "chore: Delete {{collection}} “{{slug}}” {{author-name}}"
-    uploadMedia: "chore: Upload “{{path}}” {{author-name}}"
-    deleteMedia: "chore: Delete “{{path}}” {{author-name}}"
+    create: "feat: Create {{collection}} “{{slug}}” {{author-name}} [skip ci]"
+    update: "chore: Update {{collection}} “{{slug}}” {{author-name}} [skip ci]"
+    delete: "chore: Delete {{collection}} “{{slug}}” {{author-name}} [skip ci]"
+    uploadMedia: "chore: Upload “{{path}}” {{author-name}} [skip ci]"
+    deleteMedia: "chore: Delete “{{path}}” {{author-name}} [skip ci]"
 
 local_backend: true
 


### PR DESCRIPTION
## Summary
- using netlify cms to make edits is taking a long time b4 changes can be previewed / published
- skipping ci/cd pipeline for netlify cms related commits -> https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/
- should be ok to skip, since cms related files are strictly controlled, need to test out later to see if this pr works

## Changes
- added `[skip ci]` to commit messages to netlify cms

## Issues
NA

