### PR TITLE
fix: bump synpress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@adraffy/ens-normalize": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
+      "integrity": "sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ=="
+    },
     "@babel/code-frame": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
@@ -118,11 +123,6 @@
         "resolve": "^1.14.2",
         "semver": "^6.1.2"
       }
-    },
-    "@babel/helper-environment-visitor": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.15.4",
@@ -1424,62 +1424,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@chainlink/contracts-0.0.10": {
-      "version": "npm:@chainlink/contracts@0.0.10",
-      "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
-      "integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
-      "requires": {
-        "@truffle/contract": "^4.2.6",
-        "ethers": "^4.0.45"
-      },
-      "dependencies": {
-        "ethers": {
-          "version": "4.0.49",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.49.tgz",
-          "integrity": "sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==",
-          "optional": true,
-          "requires": {
-            "aes-js": "3.0.0",
-            "bn.js": "^4.11.9",
-            "elliptic": "6.5.4",
-            "hash.js": "1.1.3",
-            "js-sha3": "0.5.7",
-            "scrypt-js": "2.0.4",
-            "setimmediate": "1.0.4",
-            "uuid": "2.0.1",
-            "xmlhttprequest": "1.8.0"
-          }
-        },
-        "hash.js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "optional": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
-          }
-        },
-        "scrypt-js": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
-          "optional": true
-        },
-        "setimmediate": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha512-/TjEmXQVEzdod/FFskf3o7oOAsGhHf2j1dZqRFbDzq4F3mvvxflIIi4Hd3bLQE9y/CpwqfSQam5JakI/mi3Pog==",
-          "optional": true
-        },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha512-nWg9+Oa3qD2CQzHIP4qKUqwNfzKn8P0LtFhotaCTFchsV7ZfDhAybeip/HZVeMIpZi9JgY1E3nUlwaCmZT1sEg==",
-          "optional": true
-        }
-      }
-    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -1491,9 +1435,9 @@
       }
     },
     "@cypress/code-coverage": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@cypress/code-coverage/-/code-coverage-3.10.0.tgz",
-      "integrity": "sha512-K5pW2KPpK4vKMXqxd6vuzo6m9BNgpAv1LcrrtmqAtOJ1RGoEILXYZVost0L6Q+V01NyY7n7jXIIfS7LR3nP6YA==",
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/@cypress/code-coverage/-/code-coverage-3.10.4.tgz",
+      "integrity": "sha512-FTB6ftXjO87KlqXiR/55UaniXwPia6+CcaO7I6aZDbB9u7Zz2InBx5iakpKB28CJoqmk1sywblOP57QHd6weLQ==",
       "requires": {
         "@cypress/webpack-preprocessor": "^5.11.0",
         "chalk": "4.1.2",
@@ -1502,7 +1446,7 @@
         "execa": "4.1.0",
         "globby": "11.0.4",
         "istanbul-lib-coverage": "3.0.0",
-        "js-yaml": "3.14.1",
+        "js-yaml": "4.1.0",
         "nyc": "15.1.0"
       },
       "dependencies": {
@@ -1513,6 +1457,11 @@
           "requires": {
             "color-convert": "^2.0.1"
           }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
         "chalk": {
           "version": "4.1.2",
@@ -1590,6 +1539,14 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
           "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
         },
         "ms": {
           "version": "2.1.2",
@@ -1682,9 +1639,9 @@
       }
     },
     "@cypress/webpack-dev-server": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@cypress/webpack-dev-server/-/webpack-dev-server-3.2.3.tgz",
-      "integrity": "sha512-59+567BQRO7kXEVz64vzbEv/9I53Tp7K+CUBd492wYZNrhjY8iDtWNmG4l5LX0ibtHmeG46rBCbd8PTViLD8Fg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@cypress/webpack-dev-server/-/webpack-dev-server-3.4.1.tgz",
+      "integrity": "sha512-S6IUklDXIkcajtkjtLZz8nzVMuG/kjEKnRVkAiIyJL3EZ+EHcXgrUQegfRb15poFlk4SZ/AMLRMqLSB6KCCxkg==",
       "requires": {
         "find-up": "6.3.0",
         "fs-extra": "9.1.0",
@@ -1697,11 +1654,6 @@
         "webpack-merge": "^5.4.0"
       },
       "dependencies": {
-        "@types/html-minifier-terser": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
-          "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg=="
-        },
         "accepts": {
           "version": "1.3.8",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1788,9 +1740,9 @@
           }
         },
         "colorette": {
-          "version": "2.0.19",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-          "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
+          "version": "2.0.20",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+          "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
         },
         "commander": {
           "version": "8.3.0",
@@ -1918,30 +1870,67 @@
           "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
           "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA=="
         },
-        "html-minifier-terser": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
-          "integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
+        "html-webpack-plugin-4": {
+          "version": "npm:html-webpack-plugin@4.5.2",
+          "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz",
+          "integrity": "sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==",
           "requires": {
-            "camel-case": "^4.1.2",
-            "clean-css": "^5.2.2",
-            "commander": "^8.3.0",
-            "he": "^1.2.0",
-            "param-case": "^3.0.4",
-            "relateurl": "^0.2.7",
-            "terser": "^5.10.0"
+            "@types/html-minifier-terser": "^5.0.0",
+            "@types/tapable": "^1.0.5",
+            "@types/webpack": "^4.41.8",
+            "html-minifier-terser": "^5.0.1",
+            "loader-utils": "^1.2.3",
+            "lodash": "^4.17.20",
+            "pretty-error": "^2.1.1",
+            "tapable": "^1.1.3",
+            "util.promisify": "1.0.0"
           }
         },
         "html-webpack-plugin-5": {
-          "version": "npm:html-webpack-plugin@5.5.0",
-          "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
-          "integrity": "sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==",
+          "version": "npm:html-webpack-plugin@5.5.1",
+          "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.1.tgz",
+          "integrity": "sha512-cTUzZ1+NqjGEKjmVgZKLMdiFg3m9MdRXkZW2OEe69WYVi5ONLMmlnSZdXzGGMOq0C8jGDrL6EWyEDDUioHO/pA==",
           "requires": {
             "@types/html-minifier-terser": "^6.0.0",
             "html-minifier-terser": "^6.0.2",
             "lodash": "^4.17.21",
             "pretty-error": "^4.0.0",
             "tapable": "^2.0.0"
+          },
+          "dependencies": {
+            "@types/html-minifier-terser": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+              "integrity": "sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg=="
+            },
+            "html-minifier-terser": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
+              "integrity": "sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==",
+              "requires": {
+                "camel-case": "^4.1.2",
+                "clean-css": "^5.2.2",
+                "commander": "^8.3.0",
+                "he": "^1.2.0",
+                "param-case": "^3.0.4",
+                "relateurl": "^0.2.7",
+                "terser": "^5.10.0"
+              }
+            },
+            "pretty-error": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
+              "integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
+              "requires": {
+                "lodash": "^4.17.20",
+                "renderkid": "^3.0.0"
+              }
+            },
+            "tapable": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+              "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+            }
           }
         },
         "http-errors": {
@@ -1991,18 +1980,36 @@
             "is-docker": "^2.0.0"
           }
         },
+        "json5": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
         "locate-path": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.1.1.tgz",
-          "integrity": "sha512-vJXaRMJgRVD3+cUZs3Mncj2mxpt5mP0EmNOsxRSZRMlbqjvxzDEOIUWXGmavo0ZC9+tNZCBLQ66reA11nbpHZg==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+          "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
           "requires": {
             "p-locate": "^6.0.0"
           }
         },
         "memfs": {
-          "version": "3.4.13",
-          "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.13.tgz",
-          "integrity": "sha512-omTM41g3Skpvx5dSYeZIbXKcXoAVc/AoMNwn9TKx++L/gaen/+4TTttmu8ZSch5vfVJ8uJvGbroTsIlslRg6lg==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.0.tgz",
+          "integrity": "sha512-yK6o8xVJlQerz57kvPROwTMgx5WtGwC2ZxDtOUsnGl49rHjYkfQoPNZPCKH73VdLE1BwBu/+Fx/NL8NYMUw2aA==",
           "requires": {
             "fs-monkey": "^1.0.3"
           }
@@ -2039,9 +2046,9 @@
           }
         },
         "open": {
-          "version": "8.4.0",
-          "resolved": "https://registry.npmjs.org/open/-/open-8.4.0.tgz",
-          "integrity": "sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==",
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+          "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
           "requires": {
             "define-lazy-prop": "^2.0.0",
             "is-docker": "^2.1.1",
@@ -2082,15 +2089,6 @@
           "version": "0.1.7",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
-        },
-        "pretty-error": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
-          "integrity": "sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==",
-          "requires": {
-            "lodash": "^4.17.20",
-            "renderkid": "^3.0.0"
-          }
         },
         "qs": {
           "version": "6.11.0",
@@ -2134,14 +2132,14 @@
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "schema-utils": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-          "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.1.tgz",
+          "integrity": "sha512-lELhBAAly9NowEsX0yZBlw9ahZG+sK/1RJ21EpzdYHKEs13Vku3LJ+MIPhh4sMs0oCCeufZQEQbMekiA4vuVIQ==",
           "requires": {
             "@types/json-schema": "^7.0.9",
-            "ajv": "^8.8.0",
+            "ajv": "^8.9.0",
             "ajv-formats": "^2.1.1",
-            "ajv-keywords": "^5.0.0"
+            "ajv-keywords": "^5.1.0"
           }
         },
         "selfsigned": {
@@ -2222,15 +2220,10 @@
             "ansi-regex": "^5.0.1"
           }
         },
