### PR TITLE
fix: FAQ ui word break for long long url text

### DIFF
--- a/src/components/FAQ/FaqContent.tsx
+++ b/src/components/FAQ/FaqContent.tsx
@@ -43,7 +43,7 @@ export const FaqContent: FunctionComponent<FAQ> = ({ faqType }) => {
             accordionIndex={index}
             setOpenIndex={setOpenIndex}
           >
-            <ReactMarkdown components={{ p: ({ ...props }) => <p className={"mb-4"} {...props} /> }}>
+            <ReactMarkdown components={{ p: ({ ...props }) => <p className={"mb-4 break-all"} {...props} /> }}>
               {faq.body}
             </ReactMarkdown>
           </AccordionItem>


### PR DESCRIPTION
## Summary

Fix a small UI bug where the url is too long and it exited the text box for FAQ page.

## Changes

- Added css wordbreak: break-all to make the word break into next line and stay within designated text box.

## Issues

no stories, jerry reviewed the recent FAQ story and feedback to me.