### PR TITLE
fix: concurrently fetch logs for endorsement chain events

### DIFF
--- a/src/common/hooks/useEndorsementChain/retrieveEndorsementChain.ts
+++ b/src/common/hooks/useEndorsementChain/retrieveEndorsementChain.ts
@@ -15,8 +15,11 @@ export const getEndorsementChain = async (
   let previousBeneficiary = "";
   let previousHolder = "";
 
-  for (const log of logChain) {
-    const timestamp = await fetchEventTime(log.blockNumber, provider);
+  const timestampPromises = logChain.map((log) => fetchEventTime(log.blockNumber, provider));
+  const timestamps = await Promise.all(timestampPromises);
+
+  logChain.forEach((log, index) => {
+    const timestamp = timestamps[index];
     const transactionDetails = {
       type: log.type,
       transactionHash: log.transactionHash,
@@ -49,6 +52,6 @@ export const getEndorsementChain = async (
       // No state changes
       historyChain.push(transactionDetails);
     }
-  }
+  });
   return historyChain;
 };


### PR DESCRIPTION
## Summary

What is the background of this pull request?
- research possible optimizations in frontend to speed up fetch endorsement chain process


## Changes
- concurrently fetch logs with Promise.all to make endorsement chain fetching process faster 

## Issues

What are the related issues or stories?
https://afa-cdi.atlassian.net/browse/TT-104