-        "tapable": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-          "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
-        },
         "terser": {
-          "version": "5.16.6",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.6.tgz",
-          "integrity": "sha512-IBZ+ZQIA9sMaXmRZCUMDjNH0D5AQQfdn4WUjHL0+1lF4TP1IHRJbrhb6fNaXWikrYQTSkb7SLxkeXAiy1p7mbg==",
+          "version": "5.16.9",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.9.tgz",
+          "integrity": "sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==",
           "requires": {
             "@jridgewell/source-map": "^0.3.2",
             "acorn": "^8.5.0",
@@ -2268,9 +2261,9 @@
           }
         },
         "webpack-dev-server": {
-          "version": "4.11.1",
-          "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.11.1.tgz",
-          "integrity": "sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==",
+          "version": "4.13.3",
+          "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.13.3.tgz",
+          "integrity": "sha512-KqqzrzMRSRy5ePz10VhjyL27K2dxqwXQLP5rAKwRJBPUahe7Z2bBWzHw37jeb8GCPKxZRO79ZdQUAPesMh/Nug==",
           "requires": {
             "@types/bonjour": "^3.5.9",
             "@types/connect-history-api-fallback": "^1.3.5",
@@ -2291,6 +2284,7 @@
             "html-entities": "^2.3.2",
             "http-proxy-middleware": "^2.0.3",
             "ipaddr.js": "^2.0.1",
+            "launch-editor": "^2.6.0",
             "open": "^8.0.9",
             "p-retry": "^4.5.0",
             "rimraf": "^3.0.2",
@@ -2300,13 +2294,13 @@
             "sockjs": "^0.3.24",
             "spdy": "^4.0.2",
             "webpack-dev-middleware": "^5.3.1",
-            "ws": "^8.4.2"
+            "ws": "^8.13.0"
           }
         },
         "ws": {
-          "version": "8.12.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
-          "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig=="
+          "version": "8.13.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA=="
         },
         "yocto-queue": {
           "version": "1.0.0",
@@ -2316,147 +2310,32 @@
       }
     },
     "@cypress/webpack-preprocessor": {
-      "version": "5.16.2",
-      "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.16.2.tgz",
-      "integrity": "sha512-C24bpNzRtrV6VhEsmn378Ww/FuhgIULYwYv3NdU0/umA2NuvX/QCGOS61GZu3WS3+6ZQEb6hFtnyQCxpS0CL0Q==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.17.0.tgz",
+      "integrity": "sha512-HyFqHkrOrIIYOt4G+r3VK0kVYTcev1tEcqBI/0DJ4AzEuEgW/TB+cX56txy4Cgn60XXdJoul2utclZwUqOsPZA==",
       "requires": {
-        "@babel/core": "^7.0.1",
-        "@babel/generator": "^7.17.9",
-        "@babel/parser": "^7.13.0",
-        "@babel/traverse": "^7.17.9",
         "bluebird": "3.7.1",
-        "debug": "^4.3.2",
-        "fs-extra": "^10.1.0",
-        "loader-utils": "^2.0.0",
-        "lodash": "^4.17.20",
-        "md5": "2.3.0",
-        "source-map": "^0.6.1",
-        "webpack-virtual-modules": "^0.4.4"
+        "debug": "^4.3.4",
+        "lodash": "^4.17.20"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-          "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-          "requires": {
-            "@babel/highlight": "^7.18.6"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.20.14",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.14.tgz",
-          "integrity": "sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==",
-          "requires": {
-            "@babel/types": "^7.20.7",
-            "@jridgewell/gen-mapping": "^0.3.2",
-            "jsesc": "^2.5.1"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.19.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
-          "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
-          "requires": {
-            "@babel/template": "^7.18.10",
-            "@babel/types": "^7.19.0"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-          "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-          "requires": {
-            "@babel/types": "^7.18.6"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-          "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
-          "requires": {
-            "@babel/types": "^7.18.6"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.19.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-          "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
-        },
-        "@babel/highlight": {
-          "version": "7.18.6",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-          "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.18.6",
-            "chalk": "^2.0.0",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "@babel/template": {
-          "version": "7.20.7",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
-          "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
-          "requires": {
-            "@babel/code-frame": "^7.18.6",
-            "@babel/parser": "^7.20.7",
-            "@babel/types": "^7.20.7"
-          },
-          "dependencies": {
-            "@babel/parser": {
-              "version": "7.20.15",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.15.tgz",
-              "integrity": "sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg=="
-            }
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.20.13",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.13.tgz",
-          "integrity": "sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==",
-          "requires": {
-            "@babel/code-frame": "^7.18.6",
-            "@babel/generator": "^7.20.7",
-            "@babel/helper-environment-visitor": "^7.18.9",
-            "@babel/helper-function-name": "^7.19.0",
-            "@babel/helper-hoist-variables": "^7.18.6",
-            "@babel/helper-split-export-declaration": "^7.18.6",
-            "@babel/parser": "^7.20.13",
-            "@babel/types": "^7.20.7",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          },
-          "dependencies": {
-            "@babel/parser": {
-              "version": "7.20.15",
-              "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.15.tgz",
-              "integrity": "sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg=="
-            }
-          }
-        },
-        "@babel/types": {
-          "version": "7.20.7",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
-          "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
-          "requires": {
-            "@babel/helper-string-parser": "^7.19.4",
-            "@babel/helper-validator-identifier": "^7.19.1",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "bluebird": {
           "version": "3.7.1",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
           "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
         },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
         },
-        "webpack-virtual-modules": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.4.6.tgz",
-          "integrity": "sha512-5tyDlKLqPfMqjT3Q9TAqf2YqjwmnUleZwzJi1A5qXnlBCdj2AtOJ6wAWdglTIDOPgOiOrXeBeFcsQ8+aGQ6QbA=="
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },
@@ -2866,6 +2745,21 @@
       "resolved": "https://registry.npmjs.org/@ensdomains/resolver/-/resolver-0.2.4.tgz",
       "integrity": "sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==",
       "optional": true
+    },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+          "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ=="
+        }
+      }
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -3759,6 +3653,11 @@
             "cosmiconfig": "^6.0.0",
             "resolve": "^1.12.0"
           }
+        },
+        "penpal-v4": {
+          "version": "npm:penpal@4.1.1",
+          "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
+          "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
         },
         "stylis": {
           "version": "4.0.13",
@@ -5364,9 +5263,9 @@
       }
     },
     "@jridgewell/gen-mapping": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
       "requires": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -5393,17 +5292,24 @@
       }
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.17",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
+      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
       "requires": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      },
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": {
+          "version": "1.4.14",
+          "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+          "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+        }
       }
     },
     "@ledgerhq/devices": {
@@ -5703,6 +5609,16 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
+    "@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -5915,18 +5831,19 @@
       }
     },
     "@playwright/test": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0.tgz",
-      "integrity": "sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==",
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
+      "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.30.0"
+        "fsevents": "2.3.2",
+        "playwright-core": "1.32.3"
       },
       "dependencies": {
         "playwright-core": {
-          "version": "1.30.0",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
-          "integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g=="
+          "version": "1.32.3",
+          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
+          "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg=="
         }
       }
     },
@@ -6135,9 +6052,9 @@
           }
         },
         "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -6328,6 +6245,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
       "integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -6335,7 +6253,8 @@
     "@sideway/formula": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
-      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "dev": true
     },
     "@sideway/pinpoint": {
       "version": "2.0.0",
@@ -9955,430 +9874,59 @@
       }
     },
     "@synthetixio/synpress": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@synthetixio/synpress/-/synpress-3.0.5.tgz",
