### PR TITLE
feat: remove polygon from network selection options

### DIFF
--- a/src/config/chain-config.ts
+++ b/src/config/chain-config.ts
@@ -5,7 +5,7 @@ import { ChainId } from "../constants/chain-info";
  */
 export const MAIN_NETWORKS = [
   ChainId.Ethereum, //
-  ChainId.Polygon,
+  // ChainId.Polygon,
 ];
 
 /**
@@ -15,5 +15,5 @@ export const TEST_NETWORKS = [
   ChainId.Ropsten, //
   ChainId.Rinkeby,
   ChainId.Goerli,
-  ChainId.PolygonMumbai,
+  // ChainId.PolygonMumbai,
 ];


### PR DESCRIPTION
## Summary

As discussed during the last sprint preview, PO would like to remove Polygon option from the network selector first.

## Changes

- Remove Polygon from main and test nets in chain configuration

## Issues
* #506
