### PR TITLE
refactor: update title escrow address fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@tradetrust-tt/address-identity-resolver": "^1.6.2",
         "@tradetrust-tt/decentralized-renderer-react-components": "^3.16.9",
         "@tradetrust-tt/document-store": "^4.1.1",
-        "@trustvc/trustvc": "^1.5.4",
+        "@trustvc/trustvc": "^1.6.0",
         "@types/gtag.js": "0.0.8",
         "buffer": "^6.0.3",
         "cross-env": "^7.0.3",
@@ -239,6 +239,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
         "@aws-crypto/supports-web-crypto": "^5.2.0",
@@ -253,6 +254,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -264,6 +266,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -276,6 +279,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -288,6 +292,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
         "@aws-sdk/types": "^3.222.0",
@@ -301,6 +306,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       }
@@ -309,6 +315,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
         "@smithy/util-utf8": "^2.0.0",
@@ -319,6 +326,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -330,6 +338,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
         "tslib": "^2.6.2"
@@ -342,6 +351,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
         "tslib": "^2.6.2"
@@ -351,47 +361,48 @@
       }
     },
     "node_modules/@aws-sdk/client-kms": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.830.0.tgz",
-      "integrity": "sha512-y24IvqKn21nF13tkhsKMCKcz0/z6UEePvpV5JAWwZSUmNJj2spagucD/ksykNqBPalbNZIuTicUqtHyBtYAWYQ==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.844.0.tgz",
+      "integrity": "sha512-hSMaGOcJPoWCr2foi8kXagdBi3l4CxcwiSt/AvU5XUdL5JQBVO8AlT0JLyPmQ7gAiWJshfbEwRuYBj4PoDnMOA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-node": "3.830.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
+        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/credential-provider-node": "3.844.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.844.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.844.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.844.0",
         "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
+        "@smithy/middleware-endpoint": "^4.1.14",
+        "@smithy/middleware-retry": "^4.1.15",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/smithy-client": "^4.4.6",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
+        "@smithy/util-defaults-mode-browser": "^4.0.22",
+        "@smithy/util-defaults-mode-node": "^4.0.22",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
+        "@smithy/util-retry": "^4.0.6",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -400,46 +411,47 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.830.0.tgz",
-      "integrity": "sha512-5zCEpfI+zwX2SIa258L+TItNbBoAvQQ6w74qdFM6YJufQ1F9tvwjTX8T+eSTT9nsFIvfYnUaGalWwJVfmJUgVQ==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.844.0.tgz",
+      "integrity": "sha512-FktodSx+pfUfIqMjoNwZ6t1xqq/G3cfT7I4JJ0HKHoIIZdoCHQB52x0OzKDtHDJAnEQPInasdPS8PorZBZtHmg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
+        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.844.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.844.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.844.0",
         "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
+        "@smithy/middleware-endpoint": "^4.1.14",
+        "@smithy/middleware-retry": "^4.1.15",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/smithy-client": "^4.4.6",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
+        "@smithy/util-defaults-mode-browser": "^4.0.22",
+        "@smithy/util-defaults-mode-node": "^4.0.22",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
+        "@smithy/util-retry": "^4.0.6",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -448,24 +460,25 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.826.0.tgz",
-      "integrity": "sha512-BGbQYzWj3ps+dblq33FY5tz/SsgJCcXX0zjQlSC07tYvU1jHTUvsefphyig+fY38xZ4wdKjbTop+KUmXUYrOXw==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.844.0.tgz",
+      "integrity": "sha512-pfpI54bG5Xf2NkqrDBC2REStXlDXNCw/whORhkEs+Tp5exU872D5QKguzjPA6hH+8Pvbq1qgt5zXMbduISTHJw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/types": "3.840.0",
         "@aws-sdk/xml-builder": "3.821.0",
-        "@smithy/core": "^3.5.3",
+        "@smithy/core": "^3.7.0",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/signature-v4": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/smithy-client": "^4.4.6",
         "@smithy/types": "^4.3.1",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-middleware": "^4.0.4",
         "@smithy/util-utf8": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
+        "fast-xml-parser": "5.2.5",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -473,12 +486,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.826.0.tgz",
-      "integrity": "sha512-DK3pQY8+iKK3MGDdC3uOZQ2psU01obaKlTYhEwNu4VWzgwQL4Vi3sWj4xSWGEK41vqZxiRLq6fOq7ysRI+qEZA==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.844.0.tgz",
+      "integrity": "sha512-WB94Ox86MqcZ4CnRjKgopzaSuZH4hMP0GqdOxG4s1it1lRWOIPOHOC1dPiM0Zbj1uqITIhbXUQVXyP/uaJeNkw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -488,19 +502,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.826.0.tgz",
-      "integrity": "sha512-N+IVZBh+yx/9GbMZTKO/gErBi/FYZQtcFRItoLbY+6WU+0cSWyZYfkoeOxHmQV3iX9k65oljERIWUmL9x6OSQg==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.844.0.tgz",
+      "integrity": "sha512-e+efVqfkhpM8zxYeiLNgTUlX+tmtXzVm3bw1A02U9Z9cWBHyQNb8pi90M7QniLoqRURY1B0C2JqkOE61gd4KNg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/types": "3.840.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/smithy-client": "^4.4.6",
         "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