-      "integrity": "sha512-tkrQra/z+CW/t+rB7SBXQ9Xgmowq4lOlVE6QelDnpHVhIhms8w+0iuv5IeB564ucSoBE6UA9xkIgp28jzZNvbw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@synthetixio/synpress/-/synpress-3.5.1.tgz",
+      "integrity": "sha512-nRTdTXVELCkA+7KxZzm5iKudAWzV6mqM1PliW7azFt0QYq/UVfn2CvpXLukDj8bNoitKZyg1Mxgu4R5GDB3ihQ==",
       "requires": {
         "@cypress/code-coverage": "^3.10.0",
-        "@cypress/webpack-dev-server": "^3.1.0",
+        "@cypress/webpack-dev-server": "^3.3.0",
         "@drptbl/gremlins.js": "^2.2.1",
-        "@playwright/test": "^1.27.1",
+        "@playwright/test": "^1.31.2",
         "@synthetixio/js": "^2.41.0",
-        "@testing-library/cypress": "^8.0.3",
-        "@testing-library/react": "^13.4.0",
+        "@testing-library/cypress": "^9.0.0",
+        "@testing-library/react": "^14.0.0",
         "@types/testing-library__cypress": "^5.0.9",
-        "axios": "^1.1.3",
+        "axios": "^1.3.4",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-plugin-react-generate-property": "^1.1.2",
         "babel-plugin-react-remove-properties": "^0.3.0",
         "babel-plugin-transform-react-qa-classes": "^1.6.0",
         "babel-plugin-transform-react-styled-components-qa": "^2.1.0",
         "bytes32": "^0.0.3",
-        "commander": "^9.4.1",
-        "cypress": "^11.0.1",
+        "commander": "^10.0.0",
+        "cypress": "^12.7.0",
         "cypress-wait-until": "^1.7.2",
         "debug": "^4.3.4",
         "dotenv": "^16.0.3",
         "dotenv-parse-variables": "^2.0.0",
         "download": "^8.0.0",
         "eslint": "^7.32.0",
-        "eslint-config-prettier": "^8.5.0",
+        "eslint-config-prettier": "^8.7.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-chai-friendly": "^0.7.2",
         "eslint-plugin-cypress": "^2.12.1",
-        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-standard": "^4.1.0",
-        "eslint-plugin-testing-library": "^5.9.1",
+        "eslint-plugin-testing-library": "^5.10.2",
         "eslint-plugin-ui-testing": "^2.0.1",
-        "eslint-plugin-unicorn": "^44.0.2",
-        "ethers": "^5.7.2",
-        "etherscan-api": "^10.2.0",
+        "eslint-plugin-unicorn": "^46.0.0",
+        "ethers": "^6.1.0",
+        "etherscan-api": "^10.3.0",
         "find-config": "^1.0.0",
         "node-fetch": "^2.6.1",
-        "prettier": "^2.7.1",
-        "serve": "^14.1.1",
-        "start-server-and-test": "^1.14.0",
+        "prettier": "^2.8.4",
+        "serve": "^14.2.0",
+        "start-server-and-test": "^2.0.0",
         "synthetix-js": "^2.74.1"
       },
       "dependencies": {
-        "@ethersproject/abi": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
-          "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
-          "requires": {
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/constants": "^5.7.0",
-            "@ethersproject/hash": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0"
-          }
-        },
-        "@ethersproject/abstract-provider": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
-          "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/networks": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0",
-            "@ethersproject/web": "^5.7.0"
-          }
-        },
-        "@ethersproject/abstract-signer": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
-          "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0"
-          }
-        },
-        "@ethersproject/address": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
-          "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/rlp": "^5.7.0"
-          }
-        },
-        "@ethersproject/base64": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
-          "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0"
-          }
-        },
-        "@ethersproject/basex": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
-          "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
-          "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "bn.js": "^5.2.1"
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
-          "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
-          "requires": {
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "@ethersproject/constants": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
-          "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.7.0"
-          }
-        },
-        "@ethersproject/contracts": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
-          "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
-          "requires": {
-            "@ethersproject/abi": "^5.7.0",
-            "@ethersproject/abstract-provider": "^5.7.0",
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/constants": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0"
-          }
-        },
-        "@ethersproject/hash": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
-          "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/base64": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0"
-          }
-        },
-        "@ethersproject/hdnode": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
-          "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/basex": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/pbkdf2": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/sha2": "^5.7.0",
-            "@ethersproject/signing-key": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0",
-            "@ethersproject/wordlists": "^5.7.0"
-          }
-        },
-        "@ethersproject/json-wallets": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
-          "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
-          "requires": {
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/hdnode": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/pbkdf2": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/random": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0",
-            "aes-js": "3.0.0",
-            "scrypt-js": "3.0.1"
-          }
-        },
-        "@ethersproject/keccak256": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
-          "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "js-sha3": "0.8.0"
-          }
-        },
-        "@ethersproject/logger": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
-          "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
-        },
-        "@ethersproject/networks": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
-          "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
-          "requires": {
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "@ethersproject/pbkdf2": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
-          "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/sha2": "^5.7.0"
-          }
-        },
-        "@ethersproject/properties": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
-          "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
-          "requires": {
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "@ethersproject/providers": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
-          "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.7.0",
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/base64": "^5.7.0",
-            "@ethersproject/basex": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/constants": "^5.7.0",
-            "@ethersproject/hash": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/networks": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/random": "^5.7.0",
-            "@ethersproject/rlp": "^5.7.0",
-            "@ethersproject/sha2": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0",
-            "@ethersproject/web": "^5.7.0",
-            "bech32": "1.1.4",
-            "ws": "7.4.6"
-          }
-        },
-        "@ethersproject/random": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
-          "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "@ethersproject/rlp": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
-          "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "@ethersproject/sha2": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
-          "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "hash.js": "1.1.7"
-          }
-        },
-        "@ethersproject/signing-key": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
-          "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "bn.js": "^5.2.1",
-            "elliptic": "6.5.4",
-            "hash.js": "1.1.7"
-          }
-        },
-        "@ethersproject/solidity": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
-          "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/sha2": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0"
-          }
-        },
-        "@ethersproject/strings": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
-          "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/constants": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "@ethersproject/transactions": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
-          "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
-          "requires": {
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/constants": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/rlp": "^5.7.0",
-            "@ethersproject/signing-key": "^5.7.0"
-          }
-        },
-        "@ethersproject/units": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
-          "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/constants": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0"
-          }
-        },
-        "@ethersproject/wallet": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
-          "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
-          "requires": {
-            "@ethersproject/abstract-provider": "^5.7.0",
-            "@ethersproject/abstract-signer": "^5.7.0",
-            "@ethersproject/address": "^5.7.0",
-            "@ethersproject/bignumber": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/hash": "^5.7.0",
-            "@ethersproject/hdnode": "^5.7.0",
-            "@ethersproject/json-wallets": "^5.7.0",
-            "@ethersproject/keccak256": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/random": "^5.7.0",
-            "@ethersproject/signing-key": "^5.7.0",
-            "@ethersproject/transactions": "^5.7.0",
-            "@ethersproject/wordlists": "^5.7.0"
-          }
-        },
-        "@ethersproject/web": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
-          "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
-          "requires": {
-            "@ethersproject/base64": "^5.7.0",
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0"
-          }
-        },
-        "@ethersproject/wordlists": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
-          "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.7.0",
-            "@ethersproject/hash": "^5.7.0",
-            "@ethersproject/logger": "^5.7.0",
-            "@ethersproject/properties": "^5.7.0",
-            "@ethersproject/strings": "^5.7.0"
-          }
-        },
         "@testing-library/dom": {
-          "version": "8.20.0",
-          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.0.tgz",
-          "integrity": "sha512-d9ULIT+a4EXLX3UU8FBjauG9NnsZHkHztXoIcTsOKoOw030fyjheN9svkTULjJxtYag9DZz5Jz5qkWZDPxTFwA==",
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.2.0.tgz",
+          "integrity": "sha512-xTEnpUKiV/bMyEsE5bT4oYA0x0Z/colMtxzUY8bKyPXBNLn/e0V4ZjBZkEhms0xE4pv9QsPfSRu9AWS4y5wGvA==",
           "requires": {
             "@babel/code-frame": "^7.10.4",
             "@babel/runtime": "^7.12.5",
@@ -10386,17 +9934,17 @@
             "aria-query": "^5.0.0",
             "chalk": "^4.1.0",
             "dom-accessibility-api": "^0.5.9",
-            "lz-string": "^1.4.4",
+            "lz-string": "^1.5.0",
             "pretty-format": "^27.0.2"
           }
         },
         "@testing-library/react": {
-          "version": "13.4.0",
-          "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
-          "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-14.0.0.tgz",
+          "integrity": "sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==",
           "requires": {
             "@babel/runtime": "^7.12.5",
-            "@testing-library/dom": "^8.5.0",
+            "@testing-library/dom": "^9.0.0",
             "@types/react-dom": "^18.0.0"
           }
         },
@@ -10406,12 +9954,17 @@
           "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q=="
         },
         "@types/react-dom": {
-          "version": "18.0.10",
-          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
-          "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
+          "version": "18.0.11",
+          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
+          "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
           "requires": {
             "@types/react": "*"
           }
+        },
+        "aes-js": {
+          "version": "4.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.3.tgz",
+          "integrity": "sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA=="
         },
         "ansi-regex": {
           "version": "5.0.1",
@@ -10435,9 +9988,9 @@
           }
         },
         "axios": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.2.tgz",
-          "integrity": "sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==",
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.5.tgz",
+          "integrity": "sha512-glL/PvG/E+xCWwV8S6nCHcrfg1exGx7vxyUIivIA1iL7BIh6bePylCfVHwp6k13ao7SATxB6imau2kqY+I67kw==",
           "requires": {
             "follow-redirects": "^1.15.0",
             "form-data": "^4.0.0",
@@ -10455,11 +10008,6 @@
             "istanbul-lib-instrument": "^5.0.4",
             "test-exclude": "^6.0.0"
           }
-        },
-        "bn.js": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
         },
         "chalk": {
           "version": "4.1.2",
@@ -10484,9 +10032,9 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "commander": {
-          "version": "9.5.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
         },
         "debug": {
           "version": "4.3.4",
@@ -10521,9 +10069,9 @@
           }
         },
         "define-properties": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+          "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
           "requires": {
             "has-property-descriptors": "^1.0.0",
             "object-keys": "^1.1.1"
@@ -10535,9 +10083,9 @@
           "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="
         },
         "eslint-config-prettier": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
-          "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA=="
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+          "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA=="
         },
         "eslint-plugin-prettier": {
           "version": "4.2.1",
@@ -10548,40 +10096,16 @@
           }
         },
         "ethers": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-          "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.3.0.tgz",
+          "integrity": "sha512-CKFYvTne1YT4S1glTiu7TgGsj0t6c6GAD7evrIk8zbeUb6nK8dcUPAiAWM8uDX/1NmRTvLM9+1Vnn49hwKtEzw==",
           "requires": {
-            "@ethersproject/abi": "5.7.0",
-            "@ethersproject/abstract-provider": "5.7.0",
-            "@ethersproject/abstract-signer": "5.7.0",
-            "@ethersproject/address": "5.7.0",
-            "@ethersproject/base64": "5.7.0",
-            "@ethersproject/basex": "5.7.0",
-            "@ethersproject/bignumber": "5.7.0",
-            "@ethersproject/bytes": "5.7.0",
-            "@ethersproject/constants": "5.7.0",
-            "@ethersproject/contracts": "5.7.0",
-            "@ethersproject/hash": "5.7.0",
-            "@ethersproject/hdnode": "5.7.0",
-            "@ethersproject/json-wallets": "5.7.0",
-            "@ethersproject/keccak256": "5.7.0",
-            "@ethersproject/logger": "5.7.0",
-            "@ethersproject/networks": "5.7.1",
-            "@ethersproject/pbkdf2": "5.7.0",
-            "@ethersproject/properties": "5.7.0",
-            "@ethersproject/providers": "5.7.2",
-            "@ethersproject/random": "5.7.0",
-            "@ethersproject/rlp": "5.7.0",
-            "@ethersproject/sha2": "5.7.0",
-            "@ethersproject/signing-key": "5.7.0",
-            "@ethersproject/solidity": "5.7.0",
-            "@ethersproject/strings": "5.7.0",
-            "@ethersproject/transactions": "5.7.0",
-            "@ethersproject/units": "5.7.0",
-            "@ethersproject/wallet": "5.7.0",
-            "@ethersproject/web": "5.7.1",
-            "@ethersproject/wordlists": "5.7.0"
+            "@adraffy/ens-normalize": "1.9.0",
+            "@noble/hashes": "1.1.2",
+            "@noble/secp256k1": "1.7.1",
+            "aes-js": "4.0.0-beta.3",
+            "tslib": "2.4.0",
+            "ws": "8.5.0"
           }
         },
         "follow-redirects": {
@@ -10661,10 +10185,10 @@
             "semver": "^6.3.0"
           }
         },
-        "js-sha3": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        "lz-string": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+          "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="
         },
         "ms": {
           "version": "2.1.2",
@@ -10683,9 +10207,9 @@
           }
         },
         "prettier": {
-          "version": "2.8.3",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-          "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw=="
+          "version": "2.8.7",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+          "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw=="
         },
         "pretty-format": {
           "version": "27.5.1",
@@ -10732,6 +10256,11 @@
             "has-flag": "^4.0.0"
           }
         },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
         "which-typed-array": {
           "version": "1.1.9",
           "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
@@ -10744,6 +10273,11 @@
             "has-tostringtag": "^1.0.0",
             "is-typed-array": "^1.1.10"
           }
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
         }
       }
     },
@@ -10763,9 +10297,9 @@
       "dev": true
     },
     "@testing-library/cypress": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.7.tgz",
