### PR TITLE
fix: reset of certificate data on finish of magic demo flow

### DIFF
--- a/src/components/CertificateViewer.tsx
+++ b/src/components/CertificateViewer.tsx
@@ -58,11 +58,13 @@ export const CertificateViewer: FunctionComponent<CertificateViewerProps> = ({ i
 
   const { currentChainId } = useProviderContext();
 
-  // Update the certificate when network is changed
+  /* Update the certificate when network is changed unless it is Magic Demo as the network does not change for it (fixed at Ropsten).
+   */
   useEffect(() => {
+    if (isMagicDemo) return;
     resetCertificateData();
     dispatch(updateCertificate(certificateDoc));
-  }, [certificateDoc, currentChainId, dispatch, resetCertificateData]);
+  }, [certificateDoc, currentChainId, dispatch, resetCertificateData, isMagicDemo]);
 
   /*
   initialise the meta token information context when new tokenId


### PR DESCRIPTION
## Summary

What is the background of this pull request?
Recent changes to cert-viewer caused magic demo to renavigate to main page as the cert data is discarded on mount.

## Changes
Adds a logical branch that prevents the discarding of cert data IFF magic demo only. (As we dont expect a switch in network while using it, no way for user to toggle dropdown)
