### PR TITLE
fix: token registry roles

### DIFF
--- a/src/common/hooks/useTokenRegistryRole.ts
+++ b/src/common/hooks/useTokenRegistryRole.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { useContractFunctionHook } from "@govtechsg/ethers-contract-hook";
+import { TradeTrustToken } from "@govtechsg/token-registry/dist/contracts";
+import { BytesLike } from "ethers";
+
+export const useTokenRegistryRole = ({
+  account,
+  role,
+  tokenRegistry,
+}: {
+  tokenRegistry?: TradeTrustToken;
+  account?: string;
+  role: BytesLike;
+}): {
+  hasRole?: boolean;
+} => {
+  const [hasRoleState, setHasRoleState] = useState<boolean>();
+  const { call: checkRole, value: hasRole, reset: resetCheckRole } = useContractFunctionHook(tokenRegistry, "hasRole");
+
+  useEffect(() => {
+    if (account) {
+      checkRole(role, account);
+      resetCheckRole();
+    }
+  }, [role, account, checkRole, tokenRegistry, resetCheckRole]);
+
+  useEffect(() => {
+    setHasRoleState(hasRole?.[0]);
+  }, [hasRole]);
+
+  return { hasRole: hasRoleState };
+};

--- a/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementDropdown/AssetManagementDropdown.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementDropdown/AssetManagementDropdown.tsx
@@ -5,7 +5,8 @@ import { AssetManagementActions } from "./../../AssetManagementActions";
 interface AssetManagementDropdownProps {
   onSetFormAction: (nextFormAction: AssetManagementActions) => void;
   canSurrender: boolean;
-  canHandleSurrender?: boolean;
+  canHandleShred?: boolean;
+  canHandleRestore?: boolean;
   canChangeHolder: boolean;
   canEndorseBeneficiary: boolean;
   canNominateBeneficiary: boolean;
@@ -15,7 +16,8 @@ interface AssetManagementDropdownProps {
 export const AssetManagementDropdown: FunctionComponent<AssetManagementDropdownProps> = ({
   onSetFormAction,
   canSurrender,
-  canHandleSurrender,
+  canHandleShred,
+  canHandleRestore,
   canChangeHolder,
   canEndorseBeneficiary,
   canNominateBeneficiary,
@@ -66,23 +68,23 @@ export const AssetManagementDropdown: FunctionComponent<AssetManagementDropdownP
           Surrender Document
         </DropdownItem>
       )}
-      {canHandleSurrender && (
-        <>
-          <DropdownItem
-            className="active:bg-cloud-200 active:text-white"
-            data-testid={"acceptSurrenderDropdown"}
-            onClick={() => onSetFormAction(AssetManagementActions.AcceptSurrendered)}
-          >
-            Accept Surrender of Document
-          </DropdownItem>
-          <DropdownItem
-            className="active:bg-cloud-200 active:text-white"
-            data-testid={"rejectSurrenderDropdown"}
-            onClick={() => onSetFormAction(AssetManagementActions.RejectSurrendered)}
-          >
-            Reject Surrender of Document
-          </DropdownItem>
-        </>
+      {canHandleShred && (
+        <DropdownItem
+          className="active:bg-cloud-200 active:text-white"
+          data-testid={"acceptSurrenderDropdown"}
+          onClick={() => onSetFormAction(AssetManagementActions.AcceptSurrendered)}
+        >
+          Accept Surrender of Document
+        </DropdownItem>
+      )}
+      {canHandleRestore && (
+        <DropdownItem
+          className="active:bg-cloud-200 active:text-white"
+          data-testid={"rejectSurrenderDropdown"}
+          onClick={() => onSetFormAction(AssetManagementActions.RejectSurrendered)}
+        >
+          Reject Surrender of Document
+        </DropdownItem>
       )}
 
       {canEndorseTransfer && (

--- a/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementForm.stories.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementForm.stories.tsx
@@ -618,7 +618,6 @@ export const SurrenderedNotMinter = () => {
       beneficiary="0xa61B056dA0084a5f391EC137583073096880C2e3"
       approvedBeneficiary=""
       holder="0xa61B056dA0084a5f391EC137583073096880C2e3"
-      // documentOwner=""
       formAction={assetManagementAction}
       tokenRegistryAddress="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
       documentOwner="0xdA8DBd2Aaffc995F11314c0040716E791de5aEd2"
@@ -642,7 +641,8 @@ export const SurrenderedNotMinter = () => {
       isTokenBurnt={false}
       onRestoreToken={() => alert("Reject document surrender")}
       restoreTokenState={FormState.UNINITIALIZED}
-      isMinter={false}
+      isAcceptor={false}
+      isRestorer={false}
     />
   );
 };
@@ -681,7 +681,8 @@ export const SurrenderedIsMinter = () => {
       isTokenBurnt={false}
       onRestoreToken={() => alert("Reject document surrender")}
       restoreTokenState={FormState.UNINITIALIZED}
-      isMinter={true}
+      isRestorer={true}
+      isAcceptor={true}
     />
   );
 };
@@ -720,7 +721,8 @@ export const SurrenderedAcceptForm = () => {
       isTokenBurnt={false}
       onRestoreToken={() => alert("Reject document surrender")}
       restoreTokenState={FormState.UNINITIALIZED}
-      isMinter={true}
+      isAcceptor={true}
+      isRestorer={false}
     />
   );
 };
@@ -761,7 +763,8 @@ export const SurrenderedRejectForm = () => {
         isTokenBurnt={false}
         onRestoreToken={() => alert("Reject document surrender")}
         restoreTokenState={FormState.UNINITIALIZED}
-        isMinter={true}
+        isRestorer={true}
+        isAcceptor={false}
       />
     </OverlayContextProvider>
   );

--- a/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementForm.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/AssetManagementForm.tsx
@@ -16,7 +16,8 @@ interface AssetManagementFormProps {
   holder?: string;
   approvedBeneficiary?: string;
   documentOwner?: string;
-  isMinter?: boolean;
+  isRestorer?: boolean;
+  isAcceptor?: boolean;
   tokenRegistryAddress: string;
   account?: string;
   formAction: AssetManagementActions;
@@ -56,7 +57,8 @@ export const AssetManagementForm: FunctionComponent<AssetManagementFormProps> = 
   onSurrender,
   onDestroyToken,
   documentOwner,
-  isMinter,
+  isRestorer,
+  isAcceptor,
   onTransferHolder,
   holderTransferringState,
   onEndorseBeneficiary,
@@ -82,7 +84,8 @@ export const AssetManagementForm: FunctionComponent<AssetManagementFormProps> = 
     - documentOwner is the tokenRegistry
     - currentUser === tokenRegistryMinter
   */
-  const canHandleSurrender = isTitleEscrow && isMinter && isSurrendered && documentOwner === tokenRegistryAddress;
+  const canHandleRestore = isTitleEscrow && isRestorer && isSurrendered && documentOwner === tokenRegistryAddress;
+  const canHandleShred = isTitleEscrow && isAcceptor && isSurrendered && documentOwner === tokenRegistryAddress;
 
   // canEndorseBeneficiary
   // function transferBeneficiary(address beneficiaryNominee) external;
@@ -226,7 +229,8 @@ export const AssetManagementForm: FunctionComponent<AssetManagementFormProps> = 
           holder={holder}
           account={account}
           canSurrender={canSurrender}
-          canHandleSurrender={canHandleSurrender}
+          canHandleRestore={canHandleRestore}
+          canHandleShred={canHandleShred}
           onConnectToWallet={onConnectToWallet}
           canChangeHolder={canTransferHolder}
           canEndorseBeneficiary={canTransferBeneficiary}

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.test.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.test.tsx
@@ -186,7 +186,7 @@ describe("ActionSelectionForm", () => {
         {...defaultProps}
         onSetFormAction={mockOnSetFormAction}
         isTitleEscrow={false}
-        canHandleSurrender={true}
+        canHandleShred={true}
       />
     );
 
@@ -209,7 +209,7 @@ describe("ActionSelectionForm", () => {
         {...defaultProps}
         onSetFormAction={mockOnSetFormAction}
         isTitleEscrow={false}
-        canHandleSurrender={true}
+        canHandleRestore={true}
       />
     );
 

--- a/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementForm/FormVariants/ActionSelectionForm/ActionSelectionForm.tsx
@@ -13,7 +13,8 @@ interface ActionSelectionFormProps {
   holder?: string;
   account?: string;
   canSurrender: boolean;
-  canHandleSurrender?: boolean;
+  canHandleShred?: boolean;
+  canHandleRestore?: boolean;
   onConnectToWallet: () => void;
   canChangeHolder: boolean;
   canEndorseBeneficiary: boolean;
@@ -32,7 +33,8 @@ export const ActionSelectionForm: FunctionComponent<ActionSelectionFormProps> = 
   holder,
   account,
   canSurrender,
-  canHandleSurrender,
+  canHandleShred,
+  canHandleRestore,
   onConnectToWallet,
   canChangeHolder,
   canEndorseBeneficiary,
@@ -44,7 +46,8 @@ export const ActionSelectionForm: FunctionComponent<ActionSelectionFormProps> = 
   isTitleEscrow,
 }) => {
   const canManage =
-    canHandleSurrender ||
+    canHandleShred ||
+    canHandleRestore ||
     canSurrender ||
     canChangeHolder ||
     canEndorseBeneficiary ||
@@ -127,7 +130,8 @@ export const ActionSelectionForm: FunctionComponent<ActionSelectionFormProps> = 
                     canEndorseBeneficiary={canEndorseBeneficiary}
                     canNominateBeneficiary={canNominateBeneficiary}
                     canEndorseTransfer={canEndorseTransfer}
-                    canHandleSurrender={canHandleSurrender}
+                    canHandleRestore={canHandleRestore}
+                    canHandleShred={canHandleShred}
                   />
                 ) : (
                   <Button


### PR DESCRIPTION
## Summary

Switch from using token-registry creator to assigned roles

## Changes

hook
`src/common/hooks/useTokenRegistryRole.ts`
split of `isMinter` to `hasRestorerRole` and `hasAcceptorRole`

## Issues