-      "integrity": "sha512-3HTV725rOS+YHve/gD9coZp/UcPK5xhr4H0GMnq/ni6USdtzVtSOG9WBFtd8rYnrXk8rrGD+0toRFYouJNIG0Q==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-9.0.0.tgz",
+      "integrity": "sha512-c1XiCGeHGGTWn0LAU12sFUfoX3qfId5gcSE2yHode+vsyHDWraxDPALjVnHd4/Fa3j4KBcc5k++Ccy6A9qnkMA==",
       "requires": {
         "@babel/runtime": "^7.14.6",
         "@testing-library/dom": "^8.1.0"
@@ -10859,9 +10393,9 @@
           }
         },
         "define-properties": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+          "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
           "requires": {
             "has-property-descriptors": "^1.0.0",
             "object-keys": "^1.1.1"
@@ -11304,6 +10838,14 @@
             "setimmediate": "1.0.4",
             "uuid": "2.0.1",
             "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "xmlhttprequest": {
+              "version": "1.8.0",
+              "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+              "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
+              "optional": true
+            }
           }
         },
         "eventemitter3": {
@@ -11498,6 +11040,12 @@
               "version": "4.12.0",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
               "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+              "optional": true
+            },
+            "xmlhttprequest": {
+              "version": "1.8.0",
+              "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+              "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
               "optional": true
             }
           }
@@ -11819,9 +11367,9 @@
       "optional": true
     },
     "@types/http-proxy": {
-      "version": "1.17.9",
-      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.9.tgz",
-      "integrity": "sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==",
+      "version": "1.17.10",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.10.tgz",
+      "integrity": "sha512-Qs5aULi+zV1bwKAg5z1PWnDXWmsn+LxIvUGv6E2+OOMYhclZMO+OXd9pYVf2gLykf2I7IV2u7oTHwChPNsvJ7g==",
       "requires": {
         "@types/node": "*"
       }
@@ -12163,9 +11711,9 @@
       }
     },
     "@types/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
+      "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -12776,9 +12324,9 @@
       }
     },
     "@walletconnect/jsonrpc-utils": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.4.tgz",
-      "integrity": "sha512-y0+tDxcTZ9BHBBKBJbjZxLUXb+zQZCylf7y/jTvDPNx76J0hYYc+F9zHzyqBLeorSKepLTk6yI8hw3NXbAQB3g==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.7.tgz",
+      "integrity": "sha512-zJziApzUF/Il4VcwabnaU+0yo1QI4eUkYX99zmCVTHJvZOf2l0zjADf/OpKqWyeNFC3Io56Z/8uJHVtcNVvyFA==",
       "requires": {
         "@walletconnect/environment": "^1.0.1",
         "@walletconnect/jsonrpc-types": "^1.0.2",
@@ -13537,6 +13085,15 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
       "dev": true
+    },
+    "array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      }
     },
     "array-find": {
       "version": "1.0.0",
@@ -15378,9 +14935,9 @@
           "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
         "minimist": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
         },
         "mkdirp": {
           "version": "0.5.6",
@@ -15770,9 +15327,9 @@
       }
     },
     "bonjour-service": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.0.tgz",
-      "integrity": "sha512-LVRinRB3k1/K0XzZ2p58COnWvkQknIY6sf0zF2rpErvcJXpMBttEPQSxK+HEXSS9VmpZlDoDnQWv8ftJT20B0Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.1.1.tgz",
+      "integrity": "sha512-Z/5lQRMOG9k7W+FkeGTNjh7htqn/2LMnfOvBZ8pynNZCM9MwkQkI3zeI4oz09uWdcgmgHugVvBqxGg4VQJ5PCg==",
       "requires": {
         "array-flatten": "^2.1.2",
         "dns-equal": "^1.0.0",
@@ -15786,9 +15343,9 @@
           "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
         },
         "dns-packet": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
-          "integrity": "sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.5.0.tgz",
+          "integrity": "sha512-USawdAUzRkV6xrqTjiAEp6M9YagZEzWcSUaZTcIFAiyQWW1SoI6KyId8y2+/71wbgHKQAKd+iupLv4YvEwYWvA==",
           "requires": {
             "@leichtgewicht/ip-codec": "^2.0.1"
           }
@@ -16615,9 +16172,9 @@
       }
     },
     "chance": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.9.tgz",
-      "integrity": "sha512-TfxnA/DcZXRTA4OekA2zL9GH8qscbbl6X0ZqU4tXhGveVY/mXWvEQLt5GwZcYXTEyEFflVtj+pG8nc8EwSm1RQ=="
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.11.tgz",
+      "integrity": "sha512-kqTg3WWywappJPqtgrdvbA380VoXO2eu9VCV895JgbyHsaErXdyHK9LOZ911OvAk6L0obK7kDk9CGs8+oBawVA=="
     },
     "change-case": {
       "version": "3.0.2",
@@ -16725,11 +16282,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-    },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
     },
     "check-error": {
       "version": "1.0.2",
@@ -17332,8 +16884,7 @@
     "commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "dev": true
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
     },
     "common-path-prefix": {
       "version": "3.0.0",
@@ -18451,11 +18002,6 @@
         "which": "^2.0.1"
       }
     },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
-    },
     "crypto-addr-codec": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/crypto-addr-codec/-/crypto-addr-codec-0.1.7.tgz",
@@ -18698,9 +18244,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.10.0.tgz",
+      "integrity": "sha512-Y0wPc221xKKW1/4iAFCphkrG2jNR4MjOne3iGn4mcuCaE7Y5EtXL83N8BzRsAht7GYfWVjJ/UeTqEdDKHz39HQ==",
       "requires": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",
@@ -18716,10 +18262,10 @@
         "check-more-types": "^2.24.0",
         "cli-cursor": "^3.1.0",
         "cli-table3": "~0.6.1",
-        "commander": "^5.1.0",
+        "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -18734,7 +18280,7 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.6",
+        "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
@@ -18747,9 +18293,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.36",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-          "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ=="
+          "version": "14.18.42",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.42.tgz",
+          "integrity": "sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg=="
         },
         "ansi-styles": {
           "version": "4.3.0",
@@ -18788,9 +18334,9 @@
           }
         },
         "ci-info": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
-          "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w=="
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+          "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw=="
         },
         "color-convert": {
           "version": "2.0.1",
@@ -18805,10 +18351,13 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
-        "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
         },
         "execa": {
           "version": "4.1.0",
@@ -18894,14 +18443,19 @@
           }
         },
         "minimist": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -19089,9 +18643,9 @@
           "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
         },
         "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -19675,9 +19229,9 @@
       }
     },
     "dijkstrajs": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.2.tgz",
-      "integrity": "sha512-QV6PMaHTCNmKSeP6QoXhVTw9snc9VD8MulTT0Bd99Pacp4SS1cjcrYPgBPmibqKVtMJJfqC6XvOXgPMEEPH/fg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -20910,9 +20464,9 @@
           }
         },
         "is-core-module": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-          "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+          "version": "2.12.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+          "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
           "requires": {
             "has": "^1.0.3"
           }
@@ -20923,11 +20477,11 @@
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "resolve": {
-          "version": "1.22.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-          "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+          "version": "1.22.2",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+          "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
           "requires": {
-            "is-core-module": "^2.9.0",
+            "is-core-module": "^2.11.0",
             "path-parse": "^1.0.7",
             "supports-preserve-symlinks-flag": "^1.0.0"
           }
@@ -20935,9 +20489,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz",
-      "integrity": "sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
+      "integrity": "sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==",
       "requires": {
         "debug": "^3.2.7"
       },
@@ -20963,9 +20517,9 @@
       "integrity": "sha512-LOIfGx5sZZ5FwM1shr2GlYAWV9Omdi+1/3byuVagvQNoGUuU0iHhp7AfjA1uR+4dJ4Isfb4+FwBJgQajIw9iAg=="
     },
     "eslint-plugin-cypress": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz",
-      "integrity": "sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-2.13.2.tgz",
+      "integrity": "sha512-LlwjnBTzuKuC0A4H0RxVjs0YeAWK+CD1iM9Dp8un3lzT713ePQxfpPstCD+9HSAss8emuE3b2hCNUST+NrUwKw==",
       "requires": {
         "globals": "^11.12.0"
       }
@@ -21059,9 +20613,9 @@
           }
         },
         "define-properties": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+          "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
           "requires": {
             "has-property-descriptors": "^1.0.0",
             "object-keys": "^1.1.1"
@@ -21076,17 +20630,17 @@
           }
         },
         "es-abstract": {
-          "version": "1.21.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
-          "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+          "version": "1.21.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+          "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
           "requires": {
+            "array-buffer-byte-length": "^1.0.0",
             "available-typed-arrays": "^1.0.5",
             "call-bind": "^1.0.2",
             "es-set-tostringtag": "^2.0.1",
             "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
             "function.prototype.name": "^1.1.5",
-            "get-intrinsic": "^1.1.3",
+            "get-intrinsic": "^1.2.0",
             "get-symbol-description": "^1.0.0",
             "globalthis": "^1.0.3",
             "gopd": "^1.0.1",
@@ -21094,8 +20648,8 @@
             "has-property-descriptors": "^1.0.0",
             "has-proto": "^1.0.1",
             "has-symbols": "^1.0.3",
-            "internal-slot": "^1.0.4",
-            "is-array-buffer": "^3.0.1",
+            "internal-slot": "^1.0.5",
+            "is-array-buffer": "^3.0.2",
             "is-callable": "^1.2.7",
             "is-negative-zero": "^2.0.2",
             "is-regex": "^1.1.4",
@@ -21103,11 +20657,12 @@
             "is-string": "^1.0.7",
             "is-typed-array": "^1.1.10",
             "is-weakref": "^1.0.2",
-            "object-inspect": "^1.12.2",
+            "object-inspect": "^1.12.3",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
+            "string.prototype.trim": "^1.2.7",
             "string.prototype.trimend": "^1.0.6",
             "string.prototype.trimstart": "^1.0.6",
             "typed-array-length": "^1.0.4",
@@ -21144,11 +20699,11 @@
           "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         },
         "internal-slot": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
-          "integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+          "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
           "requires": {
-            "get-intrinsic": "^1.1.3",
+            "get-intrinsic": "^1.2.0",
             "has": "^1.0.3",
             "side-channel": "^1.0.4"
           }
@@ -21159,9 +20714,9 @@
           "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
         },
         "is-core-module": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-          "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+          "version": "2.12.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+          "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
           "requires": {
             "has": "^1.0.3"
           }
@@ -21249,11 +20804,11 @@
           }
         },
         "resolve": {
-          "version": "1.22.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-          "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+          "version": "1.22.2",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+          "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
           "requires": {
-            "is-core-module": "^2.9.0",
+            "is-core-module": "^2.11.0",
             "path-parse": "^1.0.7",
             "supports-preserve-symlinks-flag": "^1.0.0"
           }
@@ -21452,34 +21007,34 @@
       "dev": true
     },
     "eslint-plugin-testing-library": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.10.0.tgz",
