### PR TITLE
feat: action switch network

### DIFF
--- a/src/common/hooks/useNetworkSelect.tsx
+++ b/src/common/hooks/useNetworkSelect.tsx
@@ -1,0 +1,33 @@
+import React, { useCallback, useContext } from "react";
+import { useProviderContext } from "../contexts/provider";
+import { OverlayContext, showDocumentTransferMessage } from "@govtechsg/tradetrust-ui-components";
+import { LoadingModal } from "../../components/UI/Overlay";
+import { ChainId } from "../../constants/chain-info";
+
+interface useNetworkSelectProps {
+  switchNetwork: (chainId: ChainId) => void;
+}
+
+export const useNetworkSelect = (): useNetworkSelectProps => {
+  const { changeNetwork } = useProviderContext();
+  const { showOverlay, closeOverlay } = useContext(OverlayContext);
+
+  const switchNetwork = useCallback(
+    async (chainId: ChainId) => {
+      try {
+        showOverlay(<LoadingModal title={"Changing Network..."} content={"Please respond to the metamask window"} />);
+        await changeNetwork(chainId);
+        closeOverlay();
+      } catch (e: any) {
+        showOverlay(
+          showDocumentTransferMessage("You've cancelled changing network.", {
+            isSuccess: false,
+          })
+        );
+      }
+    },
+    [changeNetwork, closeOverlay, showOverlay]
+  );
+
+  return { switchNetwork };
+};

--- a/src/components/HomePageContent/HomePageContainer.tsx
+++ b/src/components/HomePageContent/HomePageContainer.tsx
@@ -1,28 +1,74 @@
 import React from "react";
-import queryString from "query-string";
 import { useLocation } from "react-router-dom";
+import { CONSTANTS } from "@govtechsg/tradetrust-utils";
 import {
-  resetCertificateState,
+  updateCertificate,
   retrieveCertificateByAction,
   retrieveCertificateByActionFailure,
-  updateCertificate,
 } from "../../reducers/certificate";
 import { useDispatch } from "react-redux";
 import { useHistory } from "react-router";
 import { NestedDocumentState } from "../../constants/NestedDocumentState";
 import { getLogger } from "../../utils/logger";
-
 import { WelcomeSection } from "./WelcomeSection";
 import { MainBenefitsSection } from "./MainBenefitsSection";
 import { HowItWorksSection } from "./HowItWorksSection";
+import { useNetworkSelect } from "../../common/hooks/useNetworkSelect";
+import { ChainId } from "../../constants/chain-info";
 
 const { error } = getLogger("component:mainpage");
