### PR TITLE
fix: skip and exit

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,11 +1,11 @@
-name: Lighthouse Report
+name: Lighthouse
 
 on: [push]
 
 jobs:
   lhci:
     if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
-    name: Lighthouse
+    name: Lighthouse Desktop
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -1,10 +1,10 @@
-name: Lint & Test
+name: Test
 
 on: [push]
 
 jobs:
   test:
-    name: Lint & Test
+    name: Lint & Test & Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -1,10 +1,10 @@
-name: Lint & Test
+name: Test
 
 on: [push]
 
 jobs:
   test:
-    name: Lint & Test & Build
+    name: Lint & Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Lint & Test
 
 on: [push]
 

--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -18,3 +18,5 @@ jobs:
       - name: Test
         if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
         run: npm run test
+      - name: Build
+        run: npm run build:prod

--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -19,4 +19,4 @@ jobs:
         if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
         run: npm run test
       - name: Build
-        run: npm run build:prod
+        run: npm run build:prod # this MUST be run to ensure production site will be built without errors

--- a/.github/workflows/synpress.yml
+++ b/.github/workflows/synpress.yml
@@ -3,10 +3,10 @@ name: Synpress
 on: [push]
 
 jobs:
-  e2e:
+  synpress:
     if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
     # https://github.com/drptbl/synpress-setup-example/blob/1d980157ef343de54f786e1115e1da590f1ba1d1/.github/workflows/e2e.yml#L49-L102
-    name: Synpress Tests
+    name: Synpress e2e Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,4 +24,3 @@ jobs:
             ${{ runner.os }}-buildx-
       - name: Run e2e tests
         run: docker-compose up --build --exit-code-from synpress
-

--- a/.github/workflows/synpress.yml
+++ b/.github/workflows/synpress.yml
@@ -6,7 +6,7 @@ jobs:
   synpress:
     if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
     # https://github.com/drptbl/synpress-setup-example/blob/1d980157ef343de54f786e1115e1da590f1ba1d1/.github/workflows/e2e.yml#L49-L102
-    name: Synpress e2e Tests
+    name: Synpress e2e Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -4,10 +4,17 @@ on: [push]
 
 jobs:
   testcafe:
-    if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
     name: Testcafe e2e Test
     runs-on: ubuntu-latest
     steps:
+      - name: Check skip condition
+        run: |
+          if [[ ${{ contains(github.event.head_commit.message, '[skip test]') }} ]]; then
+            echo "Condition met. Exit 0 early with success."
+            exit 0
+          else
+            echo "Condition not met. Continue with test."
+          fi
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -7,18 +7,13 @@ jobs:
     name: Testcafe e2e Test
     runs-on: ubuntu-latest
     steps:
-      - name: Check skip condition
-        run: |
-          if [[ ${{ contains(github.event.head_commit.message, '[skip test]') }} ]]; then
-            echo "Condition met. Exit 0 early with success."
-            exit 0
-          else
-            echo "Condition not met. Continue with test."
-          fi
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: "14"
+      - name: Exit with success
+        if: ${{ contains(github.event.head_commit.message, '[skip test]') }}
+        run: exit 0
       - name: Install Packages
         run: npm ci
       - name: Build

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -3,15 +3,7 @@ name: Testcafe
 on: [push]
 
 jobs:
-  exit:
-    if: ${{ contains(github.event.head_commit.message, '[skip test]') }}
-    name: Exit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Exit with Success
-        run: exit 0 # to pass required branch check
   testcafe:
-    if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
     name: Testcafe e2e Test
     runs-on: ubuntu-latest
     steps:
@@ -20,10 +12,13 @@ jobs:
         with:
           node-version: "14"
       - name: Install Packages
+        if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
         run: npm ci
       - name: Build
+        if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
         run: npm run build:test
       - name: Integration - testcafe
+        if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
         id: testcafe
         run: npm run integration:testcafe:ci
       - name: Upload Artifact

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   testcafe:
     if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
-    name: Testcafe e2e Tests
+    name: Testcafe e2e Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -3,7 +3,15 @@ name: Testcafe
 on: [push]
 
 jobs:
+  exit:
+    if: ${{ contains(github.event.head_commit.message, '[skip test]') }}
+    name: Exit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Exit with Success
+        run: exit 0 # to pass required branch check
   testcafe:
+    if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
     name: Testcafe e2e Test
     runs-on: ubuntu-latest
     steps:
@@ -11,9 +19,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "14"
-      - name: Exit with success
-        if: ${{ contains(github.event.head_commit.message, '[skip test]') }}
-        run: exit 0
       - name: Install Packages
         run: npm ci
       - name: Build

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -3,8 +3,9 @@ name: Testcafe
 on: [push]
 
 jobs:
-  test:
-    name: Testcafe e2e Test
+  testcafe:
+    if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
+    name: Testcafe e2e Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -17,7 +18,6 @@ jobs:
         run: npm run build:test
       - name: Integration - testcafe
         id: testcafe
-        if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
         run: npm run integration:testcafe:ci
       - name: Upload Artifact
         if: ${{ failure() && steps.testcafe.outcome == 'failure' }}


### PR DESCRIPTION
- ensure `npm run build:prod` is ran and required by branch protection, regardless of [skip test]
- skipping each step in `Testcafe e2e Test`, no straight forward way to manage conditionals in action, exit 0 needed for branch protection