-      "integrity": "sha512-aTOsCAEI9trrX3TLOnsskfhe57DmsjP/yMKLPqg4ftdRvfR4qut2PGWUa8TwP7whZbwMzJjh98tgAPcE8vdHow==",
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.10.3.tgz",
+      "integrity": "sha512-0yhsKFsjHLud5PM+f2dWr9K3rqYzMy4cSHs3lcmFYMa1CdSzRvHGgXvsFarBjZ41gU8jhTdMIkg8jHLxGJqLqw==",
       "requires": {
-        "@typescript-eslint/utils": "^5.43.0"
+        "@typescript-eslint/utils": "^5.58.0"
       },
       "dependencies": {
         "@typescript-eslint/scope-manager": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.50.0.tgz",
-          "integrity": "sha512-rt03kaX+iZrhssaT974BCmoUikYtZI24Vp/kwTSy841XhiYShlqoshRFDvN1FKKvU2S3gK+kcBW1EA7kNUrogg==",
+          "version": "5.59.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
+          "integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
           "requires": {
-            "@typescript-eslint/types": "5.50.0",
-            "@typescript-eslint/visitor-keys": "5.50.0"
+            "@typescript-eslint/types": "5.59.0",
+            "@typescript-eslint/visitor-keys": "5.59.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.50.0.tgz",
-          "integrity": "sha512-atruOuJpir4OtyNdKahiHZobPKFvZnBnfDiyEaBf6d9vy9visE7gDjlmhl+y29uxZ2ZDgvXijcungGFjGGex7w=="
+          "version": "5.59.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
+          "integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA=="
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.50.0.tgz",
-          "integrity": "sha512-Gq4zapso+OtIZlv8YNAStFtT6d05zyVCK7Fx3h5inlLBx2hWuc/0465C2mg/EQDDU2LKe52+/jN4f0g9bd+kow==",
+          "version": "5.59.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
+          "integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
           "requires": {
-            "@typescript-eslint/types": "5.50.0",
-            "@typescript-eslint/visitor-keys": "5.50.0",
+            "@typescript-eslint/types": "5.59.0",
+            "@typescript-eslint/visitor-keys": "5.59.0",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -21488,26 +21043,26 @@
           }
         },
         "@typescript-eslint/utils": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.50.0.tgz",
-          "integrity": "sha512-v/AnUFImmh8G4PH0NDkf6wA8hujNNcrwtecqW4vtQ1UOSNBaZl49zP1SHoZ/06e+UiwzHpgb5zP5+hwlYYWYAw==",
+          "version": "5.59.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.0.tgz",
+          "integrity": "sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==",
           "requires": {
+            "@eslint-community/eslint-utils": "^4.2.0",
             "@types/json-schema": "^7.0.9",
             "@types/semver": "^7.3.12",
-            "@typescript-eslint/scope-manager": "5.50.0",
-            "@typescript-eslint/types": "5.50.0",
-            "@typescript-eslint/typescript-estree": "5.50.0",
+            "@typescript-eslint/scope-manager": "5.59.0",
+            "@typescript-eslint/types": "5.59.0",
+            "@typescript-eslint/typescript-estree": "5.59.0",
             "eslint-scope": "^5.1.1",
-            "eslint-utils": "^3.0.0",
             "semver": "^7.3.7"
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.50.0.tgz",
-          "integrity": "sha512-cdMeD9HGu6EXIeGOh2yVW6oGf9wq8asBgZx7nsR/D36gTfQ0odE5kcRYe5M81vjEFAcPeugXrHg78Imu55F6gg==",
+          "version": "5.59.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
+          "integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
           "requires": {
-            "@typescript-eslint/types": "5.50.0",
+            "@typescript-eslint/types": "5.59.0",
             "eslint-visitor-keys": "^3.3.0"
           }
         },
@@ -21529,9 +21084,9 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+          "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ=="
         },
         "fast-glob": {
           "version": "3.2.12",
@@ -21585,9 +21140,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -21608,34 +21163,34 @@
       },
       "dependencies": {
         "@typescript-eslint/experimental-utils": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.50.0.tgz",
-          "integrity": "sha512-gZIhzNRivy0RVqcxjKnQ+ipGc0qolilhBeNmvH+Dvu7Vymug+IfiYxTj2zM7mIlHsw6Q5aH7L7WmuTE3tZyzag==",
+          "version": "5.59.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.59.0.tgz",
+          "integrity": "sha512-evvdzcPrUv9+Hj+KX6fa3WMrtTZ7onnGHL3NfT/zN9q2FQhb2yvNJDa+w/ND0TpdRCbulwag0dxwMUt2MJB2Vg==",
           "requires": {
-            "@typescript-eslint/utils": "5.50.0"
+            "@typescript-eslint/utils": "5.59.0"
           }
         },
         "@typescript-eslint/scope-manager": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.50.0.tgz",
-          "integrity": "sha512-rt03kaX+iZrhssaT974BCmoUikYtZI24Vp/kwTSy841XhiYShlqoshRFDvN1FKKvU2S3gK+kcBW1EA7kNUrogg==",
+          "version": "5.59.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
+          "integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
           "requires": {
-            "@typescript-eslint/types": "5.50.0",
-            "@typescript-eslint/visitor-keys": "5.50.0"
+            "@typescript-eslint/types": "5.59.0",
+            "@typescript-eslint/visitor-keys": "5.59.0"
           }
         },
         "@typescript-eslint/types": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.50.0.tgz",
-          "integrity": "sha512-atruOuJpir4OtyNdKahiHZobPKFvZnBnfDiyEaBf6d9vy9visE7gDjlmhl+y29uxZ2ZDgvXijcungGFjGGex7w=="
+          "version": "5.59.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
+          "integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA=="
         },
         "@typescript-eslint/typescript-estree": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.50.0.tgz",
-          "integrity": "sha512-Gq4zapso+OtIZlv8YNAStFtT6d05zyVCK7Fx3h5inlLBx2hWuc/0465C2mg/EQDDU2LKe52+/jN4f0g9bd+kow==",
+          "version": "5.59.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
+          "integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
           "requires": {
-            "@typescript-eslint/types": "5.50.0",
-            "@typescript-eslint/visitor-keys": "5.50.0",
+            "@typescript-eslint/types": "5.59.0",
+            "@typescript-eslint/visitor-keys": "5.59.0",
             "debug": "^4.3.4",
             "globby": "^11.1.0",
             "is-glob": "^4.0.3",
@@ -21644,26 +21199,26 @@
           }
         },
         "@typescript-eslint/utils": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.50.0.tgz",
-          "integrity": "sha512-v/AnUFImmh8G4PH0NDkf6wA8hujNNcrwtecqW4vtQ1UOSNBaZl49zP1SHoZ/06e+UiwzHpgb5zP5+hwlYYWYAw==",
+          "version": "5.59.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.0.tgz",
+          "integrity": "sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==",
           "requires": {
+            "@eslint-community/eslint-utils": "^4.2.0",
             "@types/json-schema": "^7.0.9",
             "@types/semver": "^7.3.12",
-            "@typescript-eslint/scope-manager": "5.50.0",
-            "@typescript-eslint/types": "5.50.0",
-            "@typescript-eslint/typescript-estree": "5.50.0",
+            "@typescript-eslint/scope-manager": "5.59.0",
+            "@typescript-eslint/types": "5.59.0",
+            "@typescript-eslint/typescript-estree": "5.59.0",
             "eslint-scope": "^5.1.1",
-            "eslint-utils": "^3.0.0",
             "semver": "^7.3.7"
           }
         },
         "@typescript-eslint/visitor-keys": {
-          "version": "5.50.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.50.0.tgz",
-          "integrity": "sha512-cdMeD9HGu6EXIeGOh2yVW6oGf9wq8asBgZx7nsR/D36gTfQ0odE5kcRYe5M81vjEFAcPeugXrHg78Imu55F6gg==",
+          "version": "5.59.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
+          "integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
           "requires": {
-            "@typescript-eslint/types": "5.50.0",
+            "@typescript-eslint/types": "5.59.0",
             "eslint-visitor-keys": "^3.3.0"
           }
         },
@@ -21685,9 +21240,9 @@
           }
         },
         "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+          "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ=="
         },
         "fast-glob": {
           "version": "3.2.12",
@@ -21741,9 +21296,9 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -21756,23 +21311,25 @@
       }
     },
     "eslint-plugin-unicorn": {
-      "version": "44.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-44.0.2.tgz",
-      "integrity": "sha512-GLIDX1wmeEqpGaKcnMcqRvMVsoabeF0Ton0EX4Th5u6Kmf7RM9WBl705AXFEsns56ESkEs0uyelLuUTvz9Tr0w==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-46.0.0.tgz",
+      "integrity": "sha512-j07WkC+PFZwk8J33LYp6JMoHa1lXc1u6R45pbSAipjpfpb7KIGr17VE2D685zCxR5VL4cjrl65kTJflziQWMDA==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.19.1",
-        "ci-info": "^3.4.0",
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "ci-info": "^3.6.1",
         "clean-regexp": "^1.0.0",
-        "eslint-utils": "^3.0.0",
         "esquery": "^1.4.0",
         "indent-string": "^4.0.0",
         "is-builtin-module": "^3.2.0",
+        "jsesc": "^3.0.2",
         "lodash": "^4.17.21",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
         "regexp-tree": "^0.1.24",
+        "regjsparser": "^0.9.1",
         "safe-regex": "^2.1.1",
-        "semver": "^7.3.7",
+        "semver": "^7.3.8",
         "strip-indent": "^3.0.0"
       },
       "dependencies": {
@@ -21782,9 +21339,14 @@
           "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
         },
         "ci-info": {
-          "version": "3.7.1",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
-          "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w=="
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+          "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw=="
+        },
+        "jsesc": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+          "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="
         },
         "lru-cache": {
           "version": "6.0.0",
@@ -21792,6 +21354,21 @@
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "requires": {
             "yallist": "^4.0.0"
+          }
+        },
+        "regjsparser": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+          "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+          "requires": {
+            "jsesc": "~0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+              "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA=="
+            }
           }
         },
         "safe-regex": {
@@ -21803,9 +21380,9 @@
           }
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -21831,6 +21408,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
       "requires": {
         "eslint-visitor-keys": "^2.0.0"
       }
