### PR TITLE
fix: adds secure-headers as requested

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,3 +20,9 @@
 [context.deploy-preview]
   [context.deploy-preview.environment]
     INFURA_API_KEY = ""
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Content-Type-Options = "nosniff"
+    X-XSS-Protection = "1; mode=block" 


### PR DESCRIPTION
## Summary

What is the background of this pull request?
adds secure-headers as requested, although this skips Public Key Pinning Extension for HTTP as it seems to be obsolete. 
[here](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning)
also, X-XSS Protection is apparently non-standard, but we just add it for the heck of it.

Adding the CSP headers will completely break the app as there are tricky interdependencies regarding all our external sources and internal source. ie 
1) webpack outputting inline-evaluation which csp disallows (the fix brings about another set of problems, not trivial to handle), 
2) vendor chunk/modules utilise inline-src for their styles which again csp disallows 
3) font-awesome kit will call a subresource which then would be flagged out. 
4) probably other resources as well but I was not able to even get to the places where the other resources were called.

If anyone wants to have a stab at it feel free to do so.
Have opened an issue about it.
https://github.com/TradeTrust/tradetrust-website/issues/625#issue-1391869811

https://www.pivotaltracker.com/story/show/183411338