+        "@smithy/util-stream": "^4.2.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -508,18 +523,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.830.0.tgz",
-      "integrity": "sha512-zeQenzvh8JRY5nULd8izdjVGoCM1tgsVVsrLSwDkHxZTTW0hW/bmOmXfvdaE0wDdomXW7m2CkQDSmP7XdvNXZg==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.844.0.tgz",
+      "integrity": "sha512-jc5ArGz2HfAx5QPXD+Ep36+QWyCKzl2TG6Vtl87/vljfLhVD0gEHv8fRsqWEp3Rc6hVfKnCjLW5ayR2HYcow9w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.830.0",
-        "@aws-sdk/credential-provider-web-identity": "3.830.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/credential-provider-env": "3.844.0",
+        "@aws-sdk/credential-provider-http": "3.844.0",
+        "@aws-sdk/credential-provider-process": "3.844.0",
+        "@aws-sdk/credential-provider-sso": "3.844.0",
+        "@aws-sdk/credential-provider-web-identity": "3.844.0",
+        "@aws-sdk/nested-clients": "3.844.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -531,17 +547,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.830.0.tgz",
-      "integrity": "sha512-X/2LrTgwtK1pkWrvofxQBI8VTi6QVLtSMpsKKPPnJQ0vgqC0e4czSIs3ZxiEsOkCBaQ2usXSiKyh0ccsQ6k2OA==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.844.0.tgz",
+      "integrity": "sha512-pUqB0StTNyW0R03XjTA3wrQZcie/7FJKSXlYHue921ZXuhLOZpzyDkLNfdRsZTcEoYYWVPSmyS+Eu/g5yVsBNA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.826.0",
-        "@aws-sdk/credential-provider-http": "3.826.0",
-        "@aws-sdk/credential-provider-ini": "3.830.0",
-        "@aws-sdk/credential-provider-process": "3.826.0",
-        "@aws-sdk/credential-provider-sso": "3.830.0",
-        "@aws-sdk/credential-provider-web-identity": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/credential-provider-env": "3.844.0",
+        "@aws-sdk/credential-provider-http": "3.844.0",
+        "@aws-sdk/credential-provider-ini": "3.844.0",
+        "@aws-sdk/credential-provider-process": "3.844.0",
+        "@aws-sdk/credential-provider-sso": "3.844.0",
+        "@aws-sdk/credential-provider-web-identity": "3.844.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -553,12 +570,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.826.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.826.0.tgz",
-      "integrity": "sha512-kURrc4amu3NLtw1yZw7EoLNEVhmOMRUTs+chaNcmS+ERm3yK0nKjaJzmKahmwlTQTSl3wJ8jjK7x962VPo+zWw==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.844.0.tgz",
+      "integrity": "sha512-VCI8XvIDt2WBfk5Gi/wXKPcWTS3OkAbovB66oKcNQalllH8ESDg4SfLNhchdnN8A5sDGj6tIBJ19nk+dQ6GaqQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
         "@smithy/types": "^4.3.1",
@@ -569,14 +587,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.830.0.tgz",
-      "integrity": "sha512-+VdRpZmfekzpySqZikAKx6l5ndnLGluioIgUG4ZznrButgFD/iogzFtGmBDFB3ZLViX1l4pMXru0zFwJEZT21Q==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.844.0.tgz",
+      "integrity": "sha512-UNp/uWufGlb5nWa4dpc6uQnDOB/9ysJJFG95ACowNVL9XWfi1LJO7teKrqNkVhq0CzSJS1tCt3FvX4UfM+aN1g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.830.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/token-providers": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/client-sso": "3.844.0",
+        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/token-providers": "3.844.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
         "@smithy/types": "^4.3.1",
@@ -587,13 +606,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.830.0.tgz",
-      "integrity": "sha512-hPYrKsZeeOdLROJ59T6Y8yZ0iwC/60L3qhZXjapBFjbqBtMaQiMTI645K6xVXBioA6vxXq7B4aLOhYqk6Fy/Ww==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.844.0.tgz",
+      "integrity": "sha512-iDmX4pPmatjttIScdspZRagaFnCjpHZIEEwTyKdXxUaU0iAOSXF8ecrCEvutETvImPOC86xdrq+MPacJOnMzUA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/nested-clients": "3.844.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -603,11 +623,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.821.0.tgz",
-      "integrity": "sha512-xSMR+sopSeWGx5/4pAGhhfMvGBHioVBbqGvDs6pG64xfNwM5vq5s5v6D04e2i+uSTj4qGa71dLUs5I0UzAK3sw==",
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz",
+      "integrity": "sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -617,11 +638,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.821.0.tgz",
-      "integrity": "sha512-0cvI0ipf2tGx7fXYEEN5fBeZDz2RnHyb9xftSgUsEq7NBxjV0yTZfLJw6Za5rjE6snC80dRN8+bTNR1tuG89zA==",
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz",
+      "integrity": "sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
@@ -630,11 +652,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.821.0.tgz",
-      "integrity": "sha512-efmaifbhBoqKG3bAoEfDdcM8hn1psF+4qa7ykWuYmfmah59JBeqHLfz5W9m9JoTwoKPkFcVLWZxnyZzAnVBOIg==",
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz",
+      "integrity": "sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -644,14 +667,15 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.828.0.tgz",
-      "integrity": "sha512-nixvI/SETXRdmrVab4D9LvXT3lrXkwAWGWk2GVvQvzlqN1/M/RfClj+o37Sn4FqRkGH9o9g7Fqb1YqZ4mqDAtA==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.844.0.tgz",
+      "integrity": "sha512-SIbDNUL6ZYXPj5Tk0qEz05sW9kNS1Gl3/wNWEmH+AuUACipkyIeKKWzD6z5433MllETh73vtka/JQF3g7AuZww==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@smithy/core": "^3.5.3",
+        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.844.0",
+        "@smithy/core": "^3.7.0",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -661,46 +685,47 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.830.0.tgz",
-      "integrity": "sha512-5N5YTlBr1vtxf7+t+UaIQ625KEAmm7fY9o1e3MgGOi/paBoI0+axr3ud24qLIy0NSzFlAHEaxUSWxcERNjIoZw==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.844.0.tgz",
+      "integrity": "sha512-p2XILWc7AcevUSpBg2VtQrk79eWQC4q2JsCSY7HxKpFLZB4mMOfmiTyYkR1gEA6AttK/wpCOtfz+hi1/+z2V1A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.828.0",
+        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/middleware-host-header": "3.840.0",
+        "@aws-sdk/middleware-logger": "3.840.0",
+        "@aws-sdk/middleware-recursion-detection": "3.840.0",
+        "@aws-sdk/middleware-user-agent": "3.844.0",
+        "@aws-sdk/region-config-resolver": "3.840.0",
+        "@aws-sdk/types": "3.840.0",
+        "@aws-sdk/util-endpoints": "3.844.0",
+        "@aws-sdk/util-user-agent-browser": "3.840.0",
+        "@aws-sdk/util-user-agent-node": "3.844.0",
         "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
