### PR TITLE
fix: reset called twice

### DIFF
--- a/src/components/CertificateDropZone/CertificateDropZone.tsx
+++ b/src/components/CertificateDropZone/CertificateDropZone.tsx
@@ -45,9 +45,7 @@ export const CertificateDropZone: FunctionComponent<CertificateDropzoneProps> = 
 
   const onDrop = useCallback(
     (acceptedFiles: Blob[]) => {
-      acceptedFiles.forEach((file: any) => {
-        if (file && file.path === "certificate.svg") return; // to skip reading the image file for the demo certificate
-
+      acceptedFiles.forEach((file: Blob) => {
         const reader = new FileReader();
 
         reader.onabort = () => console.log("file reading was aborted");

--- a/src/components/CertificateViewer.tsx
+++ b/src/components/CertificateViewer.tsx
@@ -58,13 +58,15 @@ export const CertificateViewer: FunctionComponent<CertificateViewerProps> = ({ i
 
   const { currentChainId } = useProviderContext();
 
-  /* Update the certificate when network is changed unless it is Magic Demo as the network does not change for it (fixed at Ropsten).
+  /*  Update the certificate when network is changed UNLESS:
+  - it is Magic Demo certificate, as the network does not change for it (fixed at Ropsten).
+  - it is Sample certificate, as it is already updated when user changed network from network selector dropdown provided by website UI (not the metamask extension network selector)
    */
   useEffect(() => {
-    if (isMagicDemo) return;
+    if (isMagicDemo || isSampleDocument) return;
     resetCertificateData();
     dispatch(updateCertificate(certificateDoc));
-  }, [certificateDoc, currentChainId, dispatch, resetCertificateData, isMagicDemo]);
+  }, [certificateDoc, currentChainId, dispatch, resetCertificateData, isMagicDemo, isSampleDocument]);
 
   /*
   initialise the meta token information context when new tokenId


### PR DESCRIPTION
## Summary

Reset of document accidentally called for sample documents

## Changes

- additional check for sample, on top of magic demo condition

## Issues

https://github.com/TradeTrust/tradetrust-website/pull/592