### PR TITLE
fix: persona modal text overlap issue

### DIFF
--- a/src/components/HomePageContent/HowItWorksSection/Steps.tsx
+++ b/src/components/HomePageContent/HowItWorksSection/Steps.tsx
@@ -4,8 +4,8 @@ import { StepDetail, StepsProps, ContentType } from "./types";
 const Step: FunctionComponent<StepDetail> = (props) => {
   const { icon, title, description } = props;
   return (
-    <div className={`flex flex-row flex-none w-6/12 mt-8 justify-center lg:w-auto ${icon ? "" : "lg:ml-6"}`}>
-      <div className="flex flex-col max-w-[11.5rem] min-w-[11.5rem] justify-center">
+    <div className={`flex flex-row flex-none w-full xs:w-1/2 lg:w-auto mt-8 justify-center  ${icon ? "" : "lg:ml-8"}`}>
+      <div className="flex flex-col max-w-[11.5rem] min-w-[10rem] justify-center">
         {icon && (
           <div className="flex justify-center">
             <img className="max-h-10 h-10 max-w-[3rem]" src={icon} />
@@ -36,7 +36,7 @@ export const Steps: React.FunctionComponent<StepsProps> = ({ contentType, stepsD
       {contentType !== ContentType.BENEFIT && (
         <h3 className="hidden text-lemon-500 text-center mt-12 lg:inline">{contentType}</h3>
       )}
-      <div className="flex flex-wrap m-auto lg:px-16 2xl:px-0 items-start lg:w-full 2xl:max-w-7xl">
+      <div className="flex flex-wrap m-auto 2xl:px-0 items-start lg:w-full 2xl:max-w-7xl">
         {stepsDetails.map((stepDetail: StepDetail, index: number) => (
           <React.Fragment key={index}>
             <Step {...stepDetail} />

--- a/src/components/HomePageContent/HowItWorksSection/Steps.tsx
+++ b/src/components/HomePageContent/HowItWorksSection/Steps.tsx
@@ -4,7 +4,7 @@ import { ContentType, StepDetail, StepsProps } from "./types";
 const Step: FunctionComponent<StepDetail> = (props) => {
   const { icon, title, description } = props;
   return (
-    <div className={`flex flex-row flex-none w-full xs:w-6/12 lg:w-auto mt-8 justify-center  ${icon ? "" : "lg:ml-6"}`}>
+    <div className={`flex flex-row flex-none w-full xs:w-1/2 lg:w-auto mt-8 justify-center  ${icon ? "" : "lg:ml-6"}`}>
       <div className="flex flex-col max-w-[11.5rem] min-w-[11.5rem] justify-center">
         {icon && (
           <div className="flex justify-center">

--- a/src/components/HomePageContent/HowItWorksSection/Steps.tsx
+++ b/src/components/HomePageContent/HowItWorksSection/Steps.tsx
@@ -1,11 +1,11 @@
 import React, { FunctionComponent } from "react";
-import { StepDetail, StepsProps, ContentType } from "./types";
+import { ContentType, StepDetail, StepsProps } from "./types";
 
 const Step: FunctionComponent<StepDetail> = (props) => {
   const { icon, title, description } = props;
   return (
-    <div className={`flex flex-row flex-none w-full xs:w-1/2 lg:w-auto mt-8 justify-center  ${icon ? "" : "lg:ml-8"}`}>
-      <div className="flex flex-col max-w-[11.5rem] min-w-[10rem] justify-center">
+    <div className={`flex flex-row flex-none w-full xs:w-6/12 lg:w-auto mt-8 justify-center  ${icon ? "" : "lg:ml-6"}`}>
+      <div className="flex flex-col max-w-[11.5rem] min-w-[11.5rem] justify-center">
         {icon && (
           <div className="flex justify-center">
             <img className="max-h-10 h-10 max-w-[3rem]" src={icon} />
@@ -13,7 +13,7 @@ const Step: FunctionComponent<StepDetail> = (props) => {
         )}
         {title && <h5 className={`text-center ${icon ? "mt-4" : "mt-0"}`}>{title}</h5>}
         <h6
-          className={`font-normal text-center mt-2 px-4 lg:px-0 lg:-mx-6 ${
+          className={`font-normal text-center mt-2 px-4 lg:px-0 ${
             icon ? "font-gilroy-medium" : "font-ubuntu text-2xl"
           }`}
         >
@@ -36,7 +36,7 @@ export const Steps: React.FunctionComponent<StepsProps> = ({ contentType, stepsD
       {contentType !== ContentType.BENEFIT && (
         <h3 className="hidden text-lemon-500 text-center mt-12 lg:inline">{contentType}</h3>
       )}
-      <div className="flex flex-wrap m-auto 2xl:px-0 items-start lg:w-full 2xl:max-w-7xl">
+      <div className="flex flex-wrap lg:flex-nowrap m-auto lg:px-16 2xl:px-0 items-start lg:w-full 2xl:max-w-7xl">
         {stepsDetails.map((stepDetail: StepDetail, index: number) => (
           <React.Fragment key={index}>
             <Step {...stepDetail} />

--- a/src/tailwind.js
+++ b/src/tailwind.js
@@ -1,6 +1,7 @@
 const merge = require("lodash/merge");
 const commonUiConfig = require("@govtechsg/tradetrust-ui-components/build/tailwind"); //eslint-disable-line @typescript-eslint/no-var-requires
 const plugin = require("tailwindcss/plugin");
+const defaultTheme = require("tailwindcss/defaultTheme");
 
 const localConfig = {
   content: [
@@ -9,12 +10,8 @@ const localConfig = {
   ],
   theme: {
     screens: {
-      xs: "460px",
-      sm: "640px",
-      md: "768px",
-      lg: "1024px",
-      xl: "1280px",
-      "2xl": "1536px",
+      xs: "475px",
+      ...defaultTheme.screens,
     },
     backgroundImage: {
       "single-wave": "url('/static/images/home/mainBenefits/single-wave.png')",

--- a/src/tailwind.js
+++ b/src/tailwind.js
@@ -8,6 +8,14 @@ const localConfig = {
     "./node_modules/@govtechsg/tradetrust-ui-components/src/**/*.{ts,tsx,js,jsx}",
   ],
   theme: {
+    screens: {
+      xs: "460px",
+      sm: "640px",
+      md: "768px",
+      lg: "1024px",
+      xl: "1280px",
+      "2xl": "1536px",
+    },
     backgroundImage: {
       "single-wave": "url('/static/images/home/mainBenefits/single-wave.png')",
       "wave-lines-light": "url('/static/images/common/wave-lines-light.png')",


### PR DESCRIPTION
## Summary

Persona Modal text descriptions are overlapping on smaller screens. This PR is to fix this issue.

## Changes

- updated CSS to fix the overlapping text issue.

## Issues

https://www.pivotaltracker.com/n/projects/2424361/stories/182637320