+        "@smithy/core": "^3.7.0",
+        "@smithy/fetch-http-handler": "^5.1.0",
         "@smithy/hash-node": "^4.0.4",
         "@smithy/invalid-dependency": "^4.0.4",
         "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.11",
-        "@smithy/middleware-retry": "^4.1.12",
+        "@smithy/middleware-endpoint": "^4.1.14",
+        "@smithy/middleware-retry": "^4.1.15",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/smithy-client": "^4.4.6",
         "@smithy/types": "^4.3.1",
         "@smithy/url-parser": "^4.0.4",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.19",
-        "@smithy/util-defaults-mode-node": "^4.0.19",
+        "@smithy/util-defaults-mode-browser": "^4.0.22",
+        "@smithy/util-defaults-mode-node": "^4.0.22",
         "@smithy/util-endpoints": "^3.0.6",
         "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
+        "@smithy/util-retry": "^4.0.6",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -709,11 +734,12 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.821.0.tgz",
-      "integrity": "sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==",
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz",
+      "integrity": "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/types": "^4.3.1",
         "@smithy/util-config-provider": "^4.0.0",
@@ -725,13 +751,14 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.830.0.tgz",
-      "integrity": "sha512-aJ4guFwj92nV9D+EgJPaCFKK0I3y2uMchiDfh69Zqnmwfxxxfxat6F79VA7PS0BdbjRfhLbn+Ghjftnomu2c1g==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.844.0.tgz",
+      "integrity": "sha512-Kh728FEny0fil+LeH8U1offPJCTd/EDh8liBAvLtViLHt2WoX2xC8rk98D38Q5p79aIUhHb3Pf4n9IZfTu/Kog==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.826.0",
-        "@aws-sdk/nested-clients": "3.830.0",
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/core": "3.844.0",
+        "@aws-sdk/nested-clients": "3.844.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
         "@smithy/types": "^4.3.1",
@@ -742,9 +769,10 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz",
-      "integrity": "sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==",
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
+      "integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -754,12 +782,14 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.828.0.tgz",
-      "integrity": "sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.844.0.tgz",
+      "integrity": "sha512-1DHh0WTUmxlysz3EereHKtKoxVUG9UC5BsfAw6Bm4/6qDlJiqtY3oa2vebkYN23yltKdfsCK65cwnBRU59mWVg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
+        "@smithy/url-parser": "^4.0.4",
         "@smithy/util-endpoints": "^3.0.6",
         "tslib": "^2.6.2"
       },
@@ -771,6 +801,7 @@
       "version": "3.804.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.804.0.tgz",
       "integrity": "sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -779,23 +810,25 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.821.0.tgz",
-      "integrity": "sha512-irWZHyM0Jr1xhC+38OuZ7JB6OXMLPZlj48thElpsO1ZSLRkLZx5+I7VV6k3sp2yZ7BYbKz/G2ojSv4wdm7XTLw==",
+      "version": "3.840.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
+      "integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/types": "^4.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.828.0.tgz",
-      "integrity": "sha512-LdN6fTBzTlQmc8O8f1wiZN0qF3yBWVGis7NwpWK7FUEzP9bEZRxYfIkV9oV9zpt6iNRze1SedK3JQVB/udxBoA==",
+      "version": "3.844.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.844.0.tgz",
+      "integrity": "sha512-0eTpURp9Gxbyyeqr78ogARZMSWS5KUMZuN+XMHxNpQLmn2S+J3g+MAyoklCcwhKXlbdQq2aMULEiy0mqIWytuw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.828.0",
-        "@aws-sdk/types": "3.821.0",
+        "@aws-sdk/middleware-user-agent": "3.844.0",
+        "@aws-sdk/types": "3.840.0",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -816,6 +849,7 @@
       "version": "3.821.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz",
       "integrity": "sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -8283,6 +8317,19 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.40.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.2.tgz",
