### PR TITLE
fix: exn case for alphabet lists

### DIFF
--- a/cms/faq/what-are-some-pilots-that-have-involved-the-industry.md
+++ b/cms/faq/what-are-some-pilots-that-have-involved-the-industry.md
@@ -6,9 +6,9 @@ type: General
 The TradeTrust team in IMDA has orchestrated several industry-led eBL Trade Financing pilots involving Buyers, Sellers, Banks, Shipping Lines and Business Solution Providers. 
 
 These pilots seek to demonstrate TradeTrust’s ability to: 
-a. Digitalise the Bill of Lading document (among other required trade documents) which is commonly used in documentary trade financing arrangements
-b. Facilitate online presentation of all required electronic documents to the banks for verification and title ownership transfer (for eBL)
-c. Decentralise the transactions for an eBL by allowing pilot participants to use different digital solutions/platforms to verify and transact the digital document  
+1. Digitalise the Bill of Lading document (among other required trade documents) which is commonly used in documentary trade financing arrangements
+2. Facilitate online presentation of all required electronic documents to the banks for verification and title ownership transfer (for eBL)
+3. Decentralise the transactions for an eBL by allowing pilot participants to use different digital solutions/platforms to verify and transact the digital document  
 
 Below is an illustration of the pilot scope for documentary trade financing arrangements such as Letter of Credit (L/C), Documents against Acceptance (D/A) and Documents against Payment (D/P) where an eBL is issued, sent, verified and endorsed to the next party in the financing value chain. 
 

--- a/src/components/FAQ/FaqContent.tsx
+++ b/src/components/FAQ/FaqContent.tsx
@@ -32,20 +32,27 @@ export const FaqContent: FunctionComponent<FAQ> = ({ faqType }) => {
   return (
     <div className="flex flex-wrap mt-4">
       <div className="w-full lg:w-2/3">
-        {filteredFaqs.map((faq, index) => (
-          <AccordionItem
-            key={`faq-${index}`}
-            classNameContainer="bg-white mb-2"
-            classNameCollapse="rounded p-4"
-            classNameContent="pl-4 pr-16 pb-4"
-            heading={faq.attributes.title}
-            openIndex={openIndex}
-            accordionIndex={index}
-            setOpenIndex={setOpenIndex}
-          >
-            <ReactMarkdown className="wysiwyg">{faq.body}</ReactMarkdown>
-          </AccordionItem>
-        ))}
+        {filteredFaqs.map((faq, index) => {
+          const isPilotFaq = faq.attributes.title.includes("pilots");
+          return (
+            <AccordionItem
+              key={`faq-${index}`}
+              classNameContainer="bg-white mb-2"
+              classNameCollapse="rounded p-4"
+              classNameContent="pl-4 pr-16 pb-4"
+              heading={faq.attributes.title}
+              openIndex={openIndex}
+              accordionIndex={index}
+              setOpenIndex={setOpenIndex}
+            >
+              {isPilotFaq ? (
+                <ReactMarkdown className="wysiwyg pilot-faq">{faq.body}</ReactMarkdown>
+              ) : (
+                <ReactMarkdown className="wysiwyg">{faq.body}</ReactMarkdown>
+              )}
+            </AccordionItem>
+          );
+        })}
       </div>
       <div className="w-1/3 hidden lg:block">
         <img src="/static/images/faq/faq-person.png" alt="FAQ person" />

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -242,6 +242,10 @@
     @apply text-cerulean-300;
     @apply hover:text-cerulean-500;
   }
+  
+  .pilot-faq li {
+    @apply list-[lower-alpha];
+  }
 
   @media print {
     .no-print {


### PR DESCRIPTION
## Summary

Markdown does not have alphabetical lists, thus react-markdown renders it wrongly
Tried to negotiate only using ordered lists, but unable to do so.
dont really like this solution.

https://www.pivotaltracker.com/story/show/184734692