### PR TITLE
fix: update address-identity-resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3128,25 +3128,448 @@
       "dev": true
     },
     "@govtechsg/address-identity-resolver": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@govtechsg/address-identity-resolver/-/address-identity-resolver-1.4.1.tgz",
-      "integrity": "sha512-1pve3vymWUlPuf5N1ii7txLBiVN0CKX4PbJbj1noCTsSTzLGDIjdOCScQU7a9vATEv3UKUogAAsaJ2PT8ngiGw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@govtechsg/address-identity-resolver/-/address-identity-resolver-1.5.0.tgz",
+      "integrity": "sha512-ylRwzVQr7pDJodi8KKswgrDnWy3wQ2QIt3S9XpnjY+DQhrLk9HUbCox+bVEJ82T1BwXN/Xzo6qUXfDfdppJdow==",
       "requires": {
-        "axios": "^0.19.0",
+        "axios": "^0.27.2",
         "axios-extensions": "^3.1.3",
         "debug": "^4.1.1",
-        "ethers": "^5.0.17",
+        "ethers": "^5.7.2",
         "papaparse": "^5.3.0",
-        "query-string": "^6.13.7",
+        "query-string": "^7.1.3",
         "use-persisted-state": "^0.3.0"
       },
       "dependencies": {
-        "query-string": {
-          "version": "6.14.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-          "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+        "@ethersproject/abi": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+          "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
           "requires": {
-            "decode-uri-component": "^0.2.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/abstract-provider": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+          "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/networks": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/web": "^5.7.0"
+          }
+        },
+        "@ethersproject/abstract-signer": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+          "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
+          }
+        },
+        "@ethersproject/address": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+          "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0"
+          }
+        },
+        "@ethersproject/base64": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+          "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0"
+          }
+        },
+        "@ethersproject/basex": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
+          "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0"
+          }
+        },
+        "@ethersproject/bignumber": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+          "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "bn.js": "^5.2.1"
+          }
+        },
+        "@ethersproject/bytes": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+          "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+          "requires": {
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/constants": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+          "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0"
+          }
+        },
+        "@ethersproject/contracts": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
+          "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
+          "requires": {
+            "@ethersproject/abi": "^5.7.0",
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0"
+          }
+        },
+        "@ethersproject/hash": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+          "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/base64": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/hdnode": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
+          "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/basex": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/pbkdf2": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0",
+            "@ethersproject/signing-key": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/wordlists": "^5.7.0"
+          }
+        },
+        "@ethersproject/json-wallets": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
+          "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+          "requires": {
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/hdnode": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/pbkdf2": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/random": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "aes-js": "3.0.0",
+            "scrypt-js": "3.0.1"
+          }
+        },
+        "@ethersproject/keccak256": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+          "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "js-sha3": "0.8.0"
+          }
+        },
+        "@ethersproject/logger": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+          "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig=="
+        },
+        "@ethersproject/networks": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+          "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
+          "requires": {
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/pbkdf2": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
+          "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0"
+          }
+        },
+        "@ethersproject/properties": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+          "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
+          "requires": {
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/providers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
+          "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/base64": "^5.7.0",
+            "@ethersproject/basex": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/networks": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/random": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/web": "^5.7.0",
+            "bech32": "1.1.4",
+            "ws": "7.4.6"
+          }
+        },
+        "@ethersproject/random": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
+          "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/rlp": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+          "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/sha2": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
+          "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/signing-key": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+          "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "bn.js": "^5.2.1",
+            "elliptic": "6.5.4",
+            "hash.js": "1.1.7"
+          }
+        },
+        "@ethersproject/solidity": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
+          "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/sha2": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/strings": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+          "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/transactions": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+          "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
+          "requires": {
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0",
+            "@ethersproject/signing-key": "^5.7.0"
+          }
+        },
+        "@ethersproject/units": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
+          "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
+          "requires": {
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/constants": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0"
+          }
+        },
+        "@ethersproject/wallet": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
+          "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+          "requires": {
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/abstract-signer": "^5.7.0",
+            "@ethersproject/address": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/hdnode": "^5.7.0",
+            "@ethersproject/json-wallets": "^5.7.0",
+            "@ethersproject/keccak256": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/random": "^5.7.0",
+            "@ethersproject/signing-key": "^5.7.0",
+            "@ethersproject/transactions": "^5.7.0",
+            "@ethersproject/wordlists": "^5.7.0"
+          }
+        },
+        "@ethersproject/web": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+          "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
+          "requires": {
+            "@ethersproject/base64": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "@ethersproject/wordlists": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
+          "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+          "requires": {
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/hash": "^5.7.0",
+            "@ethersproject/logger": "^5.7.0",
+            "@ethersproject/properties": "^5.7.0",
+            "@ethersproject/strings": "^5.7.0"
+          }
+        },
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+        },
+        "decode-uri-component": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+          "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
+        },
+        "ethers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+          "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+          "requires": {
+            "@ethersproject/abi": "5.7.0",
+            "@ethersproject/abstract-provider": "5.7.0",
+            "@ethersproject/abstract-signer": "5.7.0",
+            "@ethersproject/address": "5.7.0",
+            "@ethersproject/base64": "5.7.0",
+            "@ethersproject/basex": "5.7.0",
+            "@ethersproject/bignumber": "5.7.0",
+            "@ethersproject/bytes": "5.7.0",
+            "@ethersproject/constants": "5.7.0",
+            "@ethersproject/contracts": "5.7.0",
+            "@ethersproject/hash": "5.7.0",
+            "@ethersproject/hdnode": "5.7.0",
+            "@ethersproject/json-wallets": "5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/logger": "5.7.0",
+            "@ethersproject/networks": "5.7.1",
+            "@ethersproject/pbkdf2": "5.7.0",
+            "@ethersproject/properties": "5.7.0",
+            "@ethersproject/providers": "5.7.2",
+            "@ethersproject/random": "5.7.0",
+            "@ethersproject/rlp": "5.7.0",
+            "@ethersproject/sha2": "5.7.0",
+            "@ethersproject/signing-key": "5.7.0",
+            "@ethersproject/solidity": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "@ethersproject/transactions": "5.7.0",
+            "@ethersproject/units": "5.7.0",
+            "@ethersproject/wallet": "5.7.0",
+            "@ethersproject/web": "5.7.1",
+            "@ethersproject/wordlists": "5.7.0"
+          }
+        },
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        },
+        "query-string": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+          "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+          "requires": {
+            "decode-uri-component": "^0.2.2",
             "filter-obj": "^1.1.0",
             "split-on-first": "^1.0.0",
             "strict-uri-encode": "^2.0.0"
@@ -12264,11 +12687,29 @@
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "follow-redirects": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+          "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "axios-extensions": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "wait": "wait-on -l -i 1000 tcp:8545 http-get://localhost:3000"
   },
   "dependencies": {
-    "@govtechsg/address-identity-resolver": "^1.4.1",
+    "@govtechsg/address-identity-resolver": "^1.5.0",
     "@govtechsg/decentralized-renderer-react-components": "^3.8.0",
     "@govtechsg/document-store": "^2.6.1",
     "@govtechsg/ethers-contract-hook": "^2.2.0",


### PR DESCRIPTION
## Summary

Update `address-identity-resolver` to v1.5.0 to resolve [CVE-2021-3749](https://www.cve.org/CVERecord?id=CVE-2021-3749) and [CVSS 7.5](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C).

## Changes

- Update `address-identity-resolver` to v1.5.0.

## Issues

- https://www.pivotaltracker.com/story/show/185636282
- https://github.com/TradeTrust/address-identity-resolver/pull/8
