### PR TITLE
test: connect wallet and manage asset button in e2e

### DIFF
--- a/tests/e2e/specs/endorse-owner.spec.js
+++ b/tests/e2e/specs/endorse-owner.spec.js
@@ -20,12 +20,10 @@ describe(
       cy.switchMetamaskAccount(1)
         .should("be.true")
         .then(() => {
-          cy.get("[data-testid='connectToWallet']").click();
-          cy.acceptMetamaskAccess(true).should("be.true");
+          cy.clickConnectAndManageAssetButton(true);
         });
       // END - approve application once after connect to wallet, subsequent tests no longer need
 
-      cy.get("[data-testid='manageAssetDropdown']").click();
       cy.get("[data-testid='endorseBeneficiaryDropdown']").click();
       cy.get("[data-testid='editable-input-owner']").type(ACCOUNT_3);
       cy.get("[data-testid='editable-input-holder']").type(ACCOUNT_2);

--- a/tests/e2e/specs/nominate-owner.spec.js
+++ b/tests/e2e/specs/nominate-owner.spec.js
@@ -23,8 +23,7 @@ describe(
         cy.get("input[type=file]").attachFile("ebl-nominate-owner.json");
         cy.get("[data-testid='asset-title-owner']").should("be.visible");
         cy.get("[data-testid='asset-title-holder']").should("be.visible");
-        cy.get("[data-testid='connectToWallet']").click();
-        cy.get("[data-testid='manageAssetDropdown']").click();
+        cy.clickConnectAndManageAssetButton();
         cy.get("[data-testid='nominateBeneficiaryHolderDropdown']").click();
         cy.get("[data-testid='editable-input-owner']").type(ACCOUNT_2);
         cy.get("[data-testid='nominationBtn']").click();
@@ -41,8 +40,7 @@ describe(
         cy.get("input[type=file]").attachFile("ebl-nominate-owner.json");
         cy.get("[data-testid='asset-title-owner']").should("be.visible");
         cy.get("[data-testid='asset-title-holder']").should("be.visible");
-        cy.get("[data-testid='connectToWallet']").click();
-        cy.get("[data-testid='manageAssetDropdown']").click();
+        cy.clickConnectAndManageAssetButton();
         cy.get("[data-testid='endorseTransferDropdown']").click();
         cy.get("[data-testid='endorseTransferBtn']").click();
         cy.confirmMetamaskTransaction();

--- a/tests/e2e/specs/surrender-1-reject.spec.js
+++ b/tests/e2e/specs/surrender-1-reject.spec.js
@@ -23,8 +23,7 @@ describe(
         cy.get("input[type=file]").attachFile("ebl-surrender.json");
         cy.get("[data-testid='asset-title-owner']").should("be.visible");
         cy.get("[data-testid='asset-title-holder']").should("be.visible");
-        cy.get("[data-testid='connectToWallet']").click();
-        cy.get("[data-testid='manageAssetDropdown']").click();
+        cy.clickConnectAndManageAssetButton();
         cy.get("[data-testid='surrenderDropdown']").click();
         cy.get("[data-testid='surrenderBtn']").click();
         cy.confirmMetamaskTransaction();
@@ -38,8 +37,7 @@ describe(
         cy.visit("/verify");
         cy.get("input[type=file]").attachFile("ebl-surrender.json");
         cy.get("[data-testid='surrenderToIssuer']").should("be.visible");
-        cy.get("[data-testid='connectToWallet']").click();
-        cy.get("[data-testid='manageAssetDropdown']").click();
+        cy.clickConnectAndManageAssetButton();
         cy.get("[data-testid='rejectSurrenderDropdown']").click();
         cy.get("[data-testid='rejectSurrenderBtn']").click();
         cy.get("[data-testid='confirmActionBtn']").click();

--- a/tests/e2e/specs/surrender-2-accept.spec.js
+++ b/tests/e2e/specs/surrender-2-accept.spec.js
@@ -23,8 +23,7 @@ describe(
         cy.get("input[type=file]").attachFile("ebl-surrender.json");
         cy.get("[data-testid='asset-title-owner']").should("be.visible");
         cy.get("[data-testid='asset-title-holder']").should("be.visible");
-        cy.get("[data-testid='connectToWallet']").click();
-        cy.get("[data-testid='manageAssetDropdown']").click();
+        cy.clickConnectAndManageAssetButton();
         cy.get("[data-testid='surrenderDropdown']").click();
         cy.get("[data-testid='surrenderBtn']").click();
         cy.confirmMetamaskTransaction();
@@ -38,8 +37,7 @@ describe(
         cy.visit("/verify");
         cy.get("input[type=file]").attachFile("ebl-surrender.json");
         cy.get("[data-testid='surrenderToIssuer']").should("be.visible");
-        cy.get("[data-testid='connectToWallet']").click();
-        cy.get("[data-testid='manageAssetDropdown']").click();
+        cy.clickConnectAndManageAssetButton();
         cy.get("[data-testid='acceptSurrenderDropdown']").click();
         cy.get("[data-testid='acceptSurrenderBtn']").click();
         cy.confirmMetamaskTransaction();

--- a/tests/e2e/specs/transfer-holder.spec.js
+++ b/tests/e2e/specs/transfer-holder.spec.js
@@ -22,8 +22,7 @@ describe(
       cy.get("input[type=file]").attachFile("ebl-transfer-holder.json");
       cy.get("[data-testid='asset-title-owner']").should("be.visible");
       cy.get("[data-testid='asset-title-holder']").should("be.visible");
-      cy.get("[data-testid='connectToWallet']").click();
-      cy.get("[data-testid='manageAssetDropdown']").click();
+      cy.clickConnectAndManageAssetButton();
       cy.get("[data-testid='transferHolderDropdown']").click();
       cy.get("[data-testid='editable-input-holder']").type(ACCOUNT_2);
       cy.get("[data-testid='transferBtn']").click();

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -1,1 +1,15 @@
 import "cypress-file-upload";
+
+Cypress.Commands.add("clickConnectAndManageAssetButton", (acceptMetamask = false) => {
+  cy.get("#title-transfer-panel").then(($transferPanel) => {
+    cy.wait(2000);
+    if ($transferPanel.find("[data-testid='connectToWallet']").length) {
+      cy.get("[data-testid='connectToWallet']").click();
+      if (acceptMetamask) {
+        cy.acceptMetamaskAccess(true).should("be.true");
+        cy.wait(2000);
+      }
+    }
+  });
+  cy.get("[data-testid='manageAssetDropdown']").click();
+});


### PR DESCRIPTION
## Summary
After the "Connect Wallet" has been clicked the first time, subsequent revisits to the page will show the "Manage Assets" button. When a test randomly fails and reattempts, all the reattempts will fail because it couldn't find the "Connect Wallet" button as it has become "Manage Assets" button. This PR changes the test to click the connect button if it's there before looking for the manage asset button, so that the reattempts can proceed.

## Changes
- Add a cypress command `clickConnectAndManageAssetButton`

## Issues
- https://www.pivotaltracker.com/story/show/182331659
