### PR TITLE
fix: action workflows

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,9 +1,10 @@
 name: Lighthouse Report
 
-on: [pull_request]
+on: [push]
 
 jobs:
   lhci:
+    if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
     name: Lighthouse
     runs-on: ubuntu-latest
     steps:
@@ -21,6 +22,7 @@ jobs:
           npm install -g @lhci/cli@0.10.x
           lhci autorun
       - name: upload artifacts
+        if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: Lighthouse reports

--- a/.github/workflows/synpress.yml
+++ b/.github/workflows/synpress.yml
@@ -1,0 +1,27 @@
+name: Synpress
+
+on: [push]
+
+jobs:
+  e2e:
+    if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
+    # https://github.com/drptbl/synpress-setup-example/blob/1d980157ef343de54f786e1115e1da590f1ba1d1/.github/workflows/e2e.yml#L49-L102
+    name: Synpress Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # pin@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # pin@v1
+      - name: Cache Docker layers
+        uses: actions/cache@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1 # pin@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Run e2e tests
+        run: docker-compose up --build --exit-code-from synpress
+

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -11,25 +11,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "14"
-      - name: Cache Node Modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
-        with:
-          # npm cache files are stored in `~/.npm` on Linux/macOS
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: Install Packages
-        # there's a problem with ganache-core using a very old version of ethereumjs-abi which fails on git checkout with ssh reasons
-        run: |
-          git config --global url."https://".insteadOf git://
-          git config --global url."https://".insteadOf git+https://
-          git config --global url."https://".insteadOf ssh://git
-          npm ci
+        run: npm ci
       - name: Check Lint
         run: npm run lint
       - name: Test

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -32,25 +32,3 @@ jobs:
           path: artifacts
           if-no-files-found: ignore
           retention-days: 1
-  synpress-e2e:
-    if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
-    # https://github.com/drptbl/synpress-setup-example/blob/1d980157ef343de54f786e1115e1da590f1ba1d1/.github/workflows/e2e.yml#L49-L102
-    name: Synpress e2e test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v2
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@8b122486cedac8393e77aa9734c3528886e4a1a8 # pin@v1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # pin@v1
-      - name: Cache Docker layers
-        uses: actions/cache@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1 # pin@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Run e2e tests
-        run: docker-compose up --build --exit-code-from synpress
-

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -41,14 +41,14 @@ jobs:
         id: testcafe
         if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
         run: npm run integration:headless:prod
-      - name: 'Upload Artifact'
+      - name: Upload Artifact
         if: ${{ failure() && steps.testcafe.outcome == 'failure' }}
         uses: actions/upload-artifact@v3
         with:
           name: testcafe-fail-screenshots
           path: artifacts
           if-no-files-found: ignore
-          retention-days: 5
+          retention-days: 1
   synpress-e2e:
     if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
     # https://github.com/drptbl/synpress-setup-example/blob/1d980157ef343de54f786e1115e1da590f1ba1d1/.github/workflows/e2e.yml#L49-L102


### PR DESCRIPTION
## Summary

To skip lighthouse checks too when cms edits. upload artifacts only when necessary and keep to 1 day.

## Changes

- move out synpress file to its own, no change to its pipeline.
- use `push` instead to access `github.event.head_commit.message` for lighthouse pipeline, only upload artifacts if lighthouse fail threshold.
- probably [not recommend](https://github.com/actions/cache/blob/main/examples.md#node---npm) to cache node modules.