@@ -24148,6 +23726,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -26129,42 +25708,6 @@
         }
       }
     },
-    "html-webpack-plugin-4": {
-      "version": "npm:html-webpack-plugin@4.5.2",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz",
-      "integrity": "sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==",
-      "requires": {
-        "@types/html-minifier-terser": "^5.0.0",
-        "@types/tapable": "^1.0.5",
-        "@types/webpack": "^4.41.8",
-        "html-minifier-terser": "^5.0.1",
-        "loader-utils": "^1.2.3",
-        "lodash": "^4.17.20",
-        "pretty-error": "^2.1.1",
-        "tapable": "^1.1.3",
-        "util.promisify": "1.0.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        },
-        "loader-utils": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
-          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^1.0.1"
-          }
-        }
-      }
-    },
     "htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -26948,12 +26491,12 @@
       }
     },
     "is-array-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
-      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
       "requires": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "is-typed-array": "^1.1.10"
       },
       "dependencies": {
@@ -29342,6 +28885,7 @@
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
       "integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+      "dev": true,
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -29699,6 +29243,22 @@
       "dev": true,
       "requires": {
         "package-json": "^6.3.0"
+      }
+    },
+    "launch-editor": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.6.0.tgz",
+      "integrity": "sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==",
+      "requires": {
+        "picocolors": "^1.0.0",
+        "shell-quote": "^1.7.3"
+      },
+      "dependencies": {
+        "shell-quote": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
+          "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA=="
+        }
       }
     },
     "lazy-ass": {
@@ -30075,22 +29635,9 @@
       },
       "dependencies": {
         "colorette": {
-          "version": "2.0.19",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
-          "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
-        },
-        "rxjs": {
-          "version": "7.8.0",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-          "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
-        "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.0.20",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+          "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
         }
       }
     },
@@ -30644,16 +30191,6 @@
       "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.9.tgz",
       "integrity": "sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ=="
     },
-    "md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -30870,9 +30407,9 @@
           }
         },
         "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -32525,11 +32062,6 @@
       "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true
     },
-    "openzeppelin-solidity-2.3.0": {
-      "version": "npm:openzeppelin-solidity@2.3.0",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-      "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
-    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
@@ -33161,11 +32693,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/penpal/-/penpal-5.3.0.tgz",
       "integrity": "sha512-ezGckenx66j3RShl4nZiswjgDxyoDaJJ9tLBp46UvVxlA9MlIPF6hWfuppw1AzaDKgUULU1i44QFOuI4SXY/mg=="
-    },
-    "penpal-v4": {
-      "version": "npm:penpal@4.1.1",
-      "resolved": "https://registry.npmjs.org/penpal/-/penpal-4.1.1.tgz",
-      "integrity": "sha512-6d1f8khVLyBz3DnhLztbfjJ7+ANxdXRM2l6awpnCdEtbrmse4AGTsELOvGuNY0SU7xZw7heGbP6IikVvaVTOWw=="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -35223,9 +34750,9 @@
       }
     },
     "regexp-tree": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
-      "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw=="
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.25.tgz",
+      "integrity": "sha512-szcL3aqw+vEeuxhL1AMYRyeMP+goYF5I/guaH10uJX5xbGyeQeNPPneaj3ZWVmGLCDxrVaaYekkr5R12gk4dJw=="
     },
     "regexp.prototype.flags": {
       "version": "1.3.1",
@@ -35892,17 +35419,17 @@
       "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA=="
     },
     "rxjs": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
-      "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
       "requires": {
-        "tslib": "~2.1.0"
+        "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
         }
       }
     },
@@ -37847,42 +37374,102 @@
       }
     },
     "start-server-and-test": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.14.0.tgz",
-      "integrity": "sha512-on5ELuxO2K0t8EmNj9MtVlFqwBMxfWOhu4U7uZD1xccVpFlOQKR93CSe0u98iQzfNxRyaNTb/CdadbNllplTsw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.0.0.tgz",
+      "integrity": "sha512-UqKLw0mJbfrsG1jcRLTUlvuRi9sjNuUiDOLI42r7R5fA9dsFoywAy9DoLXNYys9B886E4RCKb+qM1Gzu96h7DQ==",
       "requires": {
+        "arg": "^5.0.2",
         "bluebird": "3.7.2",
         "check-more-types": "2.24.0",
-        "debug": "4.3.2",
+        "debug": "4.3.4",
         "execa": "5.1.1",
         "lazy-ass": "1.6.0",
         "ps-tree": "1.2.0",
-        "wait-on": "6.0.0"
+        "wait-on": "7.0.1"
       },
       "dependencies": {
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+        "@sideway/address": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+          "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
           "requires": {
-            "follow-redirects": "^1.14.0"
+            "@hapi/hoek": "^9.0.0"
+          }
+        },
+        "@sideway/formula": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+          "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+        },
+        "arg": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+          "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+        },
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
           }
         },
         "follow-redirects": {
-          "version": "1.14.9",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-          "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "joi": {
+          "version": "17.9.1",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.1.tgz",
+          "integrity": "sha512-FariIi9j6QODKATGBrEX7HZcja8Bsh3rfdGYy/Sb65sGlZWK/QWesU1ghk7aJWDj95knjXlQfSmzFSPPkLVsfw==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0",
+            "@hapi/topo": "^5.0.0",
+            "@sideway/address": "^4.1.3",
+            "@sideway/formula": "^3.0.1",
+            "@sideway/pinpoint": "^2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "wait-on": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.0.tgz",
-          "integrity": "sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.0.1.tgz",
+          "integrity": "sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==",
           "requires": {
-            "axios": "^0.21.1",
-            "joi": "^17.4.0",
+            "axios": "^0.27.2",
+            "joi": "^17.7.0",
             "lodash": "^4.17.21",
-            "minimist": "^1.2.5",
-            "rxjs": "^7.1.0"
+            "minimist": "^1.2.7",
+            "rxjs": "^7.8.0"
           }
         }
       }
@@ -38108,26 +37695,26 @@
       },
       "dependencies": {
         "define-properties": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+          "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
           "requires": {
             "has-property-descriptors": "^1.0.0",
             "object-keys": "^1.1.1"
           }
         },
         "es-abstract": {
-          "version": "1.21.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
-          "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
+          "version": "1.21.2",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
+          "integrity": "sha512-y/B5POM2iBnIxCiernH1G7rC9qQoM77lLIMQLuob0zhp8C56Po81+2Nj0WFKnd0pNReDTnkYryc+zhOzpEIROg==",
           "requires": {
+            "array-buffer-byte-length": "^1.0.0",
             "available-typed-arrays": "^1.0.5",
             "call-bind": "^1.0.2",
             "es-set-tostringtag": "^2.0.1",
             "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
             "function.prototype.name": "^1.1.5",
-            "get-intrinsic": "^1.1.3",
+            "get-intrinsic": "^1.2.0",
             "get-symbol-description": "^1.0.0",
             "globalthis": "^1.0.3",
             "gopd": "^1.0.1",
@@ -38135,8 +37722,8 @@
             "has-property-descriptors": "^1.0.0",
             "has-proto": "^1.0.1",
             "has-symbols": "^1.0.3",
-            "internal-slot": "^1.0.4",
-            "is-array-buffer": "^3.0.1",
+            "internal-slot": "^1.0.5",
+            "is-array-buffer": "^3.0.2",
             "is-callable": "^1.2.7",
             "is-negative-zero": "^2.0.2",
             "is-regex": "^1.1.4",
@@ -38144,11 +37731,12 @@
             "is-string": "^1.0.7",
             "is-typed-array": "^1.1.10",
             "is-weakref": "^1.0.2",
-            "object-inspect": "^1.12.2",
+            "object-inspect": "^1.12.3",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.4",
             "regexp.prototype.flags": "^1.4.3",
             "safe-regex-test": "^1.0.0",
+            "string.prototype.trim": "^1.2.7",
             "string.prototype.trimend": "^1.0.6",
             "string.prototype.trimstart": "^1.0.6",
             "typed-array-length": "^1.0.4",
@@ -38185,11 +37773,11 @@
           "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         },
         "internal-slot": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
-          "integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+          "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
           "requires": {
-            "get-intrinsic": "^1.1.3",
+            "get-intrinsic": "^1.2.0",
             "has": "^1.0.3",
             "side-channel": "^1.0.4"
           }
@@ -38797,10 +38385,14 @@
         "web3-utils": "1.2.2"
       },
       "dependencies": {
-        "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        "@chainlink/contracts-0.0.10": {
+          "version": "npm:@chainlink/contracts@0.0.10",
+          "resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
+          "integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
+          "requires": {
+            "@truffle/contract": "^4.2.6",
+            "ethers": "^4.0.45"
+          }
         },
         "commander": {
           "version": "5.1.0",
@@ -38817,6 +38409,56 @@
             "xhr-request-promise": "^0.1.2"
           }
         },
+        "ethers": {
+          "version": "4.0.49",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.49.tgz",
+          "integrity": "sha512-kPltTvWiyu+OktYy1IStSO16i2e7cS9D9OxZ81q2UUaiNPVrm/RTcbxamCXF9VUSKzJIdJV68EAIhTEVBalRWg==",
+          "optional": true,
+          "requires": {
+            "aes-js": "3.0.0",
+            "bn.js": "^4.11.9",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.3",
+            "js-sha3": "0.5.7",
+            "scrypt-js": "2.0.4",
+            "setimmediate": "1.0.4",
+            "uuid": "2.0.1",
+            "xmlhttprequest": "1.8.0"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+          "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+          "optional": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "openzeppelin-solidity-2.3.0": {
+          "version": "npm:openzeppelin-solidity@2.3.0",
+          "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
+          "integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
+        },
+        "scrypt-js": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+          "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+          "optional": true
+        },
+        "setimmediate": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+          "integrity": "sha512-/TjEmXQVEzdod/FFskf3o7oOAsGhHf2j1dZqRFbDzq4F3mvvxflIIi4Hd3bLQE9y/CpwqfSQam5JakI/mi3Pog==",
+          "optional": true
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha512-nWg9+Oa3qD2CQzHIP4qKUqwNfzKn8P0LtFhotaCTFchsV7ZfDhAybeip/HZVeMIpZi9JgY1E3nUlwaCmZT1sEg==",
+          "optional": true
+        },
         "web3-utils": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
