### PR TITLE
fix: skip job [skip test]

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lhci:
-    if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
+    if: ${{ !contains(github.event.pull_request.title, '[skip test]') }}
     name: Lighthouse Desktop
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check Lint
         run: npm run lint
       - name: Test
-        if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
+        if: ${{ !contains(github.event.pull_request.title, '[skip test]') }}
         run: npm run test
       - name: Build
         run: npm run build:prod # this MUST be run to ensure production site will be built without errors

--- a/.github/workflows/synpress.yml
+++ b/.github/workflows/synpress.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   synpress:
-    if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
+    if: ${{ !contains(github.event.pull_request.title, '[skip test]') }}
     # https://github.com/drptbl/synpress-setup-example/blob/1d980157ef343de54f786e1115e1da590f1ba1d1/.github/workflows/e2e.yml#L49-L102
     name: Synpress e2e Test
     runs-on: ubuntu-latest

--- a/.github/workflows/testcafe.yml
+++ b/.github/workflows/testcafe.yml
@@ -16,13 +16,13 @@ jobs:
         with:
           node-version: "14"
       - name: Install Packages
-        if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
+        if: ${{ !contains(github.event.pull_request.title, '[skip test]') }}
         run: npm ci
       - name: Build
-        if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
+        if: ${{ !contains(github.event.pull_request.title, '[skip test]') }}
         run: npm run build:test
       - name: Integration - testcafe
-        if: ${{ !contains(github.event.head_commit.message, '[skip test]') }}
+        if: ${{ !contains(github.event.pull_request.title, '[skip test]') }}
         id: testcafe
         run: npm run integration:testcafe:ci
       - name: Upload Artifact


### PR DESCRIPTION
## Summary

- for outside contributor to be able to run github actions, the yml configuration needs be to set on `pull_request` event, hence the change in https://github.com/TradeTrust/tradetrust-website/pull/798. read more [here](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks).
- this however, results in `github.event.head_commit.message` being empty during `pull_request` event and hence not skipping job correctly for all cms related edits.


## Changes

- easiest way is to update `github.event.head_commit.message` to `github.event.pull_request.title`
  - do note that this would mean the jobs will run on master when merged.
- i've explored other solutions which can be more robust, but at the expense of being convoluted. happy to discuss if interested.