+      "integrity": "sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rspack/binding": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.3.8.tgz",
@@ -8753,6 +8800,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
       "integrity": "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -8765,6 +8813,7 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.4.tgz",
       "integrity": "sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/types": "^4.3.1",
@@ -8777,9 +8826,10 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.5.3.tgz",
-      "integrity": "sha512-xa5byV9fEguZNofCclv6v9ra0FYh5FATQW/da7FQUVTic94DfrN/NvmKZjrMyzbpqfot9ZjBaO8U1UeTbmSLuA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.7.0.tgz",
+      "integrity": "sha512-7ov8hu/4j0uPZv8b27oeOFtIBtlFmM3ibrPv/Omx1uUdoXvcpJ00U+H/OWWC/keAguLlcqwtyL2/jTlSnApgNQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/protocol-http": "^5.1.2",
@@ -8787,7 +8837,7 @@
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-stream": "^4.2.2",
+        "@smithy/util-stream": "^4.2.3",
         "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
@@ -8799,6 +8849,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz",
       "integrity": "sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/property-provider": "^4.0.4",
@@ -8811,9 +8862,10 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz",
-      "integrity": "sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.0.tgz",
+      "integrity": "sha512-mADw7MS0bYe2OGKkHYMaqarOXuDwRbO6ArD91XhHcl2ynjGCFF+hvqf0LyQcYxkA1zaWjefSkU7Ne9mqgApSgQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/querystring-builder": "^4.0.4",
@@ -8829,6 +8881,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.4.tgz",
       "integrity": "sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "@smithy/util-buffer-from": "^4.0.0",
@@ -8843,6 +8896,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.4.tgz",
       "integrity": "sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -8855,6 +8909,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
       "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -8866,6 +8921,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.4.tgz",
       "integrity": "sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
@@ -8876,11 +8932,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.11.tgz",
-      "integrity": "sha512-zDogwtRLzKl58lVS8wPcARevFZNBOOqnmzWWxVe9XiaXU2CADFjvJ9XfNibgkOWs08sxLuSr81NrpY4mgp9OwQ==",
+      "version": "4.1.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.14.tgz",
+      "integrity": "sha512-+BGLpK5D93gCcSEceaaYhUD/+OCGXM1IDaq/jKUQ+ujB0PTWlWN85noodKw/IPFZhIKFCNEe19PGd/reUMeLSQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.5.3",
+        "@smithy/core": "^3.7.0",
         "@smithy/middleware-serde": "^4.0.8",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -8894,17 +8951,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.12.tgz",
-      "integrity": "sha512-wvIH70c4e91NtRxdaLZF+mbLZ/HcC6yg7ySKUiufL6ESp6zJUSnJucZ309AvG9nqCFHSRB5I6T3Ez1Q9wCh0Ww==",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.15.tgz",
+      "integrity": "sha512-iKYUJpiyTQ33U2KlOZeUb0GwtzWR3C0soYcKuCnTmJrvt6XwTPQZhMfsjJZNw7PpQ3TU4Ati1qLSrkSJxnnSMQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/protocol-http": "^5.1.2",
-        "@smithy/service-error-classification": "^4.0.5",
-        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/service-error-classification": "^4.0.6",
+        "@smithy/smithy-client": "^4.4.6",
         "@smithy/types": "^4.3.1",
         "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.5",
+        "@smithy/util-retry": "^4.0.6",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -8920,6 +8978,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -8928,6 +8987,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz",
       "integrity": "sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
@@ -8941,6 +9001,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz",
       "integrity": "sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -8953,6 +9014,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz",
       "integrity": "sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.4",
         "@smithy/shared-ini-file-loader": "^4.0.4",
@@ -8964,9 +9026,10 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz",
-      "integrity": "sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.0.tgz",
+      "integrity": "sha512-vqfSiHz2v8b3TTTrdXi03vNz1KLYYS3bhHCDv36FYDqxT7jvTll1mMnCrkD+gOvgwybuunh/2VmvOMqwBegxEg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
@@ -8982,6 +9045,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
       "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -8994,6 +9058,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.2.tgz",
       "integrity": "sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -9006,6 +9071,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz",
       "integrity": "sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "@smithy/util-uri-escape": "^4.0.0",
@@ -9019,6 +9085,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
       "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -9028,9 +9095,10 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.5.tgz",
-      "integrity": "sha512-LvcfhrnCBvCmTee81pRlh1F39yTS/+kYleVeLCwNtkY8wtGg8V/ca9rbZZvYIl8OjlMtL6KIjaiL/lgVqHD2nA==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.6.tgz",
+      "integrity": "sha512-RRoTDL//7xi4tn5FrN2NzH17jbgmnKidUqd4KvquT0954/i6CXXkh1884jBiunq24g9cGtPBEXlU40W6EpNOOg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1"
       },
@@ -9042,6 +9110,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz",
       "integrity": "sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -9054,6 +9123,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.2.tgz",
       "integrity": "sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
         "@smithy/protocol-http": "^5.1.2",
