### PR TITLE
chore: ui fixes

### DIFF
--- a/src/components/FAQ/FaqContent.tsx
+++ b/src/components/FAQ/FaqContent.tsx
@@ -43,13 +43,11 @@ export const FaqContent: FunctionComponent<FAQ> = ({ faqType }) => {
             accordionIndex={index}
             setOpenIndex={setOpenIndex}
           >
-            <ReactMarkdown components={{ p: ({ ...props }) => <p className={"mb-4 break-word"} {...props} /> }}>
-              {faq.body}
-            </ReactMarkdown>
+            <ReactMarkdown className="wysiwyg">{faq.body}</ReactMarkdown>
           </AccordionItem>
         ))}
       </div>
-      <div className="mx-auto w-1/2 lg:w-1/3  hidden lg:block">
+      <div className="w-1/3 hidden lg:block">
         <img src="/static/images/faq/faq-person.png" alt="FAQ person" />
       </div>
     </div>

--- a/src/components/Guidelines/GuidelinesContent.tsx
+++ b/src/components/Guidelines/GuidelinesContent.tsx
@@ -19,28 +19,23 @@ export const GuidelinesContent: FunctionComponent = () => {
 
   return (
     <div className="flex flex-wrap mt-4">
-      <div className="w-full h-full lg:w-2/3 bg-white rounded-xl shadow-lg py-4">
-        <div className="border-b border-cloud-300 border-solid mx-4" />
+      <div className="w-full lg:w-2/3">
         {guidelines.map((guideline, index) => (
           <AccordionItem
             key={`guideline-${index}`}
-            classNameContainer="mb-2"
-            classNameCollapse="rounded p-4 "
-            classNameContent="px-4 pb-4"
-            headingTag="h3"
+            classNameContainer="bg-white mb-2"
+            classNameCollapse="rounded p-4"
+            classNameContent="pl-4 pr-16 pb-4"
             heading={guideline.attributes.title}
-            divider
             openIndex={openIndex}
             accordionIndex={index}
             setOpenIndex={setOpenIndex}
           >
-            <ReactMarkdown components={{ p: ({ ...props }) => <p className={"mb-4"} {...props} /> }}>
-              {guideline.body}
-            </ReactMarkdown>
+            <ReactMarkdown className="wysiwyg">{guideline.body}</ReactMarkdown>
           </AccordionItem>
         ))}
       </div>
-      <div className="my-12 lg:my-8 w-full lg:w-1/3 hidden lg:block">
+      <div className="w-1/3 hidden lg:block">
         <img className="mx-auto" src="/static/images/guidelines/Guidelines.png" alt="Guidelines person" />
       </div>
     </div>

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -227,15 +227,20 @@
 
   .wysiwyg p,
   .wysiwyg h3 {
-    margin-top: 1rem;
-    margin-bottom: 1rem;
+    @apply my-4;
     @apply text-cloud-800;
+    @apply break-words;
   }
 
   .wysiwyg a {
-    word-break: break-word;
+    @apply break-words;
     @apply text-cerulean-300;
     @apply hover:text-cerulean-500;
+  }
+
+  .wysiwyg ol,
+  .wysiwyg ul {
+    @apply pl-8;
   }
 
   @media print {


### PR DESCRIPTION
## Summary

When editing `guidelines` in CMS, ordered and unordered list appears flushed left.

## Changes

- any body markdown should have `.wysiwyg` css class
- guidelines page accordion styling to follow the same as faq page

## Issues

https://www.pivotaltracker.com/story/show/184744529
