### PR TITLE
fix: decode attachment error

### DIFF
--- a/src/components/UI/AttachmentLink/AttachmentLink.tsx
+++ b/src/components/UI/AttachmentLink/AttachmentLink.tsx
@@ -80,9 +80,11 @@ const isOpenAttestationFile = (decodedData: string) => {
 export const AttachmentLink: FunctionComponent<AttachmentLinkProps> = ({ filename, data, type, path }) => {
   let filesize = "0";
   let canOpenFile = false;
+
+  const prefix = `data:${type};base64,`;
   const hasBase64 = !!(data && type);
   const downloadHref = hasBase64 ? `data:${type};base64,${data}` : path || "#";
-  const decodedData = atob(data);
+  const decodedData = atob(data.startsWith(prefix) ? data.slice(prefix.length).trim() : data);
   canOpenFile = isOpenAttestationFile(decodedData);
   filesize = prettyBytes(decodedData.length);
 


### PR DESCRIPTION
## Summary

Some files with some attachments are not loading as intended. This fix is to solve the issue where it is returning an error while decoding the attachment file.

## Changes

- handle a prefix and a non-prefix for the attachment file.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment decoding to correctly handle base64 data URLs (data:<type>;base64,...). Attachments passed as data URLs now decode reliably, preventing corrupted content or blank files when opening or downloading. No changes to the public interface.
* **Refactor**
  * Streamlined internal decoding logic to automatically strip data URL headers before processing, improving robustness without altering behavior for non–data URL inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->