@@ -9069,16 +9139,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.3.tgz",
-      "integrity": "sha512-xxzNYgA0HD6ETCe5QJubsxP0hQH3QK3kbpJz3QrosBCuIWyEXLR/CO5hFb2OeawEKUxMNhz3a1nuJNN2np2RMA==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.6.tgz",
+      "integrity": "sha512-3wfhywdzB/CFszP6moa5L3lf5/zSfQoH0kvVSdkyK2az5qZet0sn2PAHjcTDiq296Y4RP5yxF7B6S6+3oeBUCQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.5.3",
-        "@smithy/middleware-endpoint": "^4.1.11",
+        "@smithy/core": "^3.7.0",
+        "@smithy/middleware-endpoint": "^4.1.14",
         "@smithy/middleware-stack": "^4.0.4",
         "@smithy/protocol-http": "^5.1.2",
         "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
+        "@smithy/util-stream": "^4.2.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -9089,6 +9160,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
       "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -9100,6 +9172,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
       "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/querystring-parser": "^4.0.4",
         "@smithy/types": "^4.3.1",
@@ -9113,6 +9186,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
       "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
         "@smithy/util-utf8": "^4.0.0",
@@ -9126,6 +9200,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
       "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -9137,6 +9212,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
       "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -9148,6 +9224,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
       "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
         "tslib": "^2.6.2"
@@ -9160,6 +9237,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
       "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -9168,12 +9246,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.19.tgz",
-      "integrity": "sha512-mvLMh87xSmQrV5XqnUYEPoiFFeEGYeAKIDDKdhE2ahqitm8OHM3aSvhqL6rrK6wm1brIk90JhxDf5lf2hbrLbQ==",
+      "version": "4.0.22",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.22.tgz",
+      "integrity": "sha512-hjElSW18Wq3fUAWVk6nbk7pGrV7ZT14DL1IUobmqhV3lxcsIenr5FUsDe2jlTVaS8OYBI3x+Og9URv5YcKb5QA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/smithy-client": "^4.4.6",
         "@smithy/types": "^4.3.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -9183,15 +9262,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.19.tgz",
-      "integrity": "sha512-8tYnx+LUfj6m+zkUUIrIQJxPM1xVxfRBvoGHua7R/i6qAxOMjqR6CpEpDwKoIs1o0+hOjGvkKE23CafKL0vJ9w==",
+      "version": "4.0.22",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.22.tgz",
+      "integrity": "sha512-7B8mfQBtwwr2aNRRmU39k/bsRtv9B6/1mTMrGmmdJFKmLAH+KgIiOuhaqfKOBGh9sZ/VkZxbvm94rI4MMYpFjQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.1.4",
         "@smithy/credential-provider-imds": "^4.0.6",
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.3",
+        "@smithy/smithy-client": "^4.4.6",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
@@ -9203,6 +9283,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.6.tgz",
       "integrity": "sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.3",
         "@smithy/types": "^4.3.1",
@@ -9216,6 +9297,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
       "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -9227,6 +9309,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.4.tgz",
       "integrity": "sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
@@ -9236,11 +9319,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.5.tgz",
-      "integrity": "sha512-V7MSjVDTlEt/plmOFBn1762Dyu5uqMrV2Pl2X0dYk4XvWfdWJNe9Bs5Bzb56wkCuiWjSfClVMGcsuKrGj7S/yg==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.6.tgz",
+      "integrity": "sha512-+YekoF2CaSMv6zKrA6iI/N9yva3Gzn4L6n35Luydweu5MMPYpiGZlWqehPHDHyNbnyaYlz/WJyYAZnC+loBDZg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.5",
+        "@smithy/service-error-classification": "^4.0.6",
         "@smithy/types": "^4.3.1",
         "tslib": "^2.6.2"
       },
@@ -9249,12 +9333,13 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz",
-      "integrity": "sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.3.tgz",
+      "integrity": "sha512-cQn412DWHHFNKrQfbHY8vSFI3nTROY1aIKji9N0tpp8gUABRilr7wdf8fqBbSlXresobM+tQFNk6I+0LXK/YZg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
+        "@smithy/fetch-http-handler": "^5.1.0",
+        "@smithy/node-http-handler": "^4.1.0",
         "@smithy/types": "^4.3.1",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-buffer-from": "^4.0.0",
@@ -9270,6 +9355,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
       "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
@@ -9281,6 +9367,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
       "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
         "tslib": "^2.6.2"
@@ -13683,11 +13770,12 @@
       }
     },
     "node_modules/@tradetrust-tt/ethers-aws-kms-signer": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@tradetrust-tt/ethers-aws-kms-signer/-/ethers-aws-kms-signer-2.1.3.tgz",
-      "integrity": "sha512-CdF4jFHDFZPVDBhJMP2wU7nywtM6xmBDfgaWdjmwW/0dQbEZ1AJ6UzJKsrFYEtNybUDFtsDcyxtuja84AQzqqQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@tradetrust-tt/ethers-aws-kms-signer/-/ethers-aws-kms-signer-2.1.4.tgz",
+      "integrity": "sha512-bwsPF9TOlkXUICwUIt3FJCBQZ8zJTbT3AlPdj+7dGEgPTY6sAH71BzFYFQ1aJnZht1Sww6y8ix14FK4M54lRsQ==",
+      "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-kms": "^3.826.0",
+        "@aws-sdk/client-kms": "^3.830.0",
         "@ethersproject/abstract-provider": "^5.8.0",
         "@ethersproject/abstract-signer": "^5.8.0",
         "@ethersproject/bytes": "^5.8.0",