@@ -38830,6 +38472,13 @@
             "randombytes": "^2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.8",
+              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+              "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            }
           }
         }
       }
@@ -39378,9 +39027,9 @@
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "is-core-module": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-          "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+          "version": "2.12.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+          "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
           "requires": {
             "has": "^1.0.3"
           }
@@ -39394,9 +39043,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
         },
         "object-inspect": {
           "version": "1.12.3",
@@ -39404,11 +39053,11 @@
           "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
         },
         "resolve": {
-          "version": "1.22.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-          "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+          "version": "1.22.2",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+          "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
           "requires": {
-            "is-core-module": "^2.9.0",
+            "is-core-module": "^2.11.0",
             "path-parse": "^1.0.7",
             "supports-preserve-symlinks-flag": "^1.0.0"
           }
@@ -40936,12 +40585,12 @@
       "dev": true
     },
     "tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
+      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
       "requires": {
         "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       },
@@ -40955,9 +40604,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
         }
       }
     },
@@ -45157,9 +44806,9 @@
           }
         },
         "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "integration:headless:prod": "testcafe --config-file \".testcaferc-prod.json\"",
     "integration:headless:dev": "testcafe --config-file \".testcaferc-dev.json\"",
     "integration:metamask": "run-s wait blockchain:contracts integration:synpress",
