### PR TITLE
feat: restore polygon option in network selection

### DIFF
--- a/src/config/chain-config.ts
+++ b/src/config/chain-config.ts
@@ -5,7 +5,7 @@ import { ChainId } from "../constants/chain-info";
  */
 export const MAIN_NETWORKS = [
   ChainId.Ethereum, //
-  // ChainId.Polygon,
+  ChainId.Polygon,
 ];
 
 /**
@@ -15,5 +15,5 @@ export const TEST_NETWORKS = [
   ChainId.Ropsten, //
   ChainId.Rinkeby,
   ChainId.Goerli,
-  // ChainId.PolygonMumbai,
+  ChainId.PolygonMumbai,
 ];


### PR DESCRIPTION
## Summary
IMDA has an upcoming newsletter and would now like to add back the Polygon option to the network selector. This PR reverts the revert in TradeTrust/tradetrust-website#541 to restore the Polygon option.

## Changes
- Revert the revert in TradeTrust/tradetrust-website#541 to restore the Polygon option

## Issues
* #506
* #541
* https://www.pivotaltracker.com/story/show/182241774

