### PR TITLE
feat: ignore dependabot build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,9 @@
   to = "/index.html"
   status = 200
 
+[build]
+  ignore = "git log -1 --pretty=%B | grep dependabot"
+
 # Unset the infura key with domain restriction for branch previews
 # so that the default key (without domain restriction) is used instead
 [context.deploy-preview]


### PR DESCRIPTION
- save some netlify build minutes if is dependabot
- should be safe to ignore since `npm run build` will be ran test against on ci/cd anyway