+const { TYPES, MESSAGES } = CONSTANTS;
+
+interface Payload {
+  uri: string;
+  permittedActions: string[];
+  redirect: string;
+  key?: string;
+  chainId?: ChainId;
+}
+
+interface Action {
+  type: "DOCUMENT";
+  payload: Payload;
+}
 
 export const HomePageContainer = (): React.ReactElement => {
   const location = useLocation();
   const history = useHistory();
   const dispatch = useDispatch();
+  const { switchNetwork } = useNetworkSelect();
   const loadCertificate = React.useCallback((payload: any) => dispatch(updateCertificate(payload)), [dispatch]);
+
+  React.useEffect(() => {
+    const { search, hash } = location;
+    const params = new URLSearchParams(search);
+    const query = params.get("q");
+
+    const setProviderNetworkToMatch = async (chainId: ChainId, payload: Payload, anchor: string) => {
+      await switchNetwork(chainId);
+      dispatch(retrieveCertificateByAction(payload, anchor));
+    };
+
+    if (query) {
+      const action: Action = JSON.parse(query);
+      const { type, payload } = action;
+      const { chainId } = payload;
+
+      const anchorStr = decodeURIComponent(hash.substr(1));
+      const anchor = anchorStr ? JSON.parse(anchorStr) : {}; // https://github.com/TradeTrust/tradetrust-website/pull/397
+
+      if (type !== "DOCUMENT") {
+        dispatch(retrieveCertificateByActionFailure(`The type ${type} provided from the action is not supported`));
+      } else if (chainId === undefined) {
+        dispatch(retrieveCertificateByActionFailure(MESSAGES[TYPES.NETWORK_INVALID].failureMessage));
+      } else {
+        setProviderNetworkToMatch(chainId, payload, anchor);
+      }
+
+      history.push("/verify");
+    }
+  }, [dispatch, history, location, switchNetwork]);
+
   // event listener for any custom postMessage
   window.addEventListener("message", (event) => {
     if (event.data.type === NestedDocumentState.LOAD) {
@@ -35,23 +81,7 @@ export const HomePageContainer = (): React.ReactElement => {
       }
     }
   });
-  React.useEffect(() => {
-    if (location.search !== "") {
-      const queryParams = queryString.parse(location.search);
-      const anchorStr = decodeURIComponent(location.hash.substr(1));
-      const anchor = anchorStr ? JSON.parse(anchorStr) : {};
-      dispatch(resetCertificateState());
-      const action = JSON.parse(queryParams.q as string);
-      if (action.type === "DOCUMENT") {
-        dispatch(retrieveCertificateByAction(action.payload, anchor));
-      } else {
-        dispatch(
-          retrieveCertificateByActionFailure(`The type ${action.type} provided from the action is not supported`)
-        );
-      }
-      history.push("/verify");
-    }
-  }, [dispatch, location, history]);
+
   return (
     <div className="text-lg">
       <WelcomeSection />

--- a/src/components/HomePageContent/HomePageContainer.tsx
+++ b/src/components/HomePageContent/HomePageContainer.tsx
@@ -15,21 +15,14 @@ import { MainBenefitsSection } from "./MainBenefitsSection";
 import { HowItWorksSection } from "./HowItWorksSection";
 import { useNetworkSelect } from "../../common/hooks/useNetworkSelect";
 import { ChainId } from "../../constants/chain-info";
+import { ActionType, ActionPayload } from "../../types";
 
 const { error } = getLogger("component:mainpage");
 const { TYPES, MESSAGES } = CONSTANTS;
 
-interface Payload {
-  uri: string;
-  permittedActions: string[];
-  redirect: string;
-  key?: string;
-  chainId?: ChainId;
-}
-
 interface Action {
-  type: "DOCUMENT";
-  payload: Payload;
+  type: ActionType;
+  payload: ActionPayload;
 }
 
 export const HomePageContainer = (): React.ReactElement => {
@@ -44,13 +37,13 @@ export const HomePageContainer = (): React.ReactElement => {
     const params = new URLSearchParams(search);
     const query = params.get("q");
 
-    const setProviderNetworkToMatch = async (chainId: ChainId, payload: Payload, anchor: string) => {
+    const setProviderNetworkToMatch = async (chainId: ChainId, payload: ActionPayload, anchor: string) => {
       await switchNetwork(chainId);
       dispatch(retrieveCertificateByAction(payload, anchor));
     };
 
     if (query) {
-      const action: Action = JSON.parse(query);
+      const action = JSON.parse(query) as Action;
       const { type, payload } = action;
       const { chainId } = payload;
 

--- a/src/components/Layout/NetworkSelect/NetworkSelect.tsx
+++ b/src/components/Layout/NetworkSelect/NetworkSelect.tsx
@@ -1,19 +1,12 @@
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownProps,
-  OverlayContext,
-  showDocumentTransferMessage,
-  IconError,
-} from "@govtechsg/tradetrust-ui-components";
-import React, { FunctionComponent, useContext } from "react";
+import { Dropdown, DropdownItem, DropdownProps, IconError } from "@govtechsg/tradetrust-ui-components";
+import React, { FunctionComponent } from "react";
 import { ChainId, ChainInfoObject } from "../../../constants/chain-info";
 import { useProviderContext } from "../../../common/contexts/provider";
 import { getChainInfo } from "../../../common/utils/chain-utils";
-import { LoadingModal } from "../../UI/Overlay";
+import { useNetworkSelect } from "../../../common/hooks/useNetworkSelect";
 
 interface NetworkSelectViewProps {
-  onChange: (network: ChainInfoObject) => void;
+  onChange: (chainId: ChainId) => void;
   currentChainId: ChainId | undefined;
   networks: ChainInfoObject[];
 }
@@ -86,7 +79,7 @@ const NetworkSelectView: FunctionComponent<NetworkSelectViewProps> = ({ onChange
         network={network}
         active={network.chainId === currentChainId}
         onClick={() => {
-          if (onChange) onChange(network);
+          if (onChange) onChange(network.chainId);
         }}
       />
     );
@@ -121,25 +114,11 @@ const NetworkSelectView: FunctionComponent<NetworkSelectViewProps> = ({ onChange
 };
 
 export const NetworkSelect: FunctionComponent = () => {
-  const { changeNetwork, supportedChainInfoObjects, currentChainId } = useProviderContext();
-  const { showOverlay, setOverlayVisible } = useContext(OverlayContext);
-  const closeOverlay = () => {
-    showOverlay(undefined);
-    setOverlayVisible(false);
-  };
+  const { supportedChainInfoObjects, currentChainId } = useProviderContext();
+  const { switchNetwork } = useNetworkSelect();
 
-  const changeHandler = async (network: ChainInfoObject) => {
-    try {
-      showOverlay(<LoadingModal title={"Changing Network..."} content={"Please respond to the metamask window"} />);
-      await changeNetwork(network.chainId);
-      closeOverlay();
-    } catch (e: any) {
-      showOverlay(
-        showDocumentTransferMessage("You've cancelled changing network.", {
-          isSuccess: false,
-        })
-      );
-    }
+  const changeHandler = async (chainId: ChainId) => {
+    await switchNetwork(chainId);
   };
 
   return (

--- a/src/sagas/certificate.ts
+++ b/src/sagas/certificate.ts
@@ -13,6 +13,7 @@ import { decryptString } from "@govtechsg/oa-encryption";
 import { NETWORK_NAME } from "../config";
 import { history } from "../history";
 import { CONSTANTS } from "@govtechsg/tradetrust-utils";
+import { ActionPayload } from "./../types";
 
 const { trace } = getLogger("saga:certificate");
 
@@ -52,20 +53,21 @@ export function* handleQrScanned({ payload: qrCode }: { type: string; payload: a
   }
 }
 
-export function* retrieveCertificateByAction({
-  payload: { uri, key: payloadKey },
-  anchor: { key: anchorKey },
-}: {
+interface RetrieveCertificateByAction {
   type: string;
-  payload: { uri: any; key: any };
-  anchor: { key: any };
-}): any {
+  payload: ActionPayload;
+  anchor: { key: string };
+}
+
+export function* retrieveCertificateByAction({ payload, anchor }: RetrieveCertificateByAction): any {
   try {
     yield put({
       type: types.RETRIEVE_CERTIFICATE_BY_ACTION_PENDING,
     });
 
-    const key = anchorKey || payloadKey;
+    const { uri, key: payloadKey } = payload;
+    const { key: anchorKey } = anchor;
+    const key = anchorKey || payloadKey; // https://github.com/TradeTrust/tradetrust-website/pull/397
 
     // if a key has been provided, let's assume
     let certificate = yield window.fetch(uri).then((response) => {

--- a/src/test/load-action-certificate.spec.ts
+++ b/src/test/load-action-certificate.spec.ts
@@ -13,6 +13,7 @@ test("Load document from action should work when url is valid", async (t) => {
       uri: `https://raw.githubusercontent.com/Open-Attestation/gallery/master/static/documents/tradetrust/v2/ebl-ropsten.tt`,
       permittedActions: ["VIEW"],
       redirect: "https://dev.tradetrust.io",
+      chainId: 3,
     },
   };
   await t.navigateTo(`${location}/?q=${encodeURI(JSON.stringify(action))}`);
@@ -27,6 +28,7 @@ test("Load document from action should fail when url is invalid", async (t) => {
     payload: {
       uri: `https://raw.githubusercontent.com/Open-Attestation/gallery/master/static/documents/123.tt`,
       redirect: "https://dev.tradetrust.io",
+      chainId: 3,
     },
   };
 
@@ -37,5 +39,24 @@ test("Load document from action should fail when url is invalid", async (t) => {
     "This document is not valid",
     "Unable to load certificate with the provided parameters",
     "Unable to load the certificate from https://raw.githubusercontent.com/Open-Attestation/gallery/master/static/documents/123.tt",
+  ]);
+});
+
+test("Load document from action should fail when chainId not exists", async (t) => {
+  const action = {
+    type: "DOCUMENT",
+    payload: {
+      uri: `https://raw.githubusercontent.com/Open-Attestation/gallery/master/static/documents/tradetrust/v2/ebl-ropsten.tt`,
+      redirect: "https://dev.tradetrust.io",
+    },
+  };
+
+  await t.navigateTo(`${location}/?q=${encodeURI(JSON.stringify(action))}`);
+
+  await DocumentStatus.with({ visibilityCheck: false })();
+  await validateTextContent(t, CertificateDropzone, [
+    "This document is not valid",
+    "Unable to load certificate with the provided parameters",
+    "This document has an invalid network field. Please contact your issuing authority for help or re-issue the document with a valid network field before trying again.",
   ]);
 });

--- a/src/types/index.tsx
+++ b/src/types/index.tsx
@@ -1,4 +1,6 @@
 import { HostActions } from "@govtechsg/decentralized-renderer-react-components";
+import { ChainId } from "./../constants/chain-info";
+
 export interface TemplateProps {
   id: string;
   label: string;
@@ -43,3 +45,13 @@ export enum GaAction {
 export enum GaCategory {
   MAGIC_DEMO = "magic_demo",
 }
+
+export interface ActionPayload {
+  uri: string;
+  permittedActions: string[];
+  redirect: string;
+  key?: string;
+  chainId?: ChainId;
+}
+
+export type ActionType = "DOCUMENT";


### PR DESCRIPTION
## Summary

- if user is on rinkeby network, ropsten document from oa gallery will not verify

## Changes

- refactor `changeNetwork` into custom hook
- handle switch network from `action` flow

## Issues

- https://github.com/Open-Attestation/gallery/pull/85
- https://www.pivotaltracker.com/story/show/183008769