### PR TITLE
refactor: provider context

### DIFF
--- a/src/common/contexts/TokenInformationContext/TokenInformationContext.tsx
+++ b/src/common/contexts/TokenInformationContext/TokenInformationContext.tsx
@@ -74,10 +74,13 @@ export const TokenInformationContextProvider: FunctionComponent<TokenInformation
 }) => {
   const [tokenId, setTokenId] = useState<string>();
   const [tokenRegistryAddress, setTokenRegistryAddress] = useState<string>();
-  const { getTransactor } = useProviderContext();
-  const transactor = getTransactor();
-  const { tokenRegistry } = useTokenRegistryContract(tokenRegistryAddress, transactor);
-  const { titleEscrow, updateTitleEscrow, documentOwner } = useTitleEscrowContract(transactor, tokenRegistry, tokenId);
+  const { providerOrSigner } = useProviderContext();
+  const { tokenRegistry } = useTokenRegistryContract(tokenRegistryAddress, providerOrSigner);
+  const { titleEscrow, updateTitleEscrow, documentOwner } = useTitleEscrowContract(
+    providerOrSigner,
+    tokenRegistry,
+    tokenId
+  );
   const isSurrendered = documentOwner === tokenRegistryAddress;
   const isTokenBurnt = documentOwner === "0x000000000000000000000000000000000000dEaD"; // check if the token belongs to burn address.
 
@@ -99,7 +102,7 @@ export const TokenInformationContextProvider: FunctionComponent<TokenInformation
     reset: resetDestroyingTokenState,
   } = useContractFunctionHook(tokenRegistry, "destroyToken");
 
-  const { restoreToken, state: restoreTokenState } = useRestoreToken(transactor, tokenRegistry, tokenId);
+  const { restoreToken, state: restoreTokenState } = useRestoreToken(providerOrSigner, tokenRegistry, tokenId);
 
   // Contract Write Functions (available only after provider has been upgraded)
   const {
@@ -195,7 +198,7 @@ export const TokenInformationContextProvider: FunctionComponent<TokenInformation
   }, [transferToNewEscrowState, updateTitleEscrow]);
 
   // Reset states for all write functions when provider changes to allow methods to be called again without refreshing
