### PR TITLE
refactor: error boundary

### DIFF
--- a/src/components/CertificateViewerErrorBoundary/CertificateViewerErrorBoundary.test.tsx
+++ b/src/components/CertificateViewerErrorBoundary/CertificateViewerErrorBoundary.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { Router } from "react-router-dom";
+import { createMemoryHistory } from "history";
+import { CERTIFICATE_VIEWER_ERROR_TYPE, getRetryLink } from "./CertificateViewerErrorBoundary";
+
+const MockRouter = ({ children }: { children: React.ReactNode }) => {
+  const history = createMemoryHistory();
+  return <Router history={history}>{children}</Router>;
+};
+
+describe("CertificateViewerErrorBoundary", () => {
+  it("should render home link correctly", () => {
+    const retryLink = getRetryLink({ errorType: CERTIFICATE_VIEWER_ERROR_TYPE.GENERIC, recover: () => {} });
+
+    render(<MockRouter>{retryLink}</MockRouter>);
+    expect(screen.getByText("Homepage")).toBeInTheDocument();
+  });
+
+  it("should render retry link for UNSUPPORTED_NETWORK correctly", () => {
+    const retryLink = getRetryLink({ errorType: CERTIFICATE_VIEWER_ERROR_TYPE.UNSUPPORTED_NETWORK, recover: () => {} });
+
+    render(<MockRouter>{retryLink}</MockRouter>);
+    expect(screen.getByText("OK, let's try again!")).toBeInTheDocument();
+  });
+});

--- a/src/components/CertificateViewerErrorBoundary/CertificateViewerErrorBoundary.tsx
+++ b/src/components/CertificateViewerErrorBoundary/CertificateViewerErrorBoundary.tsx
@@ -1,64 +1,89 @@
-import React, { PropsWithChildren } from "react";
+import React from "react";
 import { FunctionComponent } from "react";
-import { ErrorBoundary, ErrorBoundaryProps, ErrorBoundaryRenderer } from "../ErrorBoundary";
+import { ErrorBoundary, FallbackComponentType } from "../ErrorBoundary";
 import { getCurrentProvider, useProviderContext } from "../../common/contexts/provider";
 import { ErrorPage, ErrorPageProps } from "@govtechsg/tradetrust-ui-components";
 import { Link } from "react-router-dom";
 import { UnsupportedNetworkError } from "../../common/errors";
 
