### PR TITLE
fix: ui tune

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3999,11 +3999,6 @@
             "resolve": "^1.12.0"
           }
         },
-        "penpal-v4": {
-          "version": "npm:penpal@4.1.1",
-          "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
-          "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
-        },
         "stylis": {
           "version": "4.0.13",
           "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
@@ -32238,6 +32233,11 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/penpal/-/penpal-5.3.0.tgz",
       "integrity": "sha512-ezGckenx66j3RShl4nZiswjgDxyoDaJJ9tLBp46UvVxlA9MlIPF6hWfuppw1AzaDKgUULU1i44QFOuI4SXY/mg=="
+    },
+    "penpal-v4": {
+      "version": "npm:penpal@4.1.1",
+      "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
+      "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3999,6 +3999,11 @@
             "resolve": "^1.12.0"
           }
         },
+        "penpal-v4": {
+          "version": "npm:penpal@4.1.1",
+          "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
+          "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
+        },
         "stylis": {
           "version": "4.0.13",
           "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
@@ -32233,11 +32238,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/penpal/-/penpal-5.3.0.tgz",
       "integrity": "sha512-ezGckenx66j3RShl4nZiswjgDxyoDaJJ9tLBp46UvVxlA9MlIPF6hWfuppw1AzaDKgUULU1i44QFOuI4SXY/mg=="
-    },
-    "penpal-v4": {
-      "version": "npm:penpal@4.1.1",
-      "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
-      "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
     },
     "performance-now": {
       "version": "2.1.0",

--- a/src/pages/demo.tsx
+++ b/src/pages/demo.tsx
@@ -9,11 +9,13 @@ import { useDispatch } from "react-redux";
 export const DemoLayout: FunctionComponent = ({ children }) => {
   return (
     <div className="flex flex-wrap mt-4">
-      <div className="w-full lg:w-2/3 xl:w-1/2">
+      <div className="w-full lg:max-w-5xl">
         <div className="bg-white rounded-xl shadow-xl p-6">{children}</div>
       </div>
-      <div className="w-1/2 lg:w-1/3 xl:w-1/2 mx-auto my-8">
-        <img className="max-h-96 mx-auto" src="/static/images/faq/faq-man.png" alt="FAQ person" />
+      <div className="w-56 mx-auto my-8">
+        <div className="px-4">
+          <img className="max-h-96" src="/static/images/faq/faq-man.png" alt="FAQ person" />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
- expand column for magic demo preview
- fix error page layout
    - included in v2.18.5 https://github.com/TradeTrust/tradetrust-ui-components/pull/133
- https://www.pivotaltracker.com/story/show/182283772
- https://www.pivotaltracker.com/story/show/180833536

---

b4:
![b4](https://user-images.githubusercontent.com/4774314/170906360-4add3ee5-c0b9-4d59-85ad-b4458fc8172a.png)
![Pasted Image at 2022_05_25_16_53 pm](https://user-images.githubusercontent.com/4774314/170906532-92e705a9-9a4c-4e03-9b8b-7a4e09e3b849.png)

after:
![after](https://user-images.githubusercontent.com/4774314/170906436-15e3e379-6e85-4958-8841-0cadc08ae550.png)
![error-page](https://user-images.githubusercontent.com/4774314/170906397-3730ce35-fb4c-43c4-8615-e9e876ca5491.png)

