### PR TITLE
fix: action v3

### DIFF
--- a/src/sagas/certificate.js
+++ b/src/sagas/certificate.js
@@ -71,19 +71,21 @@ export function* retrieveCertificateByAction({ payload: { uri, key: payloadKey }
     if (!certificate) {
       throw new Error(`Certificate at address ${uri} is empty`);
     }
-    // if there is a key and the type is "OPEN-ATTESTATION-TYPE-1", let's use oa-encryption
-    if (key && certificate.type === "OPEN-ATTESTATION-TYPE-1") {
-      certificate = JSON.parse(
-        decryptString({
+
+    // will only decrypt if type is `OPEN-ATTESTATION-TYPE-1`, so far only oa-encryption uses this
+    if (certificate.type === "OPEN-ATTESTATION-TYPE-1") {
+      if (key) {
+        const decryptedCertificate = decryptString({
           tag: certificate.tag,
           cipherText: certificate.cipherText,
           iv: certificate.iv,
           key,
           type: certificate.type,
-        })
-      );
-    } else if (key || certificate.type) {
-      throw new Error(`Unable to decrypt certificate with key=${key} and type=${certificate.type}`);
+        });
+        certificate = JSON.parse(decryptedCertificate);
+      } else {
+        throw new Error(`Unable to decrypt certificate with key=${key} and type=${certificate.type}`);
+      }
     }
 
     yield put({


### PR DESCRIPTION
## Summary

- gallery v3 documents not rendering here
- failing example = https://action.openattestation.com/?q=%7B%22type%22%3A%22DOCUMENT%22%2C%22payload%22%3A%7B%22uri%22%3A%22https%3A%2F%2Fdeploy-preview-68--frosty-panini-ae12d4.netlify.app%2Fstatic%2Fdocuments%2Fv3%2Finvoice-ropsten.json%22%2C%22permittedActions%22%3A%5B%22VIEW%22%5D%2C%22redirect%22%3A%22https%3A%2F%2Fdev.tradetrust.io%22%7D%7D <- this will pass after merged tho



## Changes

- v3 document has `type`, so not to accidentally block that as "error"

## Issues

- https://www.pivotaltracker.com/story/show/177676085
