### PR TITLE
fix: signer was not passed during the issuance of document

### DIFF
--- a/src/components/Demo/DemoCreate/DemoCreateReview/index.tsx
+++ b/src/components/Demo/DemoCreate/DemoCreateReview/index.tsx
@@ -79,7 +79,7 @@ const DefaultReview = (data: Record<string, FormItemSchema>) => {
 export const DemoCreateReview: FunctionComponent = () => {
   const { setActiveStep } = useContext(DemoCreateContext);
   const { formValues } = useContext(DemoFormContext);
-  const { provider } = useProviderContext();
+  const { providerOrSigner } = useProviderContext();
   const wrapDocumentStatus = useSelector(getWrappedDocumentStatus);
   const issueDocumentStatus = useSelector(getIssuedDocumentStatus);
   const documentStoreAddress = useSelector(getDocumentStoreAddress);
@@ -103,13 +103,13 @@ export const DemoCreateReview: FunctionComponent = () => {
 
   useEffect(() => {
     if (wrapDocumentStatus !== null && wrapDocumentStatus === "success") {
-      dispatch(issuingDocument(provider));
+      dispatch(issuingDocument(providerOrSigner));
       gaEvent({
         action: GaAction.MAGIC_ISSUE,
         category: GaCategory.MAGIC_DEMO,
       });
     }
-  }, [wrapDocumentStatus, dispatch, provider]);
+  }, [wrapDocumentStatus, dispatch, providerOrSigner]);
 
   useEffect(() => {
     if (issueDocumentStatus !== null && issueDocumentStatus !== "pending") {


### PR DESCRIPTION
## Summary

What is the background of this pull request?
Due to the refactoring done in https://github.com/TradeTrust/tradetrust-website/pull/578 , 1 instance of the magic signer was mislabelled to be a provider instead, which eventually led to a transaction failing because it was trying to sign a transaction with a provider instead.

## Changes
- replaced the provider instance with the signer instance instead.

