### PR TITLE
fix: alchemy keys

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -18,7 +18,7 @@ module.exports = {
   },
   INFURA_API_KEY: process.env.INFURA_API_KEY || "bb46da3f80e040e8ab73c0a9ff365d18",
   INFURA_PROJECT_ID: "1f1ff2b3fca04f8d99f67d465c59e4ef",
-  ALCHEMY_API_KEY: process.env.ALCHEMY_API_KEY || "pV9JmoYcDFFBihXlJWt6FSDxzNAVWxdT",
+  ALCHEMY_API_KEY: process.env.ALCHEMY_API_KEY || "483Uqp_0SP0NnXI0secbJgrSRXv4OXaj",
   IS_DEVELOPMENT,
   IS_MAINNET,
   MAGIC_API_KEY: process.env.MAGIC_API_KEY || process.env.MAGIC_API_KEY_FALLBACK || "pk_test_AB1F885AF848182E", // dlt gmail fallback

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,12 +48,11 @@ module.exports = {
   plugins: [
     new webpack.IgnorePlugin(/magic-sdk$/), // HOT FIX (Temp removal of magic demo until we might decide to kill it)
     new webpack.EnvironmentPlugin({
-      // need to define variables here, so later can be overwritten at netlify env var end
-      // TODO: use dotenv instead
       NODE_ENV: "development",
       NET: "sepolia",
       INFURA_API_KEY: "bb46da3f80e040e8ab73c0a9ff365d18",
-    }),
+      ALCHEMY_API_KEY: "483Uqp_0SP0NnXI0secbJgrSRXv4OXaj",
+    }), // fallbacks for each respective env, if not defined at netlify end
     new HtmlWebpackPlugin({
       filename: "index.html",
       template: `${__dirname}/public/static/index.html`,


### PR DESCRIPTION
- as per introduced [since](https://github.com/TradeTrust/tradetrust-website/pull/769/files#diff-1523e3000d64e09cd6eb8370a4568715090b6763fd9192f61ab6044ac6d86fa9R21).
  - only used in querying fixtures in integration tests.
- this pr cleans up the alchemy keys used. free tier gives 300 million [compute units](https://docs.alchemy.com/reference/compute-units).
  - 1 run as of today on this pr consumes around 38 requests, 1140 compute units.