### PR TITLE
Updated RPC for XDC Network

### DIFF
--- a/src/constants/chain-info.ts
+++ b/src/constants/chain-info.ts
@@ -108,7 +108,7 @@ export const ChainInfo: ChainInfo = {
     networkName: "xdc",
     networkLabel: "XDC Network",
     explorerUrl: "https://xdcscan.io",
-    rpcUrl: "https://erpc.xinfin.network",
+    rpcUrl: "https://rpc.ankr.com/xdc",
     nativeCurrency: {
       name: "XDC",
       symbol: "XDC",
@@ -122,7 +122,7 @@ export const ChainInfo: ChainInfo = {
     networkName: "xdcapothem",
     networkLabel: "XDC Testnet Apothem",
     explorerUrl: "https://apothem.xdcscan.io",
-    rpcUrl: "https://apothem.xdcrpc.com",
+    rpcUrl: "https://rpc.ankr.com/xdc_testnet",
     nativeCurrency: {
       name: "XDCt",
       symbol: "XDCt",


### PR DESCRIPTION
## Summary

What is the background of this pull request?
Updated RPC URL for XDC network on mainnet and testnet.

## Changes
Updated the configuration files containing RPC URLs.

<img width="860" alt="Screenshot 2024-02-16 at 11 06 23 AM" src="https://github.com/TradeTrust/tradetrust-website/assets/39335466/b060adfc-cdb6-4af4-86a2-bab171e1e3b4">