-  useEffect(resetProviders, [resetProviders, transactor]);
+  useEffect(resetProviders, [resetProviders, providerOrSigner]);
 
   return (
     <TokenInformationContext.Provider

--- a/src/common/contexts/provider.tsx
+++ b/src/common/contexts/provider.tsx
@@ -112,7 +112,6 @@ export const ProviderContextProvider: FunctionComponent<ProviderContextProviderP
       setAccount(undefined);
     } else {
       const injectedWeb3 = ethereum || (web3 && web3.currentProvider);
-      if (!injectedWeb3) throw new Error("No injected web3 provider found");
       const newProvider = new ethers.providers.Web3Provider(injectedWeb3, "any");
       const network = await newProvider.getNetwork();
       if (!isSupportedNetwork(network.chainId)) {

--- a/src/common/contexts/provider.tsx
+++ b/src/common/contexts/provider.tsx
@@ -1,21 +1,18 @@
-import { ethers, providers, Signer } from "ethers";
-import React, { createContext, FunctionComponent, useCallback, useContext, useEffect, useState } from "react";
+import { ethers, providers } from "ethers";
+import React, { createContext, FunctionComponent, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { INFURA_API_KEY } from "../../config";
 import { utils } from "@govtechsg/oa-verify";
 import { magic } from "./helpers";
 import { ChainId, ChainInfoObject } from "../../constants/chain-info";
-import { NoMetaMaskError, UnsupportedNetworkError } from "../errors";
-import { getChainInfo } from "../utils/chain-utils";
+import { UnsupportedNetworkError } from "../errors";
+import { getChainInfo, getChainInfoFromNetworkName } from "../utils/chain-utils";
+import { NETWORK_NAME } from "../../config";
 
 export enum SIGNER_TYPE {
   IDENTITY = "Identity",
   METAMASK = "Metamask",
   MAGIC = "Magic",
 }
-
-// Utility function for use in non-react components that cannot get through hooks
-let currentProvider: providers.Provider | undefined;
-export const getCurrentProvider = (): providers.Provider | undefined => currentProvider;
 
 const createProvider = (chainId: ChainId) =>
   chainId === ChainId.Local
@@ -26,17 +23,21 @@ const createProvider = (chainId: ChainId) =>
         apiKey: INFURA_API_KEY,
       });
 
+// Utility function for use in non-react components that cannot get through hooks
+let currentProvider: providers.Provider | undefined = createProvider(getChainInfoFromNetworkName(NETWORK_NAME).chainId);
+export const getCurrentProvider = (): providers.Provider | undefined => currentProvider;
+
 interface ProviderContextProps {
   providerType: SIGNER_TYPE;
   upgradeToMetaMaskSigner: () => Promise<void>;
   upgradeToMagicSigner: () => Promise<void>;
   changeNetwork: (chainId: ChainId) => void;
   reloadNetwork: () => Promise<void>;
-  getTransactor: () => Signer | providers.Provider | undefined;
-  getSigner: () => Signer | undefined;
-  getProvider: () => providers.Provider | undefined;
   supportedChainInfoObjects: ChainInfoObject[];
   currentChainId: ChainId | undefined;
+  provider: providers.Provider | undefined;
+  providerOrSigner: providers.Provider | ethers.Signer | undefined;
+  account: string | undefined;
 }
 
 export const ProviderContext = createContext<ProviderContextProps>({
@@ -49,14 +50,11 @@ export const ProviderContext = createContext<ProviderContextProps>({
   changeNetwork: async (_chainId: ChainId) => {},
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   reloadNetwork: async () => {},
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  getTransactor: () => undefined,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  getProvider: () => undefined,
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  getSigner: () => undefined,
   supportedChainInfoObjects: [],
   currentChainId: undefined,
+  provider: currentProvider,
+  providerOrSigner: currentProvider,
+  account: undefined,
 });
 
 interface Ethereum extends providers.ExternalProvider, providers.BaseProvider {
@@ -83,71 +81,63 @@ export const ProviderContextProvider: FunctionComponent<ProviderContextProviderP
   networks: supportedChainInfoObjects,
   defaultChainId,
 }) => {
-  const [providerType, setProviderType] = useState<SIGNER_TYPE>(SIGNER_TYPE.IDENTITY);
-  const [isConnected, setIsConnected] = useState<boolean>();
-  const [currentChainId, setCurrentChainId] = useState<ChainId | undefined>(defaultChainId);
+  const defaultProvider = useRef(createProvider(defaultChainId));
 
-  const isSupportedNetwork = (chainId: ChainId) =>
-    supportedChainInfoObjects.some((chainInfoObj) => chainInfoObj.chainId === chainId);
-
-  const defaultProvider = isSupportedNetwork(defaultChainId) ? createProvider(defaultChainId) : undefined;
-  const [providerOrSigner, setProviderOrSigner] = useState<providers.Provider | Signer | undefined>(defaultProvider);
-
-  const updateProviderOrSigner = async (newProviderOrSigner: typeof providerOrSigner) => {
-    try {
-      if (!Signer.isSigner(newProviderOrSigner)) {
-        setIsConnected(false);
-      } else {
-        await (newProviderOrSigner as Signer).getAddress();
-        setIsConnected(true);
-      }
-    } catch (e) {
-      setIsConnected(false);
-    }
-    setProviderOrSigner(newProviderOrSigner);
-  };
-
-  const changeNetwork = async (chainId: ChainId) => {
-    if (!isSupportedNetwork(chainId)) throw new UnsupportedNetworkError(chainId);
-
-    const chainInfo = getChainInfo(chainId);
-
-    try {
-      const web3provider = getWeb3Provider();
-      await requestSwitchChain(chainId);
-      await updateProviderOrSigner(web3provider.getSigner());
-    } catch (e: unknown) {
-      if (e instanceof NoMetaMaskError) {
-        console.warn(e.message);
-        await updateProviderOrSigner(createProvider(chainInfo.chainId));
-      } else {
-        throw e;
-      }
-    }
-  };
-
-  const getProvider = useCallback(() => {
-    if (providers.Provider.isProvider(providerOrSigner)) return providerOrSigner;
-    if (Signer.isSigner(providerOrSigner)) return providerOrSigner.provider;
-    return undefined;
-  }, [providerOrSigner]);
-
-  const getSigner = useCallback(
-    () => (isConnected ? (providerOrSigner as Signer) : undefined),
-    [isConnected, providerOrSigner]
+  const isSupportedNetwork = useCallback(
+    (chainId: ChainId | number | string) =>
+      supportedChainInfoObjects.some((chainInfoObj) => chainInfoObj.chainId.toString() === chainId.toString()),
+    [supportedChainInfoObjects]
   );
 
-  const getTransactor = useCallback(() => getSigner() ?? getProvider(), [getProvider, getSigner]);
+  const [providerType, setProviderType] = useState<SIGNER_TYPE>(SIGNER_TYPE.IDENTITY);
+  const [currentChainId, setCurrentChainId] = useState<ChainId | undefined>(
+    isSupportedNetwork(defaultChainId) ? defaultChainId : undefined
+  );
+  const [account, setAccount] = useState<string | undefined>();
+  const [providerOrSigner, setProviderOrSigner] = useState<providers.Provider | ethers.Signer | undefined>(
+    defaultProvider.current
+  );
+  const [provider, setProvider] = useState<providers.Provider | undefined>(defaultProvider.current);
 
-  const getWeb3Provider = () => {
+  const changeNetwork = async (chainId: ChainId) => {
+    await requestSwitchChain(chainId);
+    setCurrentChainId(chainId);
+  };
+
+  const updateProvider = useCallback(async () => {
     const { ethereum, web3 } = window;
     const metamaskExtensionNotFound = typeof ethereum === "undefined" || typeof web3 === "undefined";
-    if (metamaskExtensionNotFound || !ethereum.request) throw new NoMetaMaskError();
+    if (metamaskExtensionNotFound || !ethereum.request) {
+      setProvider(createProvider(currentChainId || defaultChainId));
+      setAccount(undefined);
+    } else {
+      const injectedWeb3 = ethereum || web3.currentProvider;
+      if (!injectedWeb3) throw new Error("No injected web3 provider found");
+      const newProvider = new ethers.providers.Web3Provider(injectedWeb3, "any");
+      const network = await newProvider.getNetwork();
+      if (!isSupportedNetwork(network.chainId)) {
+        console.warn("User wallet is connected to an unsupported network, will fallback to default network");
+        setProvider(undefined);
+        setAccount(undefined);
+        setCurrentChainId(undefined);
+      } else {
+        setProvider(newProvider);
+        setCurrentChainId(network.chainId);
+      }
+    }
+  }, [currentChainId, defaultChainId, isSupportedNetwork]);
 
-    const injectedWeb3 = ethereum || web3.currentProvider;
-    if (!injectedWeb3) throw new Error("No injected web3 provider found");
-    return new ethers.providers.Web3Provider(injectedWeb3, "any");
-  };
+  const updateSigner = useCallback(async () => {
+    try {
+      const signer = (provider as ethers.providers.Web3Provider).getSigner();
+      const address = await signer.getAddress();
+      setAccount(address);
+      setProviderOrSigner(signer);
+    } catch (e) {
+      setAccount(undefined);
+      setProviderOrSigner(provider);
+    }
+  }, [provider]);
 
   const requestSwitchChain = async (chainId: ChainId) => {
     const { ethereum } = window;
@@ -167,13 +157,11 @@ export const ProviderContextProvider: FunctionComponent<ProviderContextProviderP
   };
 
   const initializeMetaMaskSigner = async () => {
-    const web3Provider = getWeb3Provider();
-    const provider = getProvider();
-    const network = await (provider ? provider.getNetwork() : web3Provider.getNetwork());
+    const web3Provider = provider as ethers.providers.Web3Provider;
     await web3Provider.send("eth_requestAccounts", []);
-    await requestSwitchChain(network.chainId);
+    const chainInfo = getChainInfo(currentChainId ?? defaultChainId);
+    await requestSwitchChain(chainInfo.chainId);
 
-    await updateProviderOrSigner(web3Provider.getSigner());
     setProviderType(SIGNER_TYPE.METAMASK);
   };
 
@@ -181,7 +169,7 @@ export const ProviderContextProvider: FunctionComponent<ProviderContextProviderP
     // needs to be cast as any before https://github.com/magiclabs/magic-js/issues/83 has been merged.
     const magicProvider = new ethers.providers.Web3Provider(magic.rpcProvider as any);
 
-    await updateProviderOrSigner(magicProvider.getSigner());
+    setProvider(magicProvider);
     setProviderType(SIGNER_TYPE.MAGIC);
   };
 
@@ -195,7 +183,6 @@ export const ProviderContextProvider: FunctionComponent<ProviderContextProviderP
   };
 
   const reloadNetwork = async () => {
-    const provider = getProvider();
     if (!provider) throw new UnsupportedNetworkError();
 
     const chainId = (await provider.getNetwork()).chainId;
@@ -203,51 +190,23 @@ export const ProviderContextProvider: FunctionComponent<ProviderContextProviderP
   };
 
   useEffect(() => {
-    currentProvider = getProvider();
-    const updateChainId = async () => {
-      const provider = getProvider();
-      if (!provider) {
-        setCurrentChainId(undefined);
-      } else {
-        const network = await provider.getNetwork();
-        setCurrentChainId(network.chainId);
-      }
-    };
-    updateChainId();
-  }, [getProvider]);
+    updateProvider();
+  }, [updateProvider]);
+
+  useEffect(() => {
+    updateSigner();
+  }, [updateSigner]);
+
+  useEffect(() => {
+    currentProvider = provider;
+  }, [provider]);
 
   useEffect(() => {
     if (!window.ethereum) return;
 
-    const chainChangedHandler = async (chainIdHex: string) => {
-      try {
-        await changeNetwork(parseInt(chainIdHex, 16));
-      } catch (e) {
-        // Clear provider/signer when user selects an unsupported network
-        await updateProviderOrSigner(undefined);
-        console.warn("An unsupported network has been selected.", e);
-        throw e;
-      }
-    };
-
-    window.ethereum.on("accountsChanged", reloadNetwork).on("chainChanged", chainChangedHandler);
-
-    const initialiseWallet = async () => {
-      try {
-        const web3Provider = getWeb3Provider();
-        const provider = getProvider();
-        if (!provider) return;
-        const [web3Network, appNetwork] = await Promise.all([web3Provider.getNetwork(), provider.getNetwork()]);
-        if (web3Network.chainId === appNetwork.chainId) setProviderOrSigner(web3Provider.getSigner().provider);
-      } catch (e) {
-        if (e instanceof NoMetaMaskError) {
-          console.warn(e.message);
-        } else {
-          throw e;
-        }
-      }
-    };
-    initialiseWallet();
+    window.ethereum
+      .on("accountsChanged", updateProvider)
+      .on("chainChanged", (chainIdHex: string) => changeNetwork(parseInt(chainIdHex, 16)));
 
     return () => {
       if (!window.ethereum) return;
@@ -264,11 +223,11 @@ export const ProviderContextProvider: FunctionComponent<ProviderContextProviderP
         upgradeToMagicSigner,
         changeNetwork,
         reloadNetwork,
-        getProvider,
-        getTransactor,
-        getSigner,
         supportedChainInfoObjects,
         currentChainId,
+        provider,
+        providerOrSigner,
+        account,
       }}
     >
       {children}

--- a/src/common/contexts/provider.tsx
+++ b/src/common/contexts/provider.tsx
@@ -111,7 +111,7 @@ export const ProviderContextProvider: FunctionComponent<ProviderContextProviderP
       setProvider(createProvider(currentChainId || defaultChainId));
       setAccount(undefined);
     } else {
-      const injectedWeb3 = ethereum || web3.currentProvider;
+      const injectedWeb3 = ethereum || (web3 && web3.currentProvider);
       if (!injectedWeb3) throw new Error("No injected web3 provider found");
       const newProvider = new ethers.providers.Web3Provider(injectedWeb3, "any");
       const network = await newProvider.getNetwork();

--- a/src/common/hooks/useEndorsementChain/useEndorsementChain.integration.test.tsx
+++ b/src/common/hooks/useEndorsementChain/useEndorsementChain.integration.test.tsx
@@ -13,7 +13,7 @@ const mockUseProviderContext = useProviderContext as jest.Mock;
 
 describe("useEndorsementChain|integration", () => {
   beforeAll(() => {
-    mockUseProviderContext.mockReturnValue({ getProvider: jest.fn().mockReturnValue(ropstenProvider) });
+    mockUseProviderContext.mockReturnValue({ provider: ropstenProvider, providerOrSigner: ropstenProvider });
   });
   it("should work correctly for a given document ID and token registry", async () => {
     const { result } = renderHook(() =>

--- a/src/common/hooks/useEndorsementChain/useEndorsementChain.ts
+++ b/src/common/hooks/useEndorsementChain/useEndorsementChain.ts
@@ -12,15 +12,14 @@ export const useEndorsementChain = (
   pending: boolean;
   error: string;
 } => {
-  const { getProvider } = useProviderContext();
-  const provider = getProvider();
+  const { providerOrSigner, provider } = useProviderContext();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState("");
   const [endorsementChain, setEndorsementChain] = useState<TradeTrustErc721Event[]>();
-  const { tokenRegistry } = useTokenRegistryContract(tokenRegistryAddress, provider);
+  const { tokenRegistry } = useTokenRegistryContract(tokenRegistryAddress, providerOrSigner);
 
   const fetchEndorsementChain = useCallback(async () => {
-    if (!tokenRegistry || !provider) return;
+    if (!tokenRegistry || !provider || !providerOrSigner) return;
     setEndorsementChain(undefined);
     setPending(true);
     try {
@@ -58,7 +57,7 @@ export const useEndorsementChain = (
       }
     }
     setPending(false);
-  }, [provider, tokenId, tokenRegistry, tokenRegistryAddress]);
+  }, [provider, providerOrSigner, tokenId, tokenRegistry, tokenRegistryAddress]);
 
   useEffect(() => {
     fetchEndorsementChain();

--- a/src/common/utils/chain-utils.ts
+++ b/src/common/utils/chain-utils.ts
@@ -37,3 +37,24 @@ export const getSupportedChainInfo = (): ChainInfoObject[] => {
   if (isTestEnv || isLocal) networks.push(ChainId.Local);
   return networks.map((chainId) => getChainInfo(chainId));
 };
+
+/**
+ * Switches the network in user's wallet if installed.
+ * @param chainId Chain ID of target network
+ */
+export const walletSwitchChain = async (chainId: ChainId): Promise<void> => {
+  const { ethereum } = window;
+  if (!ethereum || !ethereum.request) return;
+  try {
+    await ethereum.request({
+      method: "wallet_switchEthereumChain",
+      params: [{ chainId: `0x${chainId.toString(16)}` }],
+    });
+  } catch (e: any) {
+    if (e.code === -32601) {
+      // Possibly on localhost which doesn't support the call
+      return console.error(e);
+    }
+    throw e;
+  }
+};

--- a/src/components/AssetManagementPanel/AssetManagementApplication/index.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementApplication/index.tsx
@@ -46,26 +46,11 @@ export const AssetManagementApplication: FunctionComponent<AssetManagementApplic
     restoreTokenState,
   } = useTokenInformationContext();
   const [assetManagementAction, setAssetManagementAction] = useState(AssetManagementActions.None);
-  const [account, setAccount] = useState<string | undefined>();
-  const { upgradeToMetaMaskSigner, getSigner, getProvider } = useProviderContext();
+  const { upgradeToMetaMaskSigner, provider, account } = useProviderContext();
 
-  const provider = getProvider();
   const { tokenRegistry } = useTokenRegistryContract(tokenRegistryAddress, provider);
   // Check if direct owner is minter, useContractFunctionHook value returns {0: boolean}
   const { call: checkIsMinter, value: isMinter } = useContractFunctionHook(tokenRegistry, "isMinter");
-
-  useEffect(() => {
-    const updateAccount = async () => {
-      try {
-        const signer = getSigner();
-        const address = signer ? await signer.getAddress() : undefined;
-        setAccount(address);
-      } catch {
-        setAccount(undefined);
-      }
-    };
-    updateAccount();
-  }, [getSigner]);
 
   useEffect(() => {
     if (isTitleEscrow === false && account) {

--- a/src/components/Demo/DemoCreate/DemoCreateReview/index.tsx
+++ b/src/components/Demo/DemoCreate/DemoCreateReview/index.tsx
@@ -79,7 +79,7 @@ const DefaultReview = (data: Record<string, FormItemSchema>) => {
 export const DemoCreateReview: FunctionComponent = () => {
   const { setActiveStep } = useContext(DemoCreateContext);
   const { formValues } = useContext(DemoFormContext);
-  const { getTransactor } = useProviderContext();
+  const { provider } = useProviderContext();
   const wrapDocumentStatus = useSelector(getWrappedDocumentStatus);
   const issueDocumentStatus = useSelector(getIssuedDocumentStatus);
   const documentStoreAddress = useSelector(getDocumentStoreAddress);
@@ -102,7 +102,6 @@ export const DemoCreateReview: FunctionComponent = () => {
   };
 
   useEffect(() => {
-    const provider = getTransactor();
     if (wrapDocumentStatus !== null && wrapDocumentStatus === "success") {
       dispatch(issuingDocument(provider));
       gaEvent({
@@ -110,7 +109,7 @@ export const DemoCreateReview: FunctionComponent = () => {
         category: GaCategory.MAGIC_DEMO,
       });
     }
-  }, [wrapDocumentStatus, dispatch, getTransactor]);
+  }, [wrapDocumentStatus, dispatch, provider]);
 
   useEffect(() => {
     if (issueDocumentStatus !== null && issueDocumentStatus !== "pending") {

--- a/src/components/Demo/DemoCreate/DemoCreateStart/index.tsx
+++ b/src/components/Demo/DemoCreate/DemoCreateStart/index.tsx
@@ -11,7 +11,7 @@ import { LoadingModal } from "../../../UI/Overlay";
 import { GaAction, GaCategory } from "../../../../types";
 
 export const DemoCreateStart: FunctionComponent = () => {
-  const { getSigner } = useProviderContext();
+  const { providerOrSigner, account } = useProviderContext();
   const { setActiveStep } = useContext(DemoCreateContext);
   const [loading, setLoading] = useState(false);
   const [getFundsError, setGetFundsError] = useState(false);
@@ -24,16 +24,15 @@ export const DemoCreateStart: FunctionComponent = () => {
     try {
       setLoading(true);
       setGetFundsError(false);
-      const provider = getSigner();
-      if (!provider) throw new Error("Not connected");
-      const account = await provider.getAddress();
-      const balance = await provider.getBalance("latest");
+      if (!providerOrSigner) throw new Error("Invalid provider");
+      if (!account) throw new Error("Not connected");
+      const balance = await providerOrSigner.getBalance("latest");
       const formattedBalance = Number(ethers.utils.formatEther(balance));
 
       if (formattedBalance <= 1) {
         await getFunds(account as string);
       }
-      dispatch(deployingDocStore(provider));
+      dispatch(deployingDocStore(providerOrSigner));
     } catch (e) {
       setGetFundsError(true);
       setLoading(false);

--- a/src/components/VerifyPageContent/helpers.ts
+++ b/src/components/VerifyPageContent/helpers.ts
@@ -4,7 +4,11 @@ import { getChainInfo } from "../../common/utils/chain-utils";
 type LoadCertificate = (certificate: any) => void;
 
 export const getDemoCert = (chainId: ChainId): string => {
-  const networkName = getChainInfo(chainId).networkName;
+  let networkName: string | undefined;
+  try {
+    networkName = getChainInfo(chainId).networkName;
+  } catch (e) {}
+
   return `/static/demo/${networkName}.tt`;
 };
 

--- a/src/pages/verify.tsx
+++ b/src/pages/verify.tsx
@@ -2,14 +2,11 @@ import React from "react";
 import { Helmet } from "react-helmet";
 import { DropZoneSectionContainer } from "../components/VerifyPageContent/DropZoneSection";
 import { Page } from "../components/Layout/Page";
-import { useProviderContext } from "../common/contexts/provider";
-import { Link } from "react-router-dom";
-import { ErrorPage, OverlayContent, OverlayContextProvider } from "@govtechsg/tradetrust-ui-components";
+import { OverlayContent, OverlayContextProvider } from "@govtechsg/tradetrust-ui-components";
 import { NetworkSelect } from "../components/Layout/NetworkSelect";
-import { InfoOverlay } from "../components/UI/Overlay/InfoOverlay";
+import { InfoOverlay } from "../components/UI/Overlay";
 
 const VerifyPage = (): React.ReactElement => {
-  const { getProvider } = useProviderContext();
   return (
     <>
       <Helmet>
@@ -26,39 +23,24 @@ const VerifyPage = (): React.ReactElement => {
         <title>TradeTrust - Verify</title>
       </Helmet>
 
-      {getProvider() ? (
-        <Page title="Verify Documents">
-          <div className="flex items-center">
-            <div className="text-cloud-800 mr-3" data-testid="page-subtitle">
-              Verify your document on
-            </div>
-            <NetworkSelect />
-            <OverlayContextProvider>
-              <InfoOverlay className="p-0 ml-3 cursor-pointer focus:outline-none">
-                <OverlayContent className="max-w-sm lg:max-w-md" title="Network Selector">
-                  A document can only be successfully verified on the same network where the document was created in.
-                  <br />
-                  If unsure, do check with the document issuer.
-                </OverlayContent>
-              </InfoOverlay>
-            </OverlayContextProvider>
+      <Page title="Verify Documents">
+        <div className="flex items-center">
+          <div className="text-gray-900 mr-3" data-testid="page-subtitle">
+            Verify your document on
           </div>
-          <DropZoneSectionContainer />
-        </Page>
-      ) : (
-        <ErrorPage
-          pageTitle="Unsupported Network"
-          header="You're currently on an unsupported network!"
-          description="Please change to a supported network at the top of the page and try again."
-          image="/static/images/errorpage/error-boundary.png"
-        >
-          <h3 className="font-normal my-2 sm:my-4 text-lg sm:text-2xl">
-            <Link className="text-cerulean-300" to="/verify" onClick={() => window.location.reload()}>
-              Try again
-            </Link>
-          </h3>
-        </ErrorPage>
-      )}
+          <NetworkSelect />
+          <OverlayContextProvider>
+            <InfoOverlay className="p-0 ml-3 cursor-pointer focus:outline-none">
+              <OverlayContent className="max-w-sm lg:max-w-md" title="Network Selector">
+                A document can only be successfully verified on the same network where the document was created in.
+                <br />
+                If unsure, do check with the document issuer.
+              </OverlayContent>
+            </InfoOverlay>
+          </OverlayContextProvider>
+        </div>
+        <DropZoneSectionContainer />
+      </Page>
     </>
   );
 };


### PR DESCRIPTION
## Summary
Refactor and clean up the provider context a little so that the components can use the provider via a state instead of every components using it calling a function to pull for the provider. Added `account` in the context too so that components don't have to await from signer through an useEffect all the time just to get address.

## Changes
- Replace `getProvider` with `provider` and `providerOrSigner` in provider context
- Add `account` in provider context
- Update components using the context

## Issues
- https://www.pivotaltracker.com/story/show/182347719
