### PR TITLE
fix: omit magic

### DIFF
--- a/src/common/contexts/AuthenticationContext/AuthContext.tsx
+++ b/src/common/contexts/AuthenticationContext/AuthContext.tsx
@@ -9,8 +9,8 @@ interface AuthContextProps {
 
 const AuthContext = createContext<AuthContextProps>({
   isLoggedIn: false,
-  login: async () => new Promise((resolve) => resolve()),
-  logout: async () => new Promise((resolve) => resolve()),
+  login: async () => new Promise<void>((resolve) => resolve()),
+  logout: async () => new Promise<void>((resolve) => resolve()),
 });
 
 /**

--- a/src/common/contexts/helpers.tsx
+++ b/src/common/contexts/helpers.tsx
@@ -1,6 +1,9 @@
-import { Magic } from "magic-sdk";
-import { MAGIC_API_KEY } from "../../config";
+// import { Magic } from "magic-sdk";
+// import { MAGIC_API_KEY } from "../../config";
 
-export const magic = new Magic(MAGIC_API_KEY, {
-  network: "goerli", // fix to goerli network only
-});
+// export const magic = new Magic(MAGIC_API_KEY, {
+//   network: "goerli", // fix to goerli network only
+// });
+
+const dummyMagic: unknown = {}; // HOT FIX (removal of magic demo until we make a decision whether to kill it or not)
+export const magic = dummyMagic as any; // HOT FIX (removal of magic demo until we make a decision whether to kill it or not)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = {
     ],
   },
   plugins: [
+    new webpack.IgnorePlugin(/magic-sdk$/), // HOT FIX (Temp removal of magic demo until we might decide to kill it)
     new webpack.EnvironmentPlugin({
       // need to define variables here, so later can be overwritten at netlify env var end
       // TODO: use dotenv instead


### PR DESCRIPTION
## Summary

Omit magic dependancy in build

## Changes

- ignore magic-sdk in webpack

## Issues

before:

![magic-warnings](https://github.com/TradeTrust/tradetrust-website/assets/4774314/55e2470d-c858-4935-b260-e007ee3a887b)

after:
![magic-no-more](https://github.com/TradeTrust/tradetrust-website/assets/4774314/7cd799d5-a7c1-4e0f-ab72-c7cbf05db91c)
