### PR TITLE
fix: faq content not breaking appropriately

### DIFF
--- a/src/components/FAQ/FaqContent.tsx
+++ b/src/components/FAQ/FaqContent.tsx
@@ -43,7 +43,7 @@ export const FaqContent: FunctionComponent<FAQ> = ({ faqType }) => {
             accordionIndex={index}
             setOpenIndex={setOpenIndex}
           >
-            <ReactMarkdown components={{ p: ({ ...props }) => <p className={"mb-4 break-all"} {...props} /> }}>
+            <ReactMarkdown components={{ p: ({ ...props }) => <p className={"mb-4 break-word"} {...props} /> }}>
               {faq.body}
             </ReactMarkdown>
           </AccordionItem>


### PR DESCRIPTION
## Summary

What is the background of this pull request?
This fixes the problem of the content not reflowing properly.
https://www.pivotaltracker.com/story/show/183406790

## Changes
- changes the css from "break-all" to "break-word"
