### PR TITLE
Updated archive RPC for XDC

### DIFF
--- a/src/constants/chain-info.ts
+++ b/src/constants/chain-info.ts
@@ -114,7 +114,7 @@ export const ChainInfo: ChainInfo = {
     networkName: "xdc",
     networkLabel: "XDC Network",
     explorerUrl: "https://xdcscan.io",
-    rpcUrl: "https://rpc.ankr.com/xdc",
+    rpcUrl: "https://tradetrustrpc.xdcrpc.com",
     nativeCurrency: {
       name: "XDC",
       symbol: "XDC",
@@ -128,7 +128,7 @@ export const ChainInfo: ChainInfo = {
     networkName: "xdcapothem",
     networkLabel: "XDC Testnet Apothem",
     explorerUrl: "https://apothem.xdcscan.io",
-    rpcUrl: "https://rpc.ankr.com/xdc_testnet",
+    rpcUrl: "https://tradetrustarpc.xdcrpc.com",
     nativeCurrency: {
       name: "XDCt",
       symbol: "XDCt",


### PR DESCRIPTION
## Summary

What is the background of this pull request?
Change the RPC after setting up a dedicated loadbalance archival RPC on Mainnet and Testnet for TradeTrust to prevent future RPC issues. This archival RPC will include load balancing and will be connected to multiple RPC providers to ensure maximum uptime.

## Changes
Updated the configuration files containing RPC URLs.
<img width="677" alt="image" src="https://github.com/TradeTrust/tradetrust-website/assets/39335466/868b0b9c-b373-42ca-a4d6-6fd44a141fe8">

## Issues
View endorsement chain during verification of document fails as it requires archival node to fetch complete history