### PR TITLE
fix: remove continue-on-error

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -41,8 +41,7 @@ jobs:
         id: testcafe
         if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
         run: npm run integration:headless
-        continue-on-error: true
-      - name: "Upload Artifact"
+      - name: 'Upload Artifact'
         if: ${{ failure() && steps.testcafe.outcome == 'failure' }}
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
## Summary

noticed that [job](https://github.com/puayhiang/tradetrust-website/actions/runs/2074723380) continues despite failing 

## Changes

remove continue on error for testcafe step