### PR TITLE
fix: metamask chainid bug

### DIFF
--- a/src/common/utils/chain-utils.ts
+++ b/src/common/utils/chain-utils.ts
@@ -53,7 +53,7 @@ export const walletSwitchChain = async (chainId: ChainId): Promise<void> => {
   try {
     await ethereum.request({
       method: "wallet_switchEthereumChain",
-      params: [{ chainId: `0x${chainId.toString(16)}` }],
+      params: [{ chainId: `0x${(+chainId).toString(16)}` }],
     });
   } catch (e: any) {
     if (e.code === -32601) {
@@ -83,7 +83,7 @@ export const walletAddChain = async (chainId: ChainId): Promise<void> => {
       method: "wallet_addEthereumChain",
       params: [
         {
-          chainId: `0x${chainId.toString(16)}`,
+          chainId: `0x${(+chainId).toString(16)}`,
           chainName: chainInfo.networkLabel,
           nativeCurrency: chainInfo.nativeCurrency,
           blockExplorerUrls: [chainInfo.explorerUrl],


### PR DESCRIPTION
## Summary

There is a configuration bug in metamask that concerns the utilization of the urls during the scanning of qr code

## Changes

Accurate parsing of the chainid extracted from urls
