### PR TITLE
feat: cms skip test

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -33,12 +33,15 @@ jobs:
       - name: Check Lint
         run: npm run lint
       - name: Test
+        if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
         run: npm run test
       - name: Build
         run: npm run build
       - name: Integration - testcafe
+        if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
         run: npm run integration:headless
       - name: Integration - dappeteer
+        if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
         uses: mujo-code/puppeteer-headful@master
         env:
           CI: "true"

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -3,11 +3,11 @@ backend:
   branch: master
   squash_merges: true
   commit_messages:
-    create: "feat: Create {{collection}} “{{slug}}” {{author-name}}"
-    update: "chore: Update {{collection}} “{{slug}}” {{author-name}}"
-    delete: "chore: Delete {{collection}} “{{slug}}” {{author-name}}"
-    uploadMedia: "chore: Upload “{{path}}” {{author-name}}"
-    deleteMedia: "chore: Delete “{{path}}” {{author-name}}"
+    create: "feat: Create {{collection}} “{{slug}}” {{author-name}} [skip test]"
+    update: "chore: Update {{collection}} “{{slug}}” {{author-name}} [skip test]"
+    delete: "chore: Delete {{collection}} “{{slug}}” {{author-name}} [skip test]"
+    uploadMedia: "chore: Upload “{{path}}” {{author-name}} [skip test]"
+    deleteMedia: "chore: Delete “{{path}}” {{author-name}} [skip test]"
 
 local_backend: true
 


### PR DESCRIPTION
### Summary
- https://www.pivotaltracker.com/story/show/180276693
- netlify CMS is git based, so every post edit = 1 commit
- each commit starts the entire CI/CD pipeline
- in order to preview / publish, must wait for CI/CD to be done (nearly 10min currently)

### Changes
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif
- skip tests if commits are triggered from CMS updates

### Issues
- https://github.com/TradeTrust/tradetrust-website/pull/476
- https://github.com/TradeTrust/tradetrust-website/pull/468