@@ -13695,9 +13783,8 @@
         "@ethersproject/keccak256": "^5.8.0",
         "@ethersproject/properties": "^5.8.0",
         "@ethersproject/transactions": "^5.8.0",
-        "@types/node": "^18.19.111",
+        "@types/node": "^18.19.112",
         "asn1.js": "^5.4.1",
-        "aws-sdk": "^2.1692.0",
         "bn.js": "^5.2.2",
         "debug": "^4.4.1"
       },
@@ -13706,9 +13793,10 @@
       }
     },
     "node_modules/@tradetrust-tt/ethers-aws-kms-signer/node_modules/@types/node": {
-      "version": "18.19.112",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.112.tgz",
-      "integrity": "sha512-i+Vukt9POdS/MBI7YrrkkI5fMfwFtOjphSmt4WXYLfwqsfr6z/HdCx7LqT9M7JktGob8WNgj8nFB4TbGNE4Cog==",
+      "version": "18.19.118",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.118.tgz",
+      "integrity": "sha512-hIPK0hSrrcaoAu/gJMzN3QClXE4QdCdFvaenJ0JsjIbExP1JFFVH+RHcBt25c9n8bx5dkIfqKE+uw6BmBns7ug==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -13717,6 +13805,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -13732,7 +13821,8 @@
     "node_modules/@tradetrust-tt/ethers-aws-kms-signer/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/@tradetrust-tt/token-registry": {
       "version": "5.2.0",
@@ -14003,23 +14093,24 @@
       }
     },
     "node_modules/@trustvc/trustvc": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@trustvc/trustvc/-/trustvc-1.5.4.tgz",
-      "integrity": "sha512-QHd5eINKNVP3V8QKY67UHMazj48xqymtL7/tk6UFbhs+djiDs47+6uc5+ydUtrYn3Mh2CI+8dXnnt+2+nhigGA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@trustvc/trustvc/-/trustvc-1.6.0.tgz",
+      "integrity": "sha512-cQzN33TA0lChETrqMM9CD6RrEZOIsqbGfifPuue3gloAf+N3zn5UQXmjZAoJAJ0oiRAaSnY/mk3WW6wJ0eS0kQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@tradetrust-tt/dnsprove": "^2.17.0",
-        "@tradetrust-tt/ethers-aws-kms-signer": "^2.1.3",
+        "@tradetrust-tt/ethers-aws-kms-signer": "^2.1.4",
         "@tradetrust-tt/token-registry-v4": "npm:@tradetrust-tt/token-registry@^4.16.0",
         "@tradetrust-tt/token-registry-v5": "npm:@tradetrust-tt/token-registry@^5.3.0",
         "@tradetrust-tt/tradetrust": "^6.10.1",
         "@tradetrust-tt/tradetrust-utils": "^2.3.2",
         "@tradetrust-tt/tt-verify": "^9.4.0",
         "@trustvc/w3c-context": "^1.2.13",
-        "@trustvc/w3c-credential-status": "^1.2.12",
-        "@trustvc/w3c-issuer": "^1.2.3",
+        "@trustvc/w3c-credential-status": "^1.2.13",
+        "@trustvc/w3c-issuer": "^1.2.4",
         "@trustvc/w3c-vc": "^1.2.17",
         "ethers": "^5.8.0",
-        "ethersV6": "npm:ethers@^6.14.3",
+        "ethersV6": "npm:ethers@^6.14.4",
         "js-sha3": "^0.9.3",
         "ts-chacha20": "^1.2.0"
       },
@@ -17049,6 +17140,7 @@
       "version": "2.1692.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1692.0.tgz",
       "integrity": "sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -17070,6 +17162,7 @@
       "version": "4.9.2",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
       "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dev": true,
       "dependencies": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -17080,6 +17173,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -17087,17 +17181,20 @@
     "node_modules/aws-sdk/node_modules/ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
     },
     "node_modules/aws-sdk/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
+      "dev": true
     },
     "node_modules/aws-sdk/node_modules/url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "dev": true,
       "dependencies": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -17107,6 +17204,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
       "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -23597,21 +23695,18 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "strnum": "^2.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -32020,6 +32115,7 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -37426,6 +37522,7 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -39375,7 +39472,8 @@
     "node_modules/sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "dev": true
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -41121,15 +41219,16 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/style-loader": {
       "version": "2.0.0",
@@ -46274,6 +46373,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
       "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dev": true,
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -46286,6 +46386,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@tradetrust-tt/address-identity-resolver": "^1.6.2",
     "@tradetrust-tt/decentralized-renderer-react-components": "^3.16.9",
     "@tradetrust-tt/document-store": "^4.1.1",
-    "@trustvc/trustvc": "^1.5.4",
+    "@trustvc/trustvc": "^1.6.0",
     "@types/gtag.js": "0.0.8",
     "buffer": "^6.0.3",
     "cross-env": "^7.0.3",

