### PR TITLE
fix: connect wallet with address of undefined

### DIFF
--- a/src/common/contexts/provider.tsx
+++ b/src/common/contexts/provider.tsx
@@ -146,6 +146,9 @@ export const ProviderContextProvider: FunctionComponent<ProviderContextProviderP
     await web3Provider.send("eth_requestAccounts", []);
     const chainInfo = getChainInfo(currentChainId ?? defaultChainId);
     await walletSwitchChain(chainInfo.chainId);
+    const signer = web3Provider.getSigner();
+    const address = await signer.getAddress();
+    setAccount(address);
 
     setProviderType(SIGNER_TYPE.METAMASK);
   };


### PR DESCRIPTION
## Summary

There is a bug where could not connect to Sepolia wallet metamask address

## Changes

- provider context - `initializeMetaMaskSigner` to set address on click

## Issues