-type CertificateViewerErrorBoundaryProps = Omit<ErrorBoundaryProps, "renderer">;
-
-export const CertificateViewerErrorBoundary: FunctionComponent<CertificateViewerErrorBoundaryProps> = (props) => {
-  const { children, onRecover, onError } = props;
-
-  const { reloadNetwork } = useProviderContext();
-
-  const recoverHandler = async () => {
-    if (onRecover) await onRecover();
-    await reloadNetwork();
-  };
-
-  return (
-    <ErrorBoundary renderer={ErrorRenderer} onError={onError} onRecover={recoverHandler}>
-      {children}
-    </ErrorBoundary>
-  );
-};
-
-enum CertificateViewerErrorType {
-  Generic,
-  UnsupportedNetwork,
-  ContractRevert,
-  RPCCallException,
+export enum CERTIFICATE_VIEWER_ERROR_TYPE {
+  GENERIC,
+  UNSUPPORTED_NETWORK,
+  CONTRACT_REVERT,
+  RPC_CALL_EXCEPTION,
 }
+
+export const CERTIFICATE_VIEWER_ERROR_MESSAGES = {
+  [CERTIFICATE_VIEWER_ERROR_TYPE.GENERIC]: {
+    title: "Generic error",
+    heading: "Something Went Wrong",
+    description: "TradeTrust has encountered an issue.",
+  },
+  [CERTIFICATE_VIEWER_ERROR_TYPE.UNSUPPORTED_NETWORK]: {
+    title: "Unsupported network",
+    heading: "Whoops!",
+    description: "Try changing to a correct network for the document.",
+  },
+  [CERTIFICATE_VIEWER_ERROR_TYPE.CONTRACT_REVERT]: {
+    title: "Contract revert",
+    heading: "Whoops!",
+    description:
+      "There might be an issue with the network or contract. Make sure you on the correct network for the document.",
+  },
+  [CERTIFICATE_VIEWER_ERROR_TYPE.RPC_CALL_EXCEPTION]: {
+    title: "RPC call exception",
+    heading: "Whoops!",
+    description: "There might be an issue with the network.",
+  },
+};
 
 /**
  * Attempts to guess the type of error from the Error object.
  * @param error Error received from boundary
  */
-const getErrorType = (error: Error | undefined): CertificateViewerErrorType => {
+const getErrorType = (error?: Error): CERTIFICATE_VIEWER_ERROR_TYPE => {
   const provider = getCurrentProvider();
-  if (!provider || error instanceof UnsupportedNetworkError) return CertificateViewerErrorType.UnsupportedNetwork;
+  const errorMessage = error?.message;
 
-  const errMsg = error?.message;
-  if (!errMsg) return CertificateViewerErrorType.Generic;
-
-  if (errMsg.indexOf("call revert exception") > -1) {
-    return CertificateViewerErrorType.ContractRevert;
-  } else if (errMsg.indexOf("SERVER_ERROR") > -1) {
-    // RPC call may have returned an error. For eg, forbidden, bad request, etc.
-    return CertificateViewerErrorType.RPCCallException;
+  if (!errorMessage) {
+    return CERTIFICATE_VIEWER_ERROR_TYPE.GENERIC;
   }
 
-  return CertificateViewerErrorType.Generic;
+  switch (true) {
+    case !provider || error instanceof UnsupportedNetworkError:
+      return CERTIFICATE_VIEWER_ERROR_TYPE.UNSUPPORTED_NETWORK;
+    case errorMessage.includes("call revert exception"):
+      return CERTIFICATE_VIEWER_ERROR_TYPE.CONTRACT_REVERT;
+    case errorMessage.includes("SERVER_ERROR"):
+      return CERTIFICATE_VIEWER_ERROR_TYPE.RPC_CALL_EXCEPTION; // RPC call may have returned an error. For eg, forbidden, bad request, etc.
+    default:
+      return CERTIFICATE_VIEWER_ERROR_TYPE.GENERIC;
+  }
 };
 
-const ErrorRenderer: ErrorBoundaryRenderer = (props) => {
-  const { error, recover } = props;
+/**
+ * Get back retry link with recovery methods accordingly.
+ * @param errorType Error type guessed from Error object
+ * @param recover Recover method to retry
+ */
+export const getRetryLink = ({
+  errorType,
+  recover,
+}: {
+  errorType: CERTIFICATE_VIEWER_ERROR_TYPE;
+  recover: () => void;
+}): React.ReactNode => {
+  const linkHome = (
+    <h3 className="font-normal my-2 sm:my-4 text-lg sm:text-2xl">
+      Go to
+      <Link className="text-cerulean-300" to="/">
+        Homepage
+      </Link>
+      ?
+    </h3>
+  );
 
-  const errorType = getErrorType(error);
-
-  const retryErrorLink = (
+  const linkRecover = (
     <h3 className="font-normal my-2 sm:my-4 text-lg sm:text-xl">
       <Link to="#" onClick={recover}>
         {`OK, let's try again!`}
@@ -66,50 +91,82 @@ const ErrorRenderer: ErrorBoundaryRenderer = (props) => {
     </h3>
   );
 
-  // Default props for error page
-  let errorPageProps: PropsWithChildren<ErrorPageProps> = {
-    pageTitle: "ERROR",
-    header: "Something Went Wrong",
-    description: error?.message ? error.message : "TradeTrust has encountered an issue.",
-    image: "/static/images/errorpage/error-boundary.png",
-    children: (
-      <h3 className="font-normal my-2 sm:my-4 text-lg sm:text-2xl">
-        Go to
-        <Link className="text-cerulean-300" to="/">
-          {" "}
-          Homepage
-        </Link>
-        ?
-      </h3>
-    ),
-  };
-
   switch (errorType) {
-    case CertificateViewerErrorType.UnsupportedNetwork:
-      errorPageProps = {
-        ...errorPageProps,
-        pageTitle: "Whoops!",
-        header: "Unsupported Network",
-        description: "Try changing to a correct network for the document.",
-        children: retryErrorLink,
-      };
-      break;
-    case CertificateViewerErrorType.RPCCallException:
-    case CertificateViewerErrorType.ContractRevert:
-      errorPageProps = {
-        ...errorPageProps,
-        pageTitle: "Whoops!",
-        header: "Ouch! That didn't work!",
-        description:
-          "There might be an issue with the network or contract. Make sure you on the correct network for the document.",
-        children: retryErrorLink,
-      };
-      break;
-    case CertificateViewerErrorType.Generic:
+    case CERTIFICATE_VIEWER_ERROR_TYPE.UNSUPPORTED_NETWORK:
+      return linkRecover;
+    case CERTIFICATE_VIEWER_ERROR_TYPE.CONTRACT_REVERT:
+      return linkRecover;
+    case CERTIFICATE_VIEWER_ERROR_TYPE.RPC_CALL_EXCEPTION:
+      return linkRecover;
     default:
-    // Will use the default errorPageProps
+      return linkHome;
   }
+};
 
-  const { children: errorPageChildren, ...errorPageRestProps } = errorPageProps;
-  return <ErrorPage {...errorPageRestProps}>{errorPageChildren}</ErrorPage>;
+/**
+ * Get prepared props to be passed to ErrorPage component from tt-ui.
+ * @param errorType Error type guessed from Error object
+ */
+export const getErrorPageProps = ({ errorType }: { errorType: CERTIFICATE_VIEWER_ERROR_TYPE }): ErrorPageProps => {
+  switch (errorType) {
+    case CERTIFICATE_VIEWER_ERROR_TYPE.UNSUPPORTED_NETWORK:
+      return {
+        pageTitle: CERTIFICATE_VIEWER_ERROR_MESSAGES[CERTIFICATE_VIEWER_ERROR_TYPE.UNSUPPORTED_NETWORK].title,
+        header: CERTIFICATE_VIEWER_ERROR_MESSAGES[CERTIFICATE_VIEWER_ERROR_TYPE.UNSUPPORTED_NETWORK].heading,
+        description: CERTIFICATE_VIEWER_ERROR_MESSAGES[CERTIFICATE_VIEWER_ERROR_TYPE.UNSUPPORTED_NETWORK].description,
+        image: "/static/images/errorpage/error-boundary.png",
+      };
+    case CERTIFICATE_VIEWER_ERROR_TYPE.CONTRACT_REVERT:
+      return {
+        pageTitle: CERTIFICATE_VIEWER_ERROR_MESSAGES[CERTIFICATE_VIEWER_ERROR_TYPE.CONTRACT_REVERT].title,
+        header: CERTIFICATE_VIEWER_ERROR_MESSAGES[CERTIFICATE_VIEWER_ERROR_TYPE.CONTRACT_REVERT].heading,
+        description: CERTIFICATE_VIEWER_ERROR_MESSAGES[CERTIFICATE_VIEWER_ERROR_TYPE.CONTRACT_REVERT].description,
+        image: "/static/images/errorpage/error-boundary.png",
+      };
+    case CERTIFICATE_VIEWER_ERROR_TYPE.RPC_CALL_EXCEPTION:
+      return {
+        pageTitle: CERTIFICATE_VIEWER_ERROR_MESSAGES[CERTIFICATE_VIEWER_ERROR_TYPE.RPC_CALL_EXCEPTION].title,
+        header: CERTIFICATE_VIEWER_ERROR_MESSAGES[CERTIFICATE_VIEWER_ERROR_TYPE.RPC_CALL_EXCEPTION].heading,
+        description: CERTIFICATE_VIEWER_ERROR_MESSAGES[CERTIFICATE_VIEWER_ERROR_TYPE.RPC_CALL_EXCEPTION].description,
+        image: "/static/images/errorpage/error-boundary.png",
+      };
+    default:
+      return {
+        pageTitle: CERTIFICATE_VIEWER_ERROR_MESSAGES[CERTIFICATE_VIEWER_ERROR_TYPE.GENERIC].title,
+        header: CERTIFICATE_VIEWER_ERROR_MESSAGES[CERTIFICATE_VIEWER_ERROR_TYPE.GENERIC].heading,
+        description: CERTIFICATE_VIEWER_ERROR_MESSAGES[CERTIFICATE_VIEWER_ERROR_TYPE.GENERIC].description,
+        image: "/static/images/errorpage/error-boundary.png", // TODO: should make optional in tt-ui, defaults to this image
+      };
+  }
+};
+
+/**
+ * Fallback component to show when ErrorBoundary is triggered
+ */
+const ErrorComponent: FallbackComponentType = (props) => {
+  const { error, recover } = props;
+
+  const errorType = getErrorType(error);
+  const errorPageProps = getErrorPageProps({ errorType });
+  const retryLink = getRetryLink({ errorType, recover });
+
+  return <ErrorPage {...errorPageProps}>{retryLink}</ErrorPage>;
+};
+
+/**
+ * ErrorBoundary for CertificateViewer component
+ */
+export const CertificateViewerErrorBoundary: FunctionComponent = (props) => {
+  const { children } = props;
+
+  const { reloadNetwork } = useProviderContext();
+  const recoverHandler = async () => {
+    await reloadNetwork();
+  }; // TODO: depending on error type, should recover accordingly. currently only reloads network for all error cases other then CERTIFICATE_VIEWER_ERROR_TYPE.GENERIC
+
+  return (
+    <ErrorBoundary FallbackComponent={ErrorComponent} onRecover={recoverHandler}>
+      {children}
+    </ErrorBoundary>
+  );
 };

--- a/src/components/ErrorBoundary/ErrorBoundary.stories.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.stories.tsx
@@ -1,7 +1,7 @@
 import { createBrowserHistory } from "history";
 import React, { FunctionComponent } from "react";
 import { Router } from "react-router-dom";
-import { ErrorBoundary, ErrorBoundaryRenderer } from "./ErrorBoundary";
+import { ErrorBoundary } from "./ErrorBoundary";
 
 const history = createBrowserHistory();
 
@@ -19,12 +19,12 @@ const ErrorComponent: FunctionComponent = () => {
   );
 };
 
-const MockRenderer: ErrorBoundaryRenderer = () => <div>Error Renderer</div>;
+const MockFallbackComponent = () => <div>Fallback component</div>;
 
 export const Default = () => {
   return (
     <Router history={history}>
-      <ErrorBoundary renderer={MockRenderer}>
+      <ErrorBoundary FallbackComponent={MockFallbackComponent} onRecover={() => {}}>
         <ErrorComponent />
       </ErrorBoundary>
     </Router>

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -3,23 +3,23 @@ import { getLogger } from "../../utils/logger";
 
 const { stack } = getLogger("component:errorBoundary");
 
-interface ErrorBoundaryState {
-  hasError: boolean;
-  error?: Error;
-}
-
-export interface ErrorBoundaryRendererProps {
+export interface FallbackComponentProps {
   error?: Error;
   recover: () => void;
 }
 
+export type FallbackComponentType = FunctionComponent<FallbackComponentProps>;
+
 export interface ErrorBoundaryProps {
-  renderer: ErrorBoundaryRenderer;
-  onError?: (error: Error) => void;
-  onRecover?: () => void;
+  children?: React.ReactNode;
+  FallbackComponent: FallbackComponentType;
+  onRecover: () => void;
 }
 
-export type ErrorBoundaryRenderer = FunctionComponent<ErrorBoundaryRendererProps>;
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
@@ -33,8 +33,6 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   componentDidCatch(error: Error): void {
     stack(error);
-    const { onError } = this.props;
-    if (onError) onError(error);
   }
 
   componentDidMount(): void {
@@ -45,37 +43,38 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     window.removeEventListener("unhandledrejection", this.onUnhandledRejection);
   }
 
+  /**
+   * Global promise unhandled promise rejection to trigger error boundary
+   */
   onUnhandledRejection = (event: PromiseRejectionEvent): void => {
-    const { onError } = this.props;
     event.preventDefault();
     event.promise.catch(async (error) => {
-      stack(error);
-      this.setState(ErrorBoundary.getDerivedStateFromError(error), () => {
-        if (onError) onError(error);
-      });
+      this.setState(ErrorBoundary.getDerivedStateFromError(error));
     });
   };
 
+  /**
+   * Attempts to recover from error.
+   */
   recover = (): void => {
     const { onRecover } = this.props;
-    this.setState(
-      {
-        hasError: false,
-        error: undefined,
-      },
-      () => {
-        if (onRecover) onRecover();
-      }
-    );
+    onRecover();
+
+    this.setState({
+      hasError: false,
+      error: undefined,
+    });
   };
 
   render(): ReactNode {
-    const error = this.state.error;
-    const {
-      recover,
-      props: { renderer: ErrorRenderer },
-    } = this;
+    const { recover } = this;
+    const { hasError, error } = this.state;
+    const { children, FallbackComponent } = this.props;
 
-    return this.state.hasError ? <ErrorRenderer error={error} recover={recover} /> : this.props.children;
+    if (hasError) {
+      return <FallbackComponent error={error} recover={recover} />;
+    }
+
+    return children;
   }
 }

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -58,12 +58,16 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
    */
   recover = (): void => {
     const { onRecover } = this.props;
-    onRecover();
 
-    this.setState({
-      hasError: false,
-      error: undefined,
-    });
+    this.setState(
+      {
+        hasError: false,
+        error: undefined,
+      },
+      () => {
+        onRecover();
+      }
+    );
   };
 
   render(): ReactNode {


### PR DESCRIPTION
## Summary

Refactor error boundary before sentry tech spike

## Changes

- map messages to error
- rename vars
- add tests