--- a/src/common/hooks/useEndorsementChain/useEndorsementChain.ts
+++ b/src/common/hooks/useEndorsementChain/useEndorsementChain.ts
@@ -19,8 +19,7 @@ export const useEndorsementChain = (
   const [error, setError] = useState("");
   const [endorsementChain, setEndorsementChain] = useState<EndorsementChain>();
   const { tokenRegistry } = useTokenRegistryContract(tokenRegistryAddress, providerOrSigner);
-  const { version: tokenRegistryVersion } = useTokenInformationContext();
-
+  const { version: tokenRegistryVersion, titleEscrowAddress } = useTokenInformationContext();
   /*
     retrieve transactions from token registry and title escrow events
     merge, sort and provide history of events
@@ -35,13 +34,28 @@ export const useEndorsementChain = (
         throw new Error('"Only Token Registry V5 is supported"');
       }
 
-      const retrievedEndorsementChain = await fetchEndorsementChain(tokenRegistryAddress, tokenId, provider, keyId);
+      const retrievedEndorsementChain = await fetchEndorsementChain(
+        tokenRegistryAddress,
+        tokenId,
+        provider,
+        keyId,
+        titleEscrowAddress
+      );
       setEndorsementChain(retrievedEndorsementChain);
     } catch (e: unknown) {
       setError(getErrorMessage(e));
     }
     setPending(false);
-  }, [provider, providerOrSigner, tokenId, tokenRegistry, tokenRegistryAddress, tokenRegistryVersion, keyId]);
+  }, [
+    provider,
+    providerOrSigner,
+    tokenId,
+    tokenRegistry,
+    tokenRegistryAddress,
+    tokenRegistryVersion,
+    keyId,
+    titleEscrowAddress,
+  ]);
 
   useEffect(() => {
     fetchEndorsementChainV5();

--- a/src/common/hooks/useQueue.tsx
+++ b/src/common/hooks/useQueue.tsx
@@ -19,6 +19,7 @@ import { useProviderContext } from "../contexts/provider";
 import { getChainInfo } from "../utils/chain-utils";
 import { flattenData, getDataW3C } from "../utils/dataHelpers";
 import { encodeQrCode } from "../utils/qrCode";
+import { IS_DEVELOPMENT } from "../../config";
 
 const { stack } = getLogger("useQueue");
 
@@ -124,7 +125,7 @@ export const useQueue = ({ formEntry, formTemplate }: UseQueue): UseQueueReturn 
         }
 
         // Add QR code
-        if (process.env.NODE_ENV !== "test") {
+        if (!IS_DEVELOPMENT) {
           if (!documentStorageURL) throw new Error("No document storage URL found");
           const chainInfo = currentChainId ? getChainInfo(currentChainId) : undefined;
           const actionsUrlObj = await getReservedStorageUrl(documentStorageURL, chainInfo?.networkName);

--- a/src/common/hooks/useQueue.tsx
+++ b/src/common/hooks/useQueue.tsx
@@ -19,7 +19,6 @@ import { useProviderContext } from "../contexts/provider";
 import { getChainInfo } from "../utils/chain-utils";
 import { flattenData, getDataW3C } from "../utils/dataHelpers";
 import { encodeQrCode } from "../utils/qrCode";
-import { IS_DEVELOPMENT } from "../../config";
 
 const { stack } = getLogger("useQueue");
 
@@ -125,7 +124,7 @@ export const useQueue = ({ formEntry, formTemplate }: UseQueue): UseQueueReturn 
         }
 
         // Add QR code
-        if (!IS_DEVELOPMENT) {
+        if (process.env.NODE_ENV !== "test") {
           if (!documentStorageURL) throw new Error("No document storage URL found");
           const chainInfo = currentChainId ? getChainInfo(currentChainId) : undefined;
           const actionsUrlObj = await getReservedStorageUrl(documentStorageURL, chainInfo?.networkName);

--- a/src/common/hooks/useTitleEscrowContract.ts
+++ b/src/common/hooks/useTitleEscrowContract.ts
@@ -32,7 +32,7 @@ export const useTitleEscrowContract = (
       const address = await getTitleEscrowAddress(tokenRegistry.address, tokenId, provider);
       const instance = TitleEscrow__factory.connect(address, providerOrSigner);
       setTitleEscrow(instance);
-      setTitleEscrowAddress(instance.address);
+      setTitleEscrowAddress(address);
     } catch (error) {
       setTitleEscrow(undefined);
       setTitleEscrowAddress(undefined);

--- a/src/common/hooks/useTitleEscrowContract.ts
+++ b/src/common/hooks/useTitleEscrowContract.ts
@@ -30,7 +30,7 @@ export const useTitleEscrowContract = (
       const titleEscrowOwner = await tokenRegistry.ownerOf(tokenId);
       setDocumentOwner(titleEscrowOwner);
       const address = await getTitleEscrowAddress(tokenRegistry.address, tokenId, provider);
-      const instance = TitleEscrow__factory.connect(address, provider);
+      const instance = TitleEscrow__factory.connect(address, providerOrSigner);
       setTitleEscrow(instance);
       setTitleEscrowAddress(address);
     } catch (error) {

--- a/src/common/hooks/useTitleEscrowContract.ts
+++ b/src/common/hooks/useTitleEscrowContract.ts
@@ -32,7 +32,7 @@ export const useTitleEscrowContract = (
       const address = await getTitleEscrowAddress(tokenRegistry.address, tokenId, provider);
       const instance = TitleEscrow__factory.connect(address, providerOrSigner);
       setTitleEscrow(instance);
-      setTitleEscrowAddress(address);
+      setTitleEscrowAddress(instance.address);
     } catch (error) {
       setTitleEscrow(undefined);
       setTitleEscrowAddress(undefined);

--- a/src/common/hooks/useTitleEscrowContract.ts
+++ b/src/common/hooks/useTitleEscrowContract.ts
@@ -1,8 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { providers, Signer } from "ethers";
-import { v5Contracts } from "@trustvc/trustvc";
-import { BurnAddress } from "../../constants/chain-info";
-const { TitleEscrowFactory__factory, TitleEscrow__factory } = v5Contracts;
+import { getTitleEscrowAddress, v5Contracts } from "@trustvc/trustvc";
+const { TitleEscrow__factory } = v5Contracts;
 type TitleEscrow = typeof v5Contracts.TitleEscrow;
 type TradeTrustToken = typeof v5Contracts.TradeTrustToken;
 interface useTitleEscrowContractProps {
@@ -13,7 +12,7 @@ interface useTitleEscrowContractProps {
 }
 
 export const useTitleEscrowContract = (
-  provider: providers.Provider | Signer | undefined,
+  providerOrSigner: providers.Provider | Signer | undefined,
   tokenRegistry?: TradeTrustToken,
   tokenId?: string
 ): useTitleEscrowContractProps => {
@@ -22,22 +21,23 @@ export const useTitleEscrowContract = (
   const [documentOwner, setDocumentOwner] = useState<string>();
 
   const updateTitleEscrow = useCallback(async () => {
-    if (!tokenRegistry || !tokenId || !provider) return;
+    if (!tokenRegistry || !tokenId || !providerOrSigner) return;
+
     try {
+      const provider = (
+        "provider" in providerOrSigner ? providerOrSigner.provider : providerOrSigner
+      ) as providers.Provider;
       const titleEscrowOwner = await tokenRegistry.ownerOf(tokenId);
       setDocumentOwner(titleEscrowOwner);
-      const instance = await connectToTitleEscrow({
-        provider,
-        tokenRegistry,
-        tokenId,
-      });
+      const address = await getTitleEscrowAddress(tokenRegistry.address, tokenId, provider);
+      const instance = TitleEscrow__factory.connect(address, provider);
       setTitleEscrow(instance);
-      setTitleEscrowAddress(instance.address);
+      setTitleEscrowAddress(address);
     } catch (error) {
       setTitleEscrow(undefined);
       setTitleEscrowAddress(undefined);
     }
-  }, [provider, tokenId, tokenRegistry]);
+  }, [providerOrSigner, tokenId, tokenRegistry]);
 
   useEffect(() => {
     updateTitleEscrow();
@@ -46,42 +46,7 @@ export const useTitleEscrowContract = (
       setDocumentOwner(undefined);
       setTitleEscrowAddress(undefined);
     };
-  }, [updateTitleEscrow, tokenId, provider]);
+  }, [updateTitleEscrow, tokenId, providerOrSigner]);
 
   return { titleEscrow, titleEscrowAddress, updateTitleEscrow, documentOwner };
-};
-
-export const retrieveTitleEscrowAddressOnFactory = async (
-  tokenRegistry: TradeTrustToken,
-  tokenId: string,
-  signer: providers.Provider | Signer
-): Promise<string> => {
-  const titleEscrowFactoryAddress = await tokenRegistry.titleEscrowFactory();
-  const tokenRegistryAddress = await tokenRegistry.address;
-  const titleEscrowFactory = TitleEscrowFactory__factory.connect(titleEscrowFactoryAddress, signer);
-  const titleEscrowAddress = await titleEscrowFactory.getEscrowAddress(tokenRegistryAddress, tokenId);
-  return titleEscrowAddress;
-};
-
-interface ConnectToTitleEscrowArgs {
-  provider: providers.Provider | Signer;
-  tokenRegistry: TradeTrustToken;
-  tokenId: string;
-}
-
-export const connectToTitleEscrow = async ({
-  provider,
-  tokenRegistry,
-  tokenId,
-}: ConnectToTitleEscrowArgs): Promise<TitleEscrow> => {
-  const tokenRegistryAddress = tokenRegistry.address;
-  const titleEscrowOwner = await tokenRegistry.ownerOf(tokenId);
-  const inactiveEscrow = [BurnAddress, tokenRegistryAddress]
-    .map((s) => s.toLowerCase())
-    .includes(titleEscrowOwner.toLowerCase());
-  let titleEscrowAddress = titleEscrowOwner;
-  if (inactiveEscrow) {
-    titleEscrowAddress = await retrieveTitleEscrowAddressOnFactory(tokenRegistry, tokenId, provider);
-  }
-  return TitleEscrow__factory.connect(titleEscrowAddress, provider);
 };

--- a/tests/e2e/specs/5a-creator.spec.js
+++ b/tests/e2e/specs/5a-creator.spec.js
@@ -14,9 +14,9 @@ const fileName = "EBOL.tt"
 before(() => {
     cy.window().then((window) => {
       window.localStorage.setItem("hasSeenPopup", "true");
+      window.localStorage.removeItem("tokenRegistry");
     });
     cy.switchMetamaskAccount(1);
-    window.localStorage.removeItem("tokenRegistry");
     cy.task("clearDownloads", { tempDirectory });
 });
 


### PR DESCRIPTION
## Summary

- To avoid title escrow address refetching, during verifying document and then fetching endorsement chain
 
## Changes

- Use getTitleEscrowAddress method from trustvc package
- pass title escrow address to fetchEndorsementChain method
