### PR TITLE
fix: try again not navigating | make AuthContext depend on ProviderProvider

### DIFF
--- a/src/components/Demo/DemoCreate/DemoCreateIssue/index.tsx
+++ b/src/components/Demo/DemoCreate/DemoCreateIssue/index.tsx
@@ -88,7 +88,7 @@ export const DemoCreateIssue: FunctionComponent = () => {
                 <br /> alternatively, see <Link to="/faq">FAQ</Link> or <Link to="/contact">Contact us</Link>
               </p>
               <Button className="bg-cerulean text-white rounded hover:bg-cerulean-500">
-                <Link className="text-white hover:text-white" to="/demo/create">
+                <Link className="text-white hover:text-white" to="/demo">
                   Try Again
                 </Link>
               </Button>

--- a/src/components/Demo/DemoCreate/index.tsx
+++ b/src/components/Demo/DemoCreate/index.tsx
@@ -47,7 +47,6 @@ export const DemoCreate: FunctionComponent = () => {
       );
       return false;
     }
-
     return true;
   };
 

--- a/src/components/Demo/DemoInitial/index.tsx
+++ b/src/components/Demo/DemoInitial/index.tsx
@@ -3,20 +3,23 @@ import React, { FunctionComponent, useContext, useState } from "react";
 import { Checkbox } from "../../UI/Checkbox";
 import { useHistory } from "react-router-dom";
 import { contentPdpa } from "../../../common/utils/overlay";
-import { magic } from "../../../common/contexts/helpers";
+import { useAuthContext } from "../../../common/contexts/AuthenticationContext";
 
-interface DemoInitialProps {
-  login: (email: string) => Promise<void | null | string> | ReturnType<typeof magic.auth.loginWithMagicLink>;
-  upgradeToMagicSigner: () => Promise<void>;
-}
-
-export const DemoInitial: FunctionComponent<DemoInitialProps> = ({ login, upgradeToMagicSigner }) => {
+export const DemoInitial: FunctionComponent = () => {
+  const { login, isLoggedIn } = useAuthContext();
   const { showOverlay } = useContext(OverlayContext);
+  const history = useHistory();
+
   const [form, setForm] = useState({
     "Receive communications": "No",
     email: "",
   });
-  const history = useHistory();
+
+  React.useLayoutEffect(() => {
+    if (isLoggedIn) {
+      history.push("/demo/create");
+    }
+  }, [isLoggedIn, history]);
 
   const handleInputOrTextareaChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setForm({ ...form, [event.target.name]: event.target.value });
@@ -31,8 +34,6 @@ export const DemoInitial: FunctionComponent<DemoInitialProps> = ({ login, upgrad
     try {
       event.preventDefault();
       await login(form.email);
-      await upgradeToMagicSigner();
-      history.push("/demo/create");
     } catch (e) {
       console.log(e);
     }

--- a/src/pages/demo.tsx
+++ b/src/pages/demo.tsx
@@ -1,10 +1,10 @@
-import React, { FunctionComponent, useEffect } from "react";
+import React, { FunctionComponent } from "react";
 import { Helmet } from "react-helmet";
-import { useHistory } from "react-router-dom";
-import { useAuthContext } from "../common/contexts/AuthenticationContext";
-import { useProviderContext } from "../common/contexts/provider";
 import { DemoInitial } from "../components/Demo/DemoInitial";
 import { Page } from "../components/Layout/Page";
+import { resetDemoCreateState } from "../reducers/demo-create";
+import { resetDemoState as resetDemoVerifyState } from "../reducers/demo-verify";
+import { useDispatch } from "react-redux";
 
 export const DemoLayout: FunctionComponent = ({ children }) => {
   return (
@@ -20,22 +20,14 @@ export const DemoLayout: FunctionComponent = ({ children }) => {
 };
 
 export const Demo: FunctionComponent = () => {
-  const { login, isLoggedIn } = useAuthContext();
-  const { upgradeToMagicSigner } = useProviderContext();
-  const history = useHistory();
+  const dispatch = useDispatch();
 
-  useEffect(() => {
-    const handleIsLoggedIn = async () => {
-      if (isLoggedIn) {
-        await upgradeToMagicSigner();
-        history.push("/demo/create");
-      }
-    };
+  React.useLayoutEffect(() => {
+    dispatch(resetDemoCreateState());
+    dispatch(resetDemoVerifyState());
+  }, [dispatch]);
 
-    handleIsLoggedIn();
-  }, [isLoggedIn, history, upgradeToMagicSigner]);
-
-  return <DemoInitial login={login} upgradeToMagicSigner={upgradeToMagicSigner} />;
+  return <DemoInitial />;
 };
 
 export const DemoPage: FunctionComponent = () => (


### PR DESCRIPTION
## Summary

What is the background of this pull request?
try again not navigating | make AuthContext depend on ProviderProvider

## Changes

- What are the changes made in this pull request?
- made try again button navigate back to `/demo` instead of `/demo/create`
- made auth context depend on provider provider and streamlined some of the upgrading magic signer stuff.
