### PR TITLE
fix: redirect resources

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,10 @@
   to = "/index.html"
   status = 200
 
+[[redirects]]
+  from = "/resources"
+  to = "/learn"
+
 # Unset the infura key with domain restriction for branch previews
 # so that the default key (without domain restriction) is used instead
 [context.deploy-preview]

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,13 +4,13 @@
   status = 200
 
 [[redirects]]
+  from = "/resources"
+  to = "/learn"
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200
-
-[[redirects]]
-  from = "/resources"
-  to = "/learn"
 
 # Unset the infura key with domain restriction for branch previews
 # so that the default key (without domain restriction) is used instead


### PR DESCRIPTION
## Summary

previous print materials such as pdfs still refers url to `/resources`, it has since moved

## Changes

- redirect `/resources` to `/learn`

## Issues

https://www.pivotaltracker.com/story/show/180094004