-    "integration:synpress": "cross-env STABLE_MODE=true SLOW_MODE=true SECRET_WORDS='indicate swing place chair flight used hammer soon photo region volume shuffle' NETWORK_NAME='localhost' synpress run --config supportFile='tests/e2e/support/index.js',fixturesFolder='tests/e2e/fixtures',video=false,screenshotOnRunFailure=false",
+    "integration:synpress": "cross-env CYPRESS_RESOURCES_WAIT=1 STABLE_MODE=true SLOW_MODE=true SECRET_WORDS='indicate swing place chair flight used hammer soon photo region volume shuffle' NETWORK_NAME='localhost' synpress run --config supportFile='tests/e2e/support/index.js',fixturesFolder='tests/e2e/fixtures',video=false,screenshotOnRunFailure=false",
     "integration:local": "cross-env NET=local npm run dev",
     "integration:headful": "concurrently -k -s first \"npm:blockchain\" \"npm:integration:local\" \"npm:integration:metamask\"",
     "lint": "eslint ./src --ext .js,.ts,.tsx --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "license": "ISC",
   "scripts": {
-    "blockchain": "ganache --wallet.mnemonic \"indicate swing place chair flight used hammer soon photo region volume shuffle\" -i 1337 --fork.network goerli --fork.blockNumber 8506655 --logging.quiet=true",
+    "blockchain": "ganache --wallet.mnemonic \"indicate swing place chair flight used hammer soon photo region volume shuffle\" -i 1337 --fork.network goerli --fork.blockNumber 8506655",
     "blockchain:contracts": "node --experimental-modules ./tests/e2e/setup-contracts.mjs",
     "blockchain:testrun": "concurrently -k -s first \"npm:blockchain\" \"npm:blockchain:contracts\"",
     "build": "run-s check-types build:css build:app",
@@ -57,7 +57,7 @@
     "@govtechsg/tradetrust-ui-components": "^2.18.16",
     "@govtechsg/tradetrust-utils": "^1.4.3",
     "@reduxjs/toolkit": "^1.6.1",
-    "@synthetixio/synpress": "^3.0.5",
+    "@synthetixio/synpress": "^3.5.1",
     "@types/gtag.js": "0.0.8",
     "cross-env": "^7.0.3",
     "date-fns": "^2.22.1",

--- a/public/static/index.html
+++ b/public/static/index.html
@@ -32,7 +32,7 @@
       src="https://www.googletagmanager.com/gtag/js?id=<%= htmlWebpackPlugin.options.GA_MEASUREMENT_ID %>"
     ></script>
     <script>
-      var option = JSON.parse("<%= JSON.stringify(htmlWebpackPlugin.options.GA_CONFIG_OPTION) %>");
+      var option = JSON.parse(`<%= JSON.stringify(htmlWebpackPlugin.options.GA_CONFIG_OPTION) %>`);
 
       window.dataLayer = window.dataLayer || [];
       function gtag() {

--- a/public/static/index.html
+++ b/public/static/index.html
@@ -22,9 +22,9 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Ubuntu:wght@400;700&display=swap" rel="stylesheet" />
+    <link href="https://use.fontawesome.com/releases/v5.2.0/css/all.css" rel="stylesheet" />
 
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-    <script src="https://kit.fontawesome.com/491fca5fd9.js" crossorigin="anonymous"></script>
 
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script
@@ -32,7 +32,7 @@
       src="https://www.googletagmanager.com/gtag/js?id=<%= htmlWebpackPlugin.options.GA_MEASUREMENT_ID %>"
     ></script>
     <script>
-      var option = JSON.parse('<%= JSON.stringify(htmlWebpackPlugin.options.GA_CONFIG_OPTION) %>');
+      var option = JSON.parse("<%= JSON.stringify(htmlWebpackPlugin.options.GA_CONFIG_OPTION) %>");
 
       window.dataLayer = window.dataLayer || [];
       function gtag() {
@@ -46,7 +46,7 @@
     <div id="root"></div>
     <script>
       if (window.netlifyIdentity) {
-        window.netlifyIdentity.on("init", user => {
+        window.netlifyIdentity.on("init", (user) => {
           if (!user) {
             window.netlifyIdentity.on("login", () => {
               document.location.href = "/imd@/";

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Ubuntu:ital,wght@0,300;0,400;0,500;0,700;1,300;1,400;1,500;1,700&display=swap");
-
 @font-face {
   font-family: "Gilroy-Light";
   src: url("https://ui.tradetrust.io/static/fonts/GilroyLight/font.woff2") format("woff2"),

--- a/tests/e2e/setup-contracts.mjs
+++ b/tests/e2e/setup-contracts.mjs
@@ -1,49 +1,45 @@
 import shell from "shelljs";
 
 const ACCOUNT_KEY = "0xe82294532bcfcd8e0763ee5cef194f36f00396be59b94fb418f5f8d83140d9a7";
-const TOKEN_REGISTRY_ADDRESS = "0xf18CD26780B6D3589371fb0b3fE8E2a513D6Fdc6"; // Pre-deployed on goerli using token-registry or oa-cli 
-const DOCUMENT_STORE_ADDRESS = "0x63A223E025256790E88778a01f480eBA77731D04"
+const TOKEN_REGISTRY_ADDRESS = "0xf18CD26780B6D3589371fb0b3fE8E2a513D6Fdc6"; // Pre-deployed on goerli using token-registry or oa-cli
 const ADDRESS_EXAMPLE_1 = "0xe0a71284ef59483795053266cb796b65e48b5124";
-const ADDRESS_EXAMPLE_2 = "0xcdfacbb428dd30ddf6d99875dcad04cbefcd6e60";
 const ADDRESS_EXAMPLE_3 = "0x391aFf3942857a10958425FebF1fC1938D9F5AE7";
 
-const oaCLI_PATH = "open-attestation"
-export const contractAddress = {
-  TitleEscrowFactory: "0x878A327daA390Bc602Ae259D3A374610356b6485",
-  Deployer: "0x9eBC30E7506E6Ce36eAc5507FCF0121BaF7AeA57",
-  TokenImplementation: "0xE5C75026d5f636C89cc77583B6BCe7C99F512763",
-};
+const oaCLI_PATH = "open-attestation";
 
 const defaultToken = {
   accountKey: ACCOUNT_KEY,
   tokenRegistryAddress: TOKEN_REGISTRY_ADDRESS,
   owner: ADDRESS_EXAMPLE_1,
   holder: ADDRESS_EXAMPLE_1,
-}
+};
 
 const merkleRootToMint = {
-  tokenRegistry: [{
-    // Endorse Owner
-    merkleRoot: "0xf82cf3c92462175888eda124a5227e0a46344ba09650e4ef85015d97e342251a",
-    ...defaultToken,
-  },{
-    // Nominate Owner
-    merkleRoot: "0x764fb454298834edfdb2d169f8397d7a6e4c4b997f872e6a0808e4a2e2bdb00e",
-    ...defaultToken,
-  },{
-    // Surrender
-    merkleRoot: "0xfb4a84f4b9e8e28c552eab1d94f5d4a831584082478f9fa83a2e8aac61e07c4a",
-    ...defaultToken,
-  },{
-    // Transfer Holder
-    merkleRoot: "0x1c92119b530b5028e8cb45e74624a5f52a1ae84d68e1c165776813a84722807a",
-    ...defaultToken,
-  },],
-}
+  tokenRegistry: [
+    {
+      // Endorse Owner
+      merkleRoot: "0xf82cf3c92462175888eda124a5227e0a46344ba09650e4ef85015d97e342251a",
+      ...defaultToken,
+    },
+    {
+      // Nominate Owner
+      merkleRoot: "0x764fb454298834edfdb2d169f8397d7a6e4c4b997f872e6a0808e4a2e2bdb00e",
+      ...defaultToken,
+    },
+    {
+      // Surrender
+      merkleRoot: "0xfb4a84f4b9e8e28c552eab1d94f5d4a831584082478f9fa83a2e8aac61e07c4a",
+      ...defaultToken,
+    },
+    {
+      // Transfer Holder
+      merkleRoot: "0x1c92119b530b5028e8cb45e74624a5f52a1ae84d68e1c165776813a84722807a",
+      ...defaultToken,
+    },
+  ],
+};
 
-shell.exec(`${oaCLI_PATH} deploy document-store "My Document Store" -n local -k ${ACCOUNT_KEY}`);  
-
-merkleRootToMint.tokenRegistry.forEach(element => {
+merkleRootToMint.tokenRegistry.forEach((element) => {
   shell.exec(
     `${oaCLI_PATH} token-registry issue --beneficiary ${element.owner} --holder ${element.holder} --address ${element.tokenRegistryAddress} --tokenId ${element.merkleRoot} -n local -k ${element.accountKey}`
   );

--- a/tests/e2e/specs/endorse-owner.spec.js
+++ b/tests/e2e/specs/endorse-owner.spec.js
@@ -1,8 +1,8 @@
 import { ACCOUNT_3 } from "../utils";
 
 before(() => {
-  cy.importMetamaskAccount("0xc58c1ff75001afdca8cecb61b47f36964febe4188b8f7b26252286ecae5a8879").should("be.true");
-  cy.switchMetamaskAccount(1).should("be.true");
+  cy.importMetamaskAccount("0xc58c1ff75001afdca8cecb61b47f36964febe4188b8f7b26252286ecae5a8879");
+  cy.switchMetamaskAccount(1);
 });
 
 describe("Endorse Owner", () => {

--- a/tests/e2e/specs/endorse-owner.spec.js
+++ b/tests/e2e/specs/endorse-owner.spec.js
@@ -1,4 +1,4 @@
-import { ACCOUNT_3, ACCOUNT_2 } from "../utils";
+import { ACCOUNT_3 } from "../utils";
 
 before(() => {
   cy.importMetamaskAccount("0xc58c1ff75001afdca8cecb61b47f36964febe4188b8f7b26252286ecae5a8879").should("be.true");
@@ -11,8 +11,8 @@ describe("Endorse Owner", () => {
     cy.get("input[type=file]").attachFile("ebl-endorse-owner.json");
     cy.get("[data-testid='asset-title-owner']").should("be.visible");
     cy.get("[data-testid='asset-title-holder']").should("be.visible");
-    cy.clickConnectAndManageAssetButton(true);
-    cy.get("[data-testid='endorseBeneficiaryDropdown']").click();
+    cy.clickConnectAndManageAssetButton(true); // approve all acccounts to application once after connect to wallet, subsequent tests no longer need `true`
+    cy.get("[data-testid='endorseBeneficiaryDropdown']").click(); // Endorse Change of Ownership
     cy.get("[data-testid='endorseBtn']").click();
     cy.confirmMetamaskTransaction();
     cy.get("[data-testid='non-editable-input-owner']").should("have.text", ACCOUNT_3);

--- a/tests/e2e/specs/nominate-owner.spec.js
+++ b/tests/e2e/specs/nominate-owner.spec.js
@@ -1,9 +1,5 @@
 import { ACCOUNT_1, ACCOUNT_2 } from "../utils";
 
-before(() => {
-  cy.switchMetamaskAccount(1).should("be.true");
-});
-
 describe("Nominate Owner", () => {
   context("Nominate Owner", () => {
     it("should go to verify page, upload a file, connect to wallet and nominate owner successfully", () => {

--- a/tests/e2e/specs/nominate-owner.spec.js
+++ b/tests/e2e/specs/nominate-owner.spec.js
@@ -11,8 +11,8 @@ describe("Nominate Owner", () => {
       cy.get("input[type=file]").attachFile("ebl-nominate-owner.json");
       cy.get("[data-testid='asset-title-owner']").should("be.visible");
       cy.get("[data-testid='asset-title-holder']").should("be.visible");
-      cy.clickConnectAndManageAssetButton(true);
-      cy.get("[data-testid='nominateBeneficiaryHolderDropdown']").click();
+      cy.clickConnectAndManageAssetButton();
+      cy.get("[data-testid='nominateBeneficiaryHolderDropdown']").click(); // Nominate Change of Ownership
       cy.get("[data-testid='editable-input-owner']").type(ACCOUNT_2);
       cy.get("[data-testid='nominationBtn']").click();
       cy.confirmMetamaskTransaction();
@@ -27,8 +27,8 @@ describe("Nominate Owner", () => {
       cy.get("input[type=file]").attachFile("ebl-nominate-owner.json");
       cy.get("[data-testid='asset-title-owner']").should("be.visible");
       cy.get("[data-testid='asset-title-holder']").should("be.visible");
-      cy.clickConnectAndManageAssetButton(true);
-      cy.get("[data-testid='endorseTransferDropdown']").click();
+      cy.clickConnectAndManageAssetButton();
+      cy.get("[data-testid='endorseTransferDropdown']").click(); // Endorse Transfer of Ownership
       cy.get("[data-testid='editable-input-holder']").clear();
       cy.get("[data-testid='editable-input-holder']").type(ACCOUNT_2);
       cy.get("[data-testid='endorseTransferBtn']").click();

--- a/tests/e2e/specs/surrender-1-reject.spec.js
+++ b/tests/e2e/specs/surrender-1-reject.spec.js
@@ -9,8 +9,8 @@ describe("Surrender-Reject", () => {
       cy.get("input[type=file]").attachFile("ebl-surrender.json");
       cy.get("[data-testid='asset-title-owner']").should("be.visible");
       cy.get("[data-testid='asset-title-holder']").should("be.visible");
-      cy.clickConnectAndManageAssetButton(true);
-      cy.get("[data-testid='surrenderDropdown']").click();
+      cy.clickConnectAndManageAssetButton();
+      cy.get("[data-testid='surrenderDropdown']").click(); // Surrender Document
       cy.get("[data-testid='surrenderBtn']").click();
       cy.confirmMetamaskTransaction();
       cy.get("#surrender-sign").should("have.text", "Surrendered To Issuer");
@@ -23,8 +23,8 @@ describe("Surrender-Reject", () => {
       cy.visit("/verify");
       cy.get("input[type=file]").attachFile("ebl-surrender.json");
       cy.get("[data-testid='surrenderToIssuer']").should("be.visible");
-      cy.clickConnectAndManageAssetButton(true);
-      cy.get("[data-testid='rejectSurrenderDropdown']").click();
+      cy.clickConnectAndManageAssetButton();
+      cy.get("[data-testid='rejectSurrenderDropdown']").click(); // Reject Surrender
       cy.get("[data-testid='rejectSurrenderBtn']").click();
       cy.get("[data-testid='confirmActionBtn']").click();
       cy.confirmMetamaskTransaction();

--- a/tests/e2e/specs/surrender-1-reject.spec.js
+++ b/tests/e2e/specs/surrender-1-reject.spec.js
@@ -1,7 +1,3 @@
-before(() => {
-  cy.switchMetamaskAccount(1).should("be.true");
-});
-
 describe("Surrender-Reject", () => {
   context("Surrender", () => {
     it("should go to verify page, upload a file, connect to wallet and surrender a document successfully", () => {

--- a/tests/e2e/specs/surrender-2-accept.spec.js
+++ b/tests/e2e/specs/surrender-2-accept.spec.js
@@ -1,7 +1,3 @@
-before(() => {
-  cy.switchMetamaskAccount(1).should("be.true");
-});
-
 describe("Surrender-Accept", () => {
   context("Surrender", () => {
     it("should go to verify page, upload a file, connect to wallet and surrender a document successfully", () => {

--- a/tests/e2e/specs/surrender-2-accept.spec.js
+++ b/tests/e2e/specs/surrender-2-accept.spec.js
@@ -9,8 +9,8 @@ describe("Surrender-Accept", () => {
       cy.get("input[type=file]").attachFile("ebl-surrender.json");
       cy.get("[data-testid='asset-title-owner']").should("be.visible");
       cy.get("[data-testid='asset-title-holder']").should("be.visible");
-      cy.clickConnectAndManageAssetButton(true);
-      cy.get("[data-testid='surrenderDropdown']").click();
+      cy.clickConnectAndManageAssetButton();
+      cy.get("[data-testid='surrenderDropdown']").click(); // Surrender Document
       cy.get("[data-testid='surrenderBtn']").click();
       cy.confirmMetamaskTransaction();
       cy.get("#surrender-sign").should("have.text", "Surrendered To Issuer");
@@ -23,8 +23,8 @@ describe("Surrender-Accept", () => {
       cy.visit("/verify");
       cy.get("input[type=file]").attachFile("ebl-surrender.json");
       cy.get("[data-testid='surrenderToIssuer']").should("be.visible");
-      cy.clickConnectAndManageAssetButton(true);
-      cy.get("[data-testid='acceptSurrenderDropdown']").click();
+      cy.clickConnectAndManageAssetButton();
+      cy.get("[data-testid='acceptSurrenderDropdown']").click(); // Accept Surrender
       cy.get("[data-testid='acceptSurrenderBtn']").click();
       cy.confirmMetamaskTransaction();
       cy.get("[data-testid='overlay-title']").should("have.text", "Surrender Accepted");

--- a/tests/e2e/specs/transfer-holder.spec.js
+++ b/tests/e2e/specs/transfer-holder.spec.js
@@ -10,8 +10,8 @@ describe("Transfer Holder", () => {
     cy.get("input[type=file]").attachFile("ebl-transfer-holder.json");
     cy.get("[data-testid='asset-title-owner']").should("be.visible");
     cy.get("[data-testid='asset-title-holder']").should("be.visible");
-    cy.clickConnectAndManageAssetButton(true);
-    cy.get("[data-testid='transferHolderDropdown']").click();
+    cy.clickConnectAndManageAssetButton();
+    cy.get("[data-testid='transferHolderDropdown']").click(); // Transfer Holdership
     cy.get("[data-testid='editable-input-holder']").type(ACCOUNT_2);
     cy.get("[data-testid='transferBtn']").click();
     cy.confirmMetamaskTransaction();

--- a/tests/e2e/specs/transfer-holder.spec.js
+++ b/tests/e2e/specs/transfer-holder.spec.js
@@ -1,9 +1,5 @@
 import { ACCOUNT_2 } from "../utils";
 
-before(() => {
-  cy.switchMetamaskAccount(1).should("be.true");
-});
-
 describe("Transfer Holder", () => {
   it("should go to verify page, upload a file, connect to wallet and transfer holder successfully", () => {
     cy.visit("/verify");


### PR DESCRIPTION
## Summary

synpress v3.0.5 started to fail consistently for **all** tests (metamask flow)

## Changes

- Tests:
  - v3.0.5 appears not to be adding local testnet during initial metamask setup
    - without local testnet, all tests will fail
    - bumping to v3.5.1 fixes it
  - tests sometimes fail due to font-awesome load. change to cdn link, with the same version as [tradetrust-ui](https://github.com/TradeTrust/tradetrust-ui-components/blob/4f8ff451c0d8f68a838b711b2b513acee7308d10/src/tailwind.css#L1)
  
![error-font-awesome](https://user-images.githubusercontent.com/4774314/232680611-2ab90d3c-10ca-47c3-82b2-b5bd7df4f6b9.png)

- Housekeep:
  - Remove deploying of local document store, not needed
  - Remove unused variables
  - Remove duplicate import of Ubuntu font
