### PR TITLE
fix: update exec test commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@tradetrust-tt/address-identity-resolver": "^1.6.2",
         "@tradetrust-tt/decentralized-renderer-react-components": "^3.16.12",
         "@tradetrust-tt/document-store": "^4.1.1",
-        "@trustvc/trustvc": "^2.6.1",
+        "@trustvc/trustvc": "^2.11.0",
         "@types/gtag.js": "0.0.8",
         "buffer": "^6.0.3",
         "cross-env": "^7.0.3",
@@ -3783,6 +3783,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/bbs-2023-cryptosuite/-/bbs-2023-cryptosuite-2.0.1.tgz",
       "integrity": "sha512-Uw7aDSuCehLUsiSsTi2ob1hQ8AgVq+jV3OgvPsOzy/AmIh2yG9kg2tNCv6PngWPyOm3VCzolwh+5MzWySASiww==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/bls12-381-multikey": "^2.0.0",
         "@digitalbazaar/di-sd-primitives": "^3.0.4",
@@ -3797,6 +3798,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/bbs-signatures/-/bbs-signatures-3.0.0.tgz",
       "integrity": "sha512-mQMCMnCWAraVSswJg1kJK/qmUrb3jMoWB9c8kOmztsWfnMZJcyYAcavuF8jgrVZ5cl/ZRNMK61ZbIvkqd6BE6g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@noble/curves": "^1.3.0"
       },
@@ -3808,6 +3810,7 @@
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -3822,6 +3825,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3833,6 +3837,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/bls12-381-multikey/-/bls12-381-multikey-2.1.0.tgz",
       "integrity": "sha512-JelU85fNhvHl2/mqRdmrtrE2ZQJ0//+UwI0l/YFmvsOr6YN2GuKPzdkfXjpm7f3UvnBqz5f8QKFTb9mVa7mVVg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/bbs-signatures": "^3.0.0",
         "@noble/curves": "^1.3.0",
@@ -3848,6 +3853,7 @@
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -3862,6 +3868,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3873,6 +3880,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/data-integrity/-/data-integrity-2.5.0.tgz",
       "integrity": "sha512-ohIieLfgtPQU9BYfj0eKNiz55/ZDOk5YSE9FN/Hn0eXzI8WQzLkzRvC8pvBnzuzXDgCsjPdSqYvzok5PoClMBQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "base58-universal": "^2.0.0",
         "base64url-universal": "^2.0.0",
@@ -3886,6 +3894,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.3.0.tgz",
       "integrity": "sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "ky": "^1.14.2",
         "undici": "^6.23.0"
@@ -3898,6 +3907,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
       "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
       "bin": {
         "canonicalize": "bin/canonicalize.js"
       }
@@ -3906,6 +3916,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz",
       "integrity": "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/http-client": "^4.2.0",
         "canonicalize": "^2.1.0",
@@ -3920,6 +3931,7 @@
       "version": "11.6.0",
       "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.6.0.tgz",
       "integrity": "sha512-hzYNZXnfy4cUFf9aiFBtduUz+cknbfBLWtTKvoqVyP2ECPwqfsfkHWFlhccWfAKV/LJkPLyKZRwC1B4T5LO4ZQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/security-context": "^1.0.0",
         "jsonld": "^9.0.0",
@@ -3934,6 +3946,7 @@
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
       "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3945,6 +3958,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3956,6 +3970,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
       "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "setimmediate": "^1.0.5"
       },
@@ -3967,6 +3982,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
       "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -3981,6 +3997,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -3992,6 +4009,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
       "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
@@ -3999,12 +4017,14 @@
     "node_modules/@digitalbazaar/data-integrity/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/@digitalbazaar/di-sd-primitives": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/di-sd-primitives/-/di-sd-primitives-3.2.0.tgz",
       "integrity": "sha512-DydbRtDPY2vVVk7hLicSFfCCzd1d5e3GLjzqamLV4t9f9mGbHtnU2IeNhtUDGJZRpviFmtFjPMZwuns6sCAP9A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "base64url-universal": "^2.0.0",
         "jsonld": "^9.0.0",
@@ -4020,6 +4040,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.3.0.tgz",
       "integrity": "sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "ky": "^1.14.2",
         "undici": "^6.23.0"
@@ -4032,6 +4053,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
       "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
       "bin": {
         "canonicalize": "bin/canonicalize.js"
       }
@@ -4040,6 +4062,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz",
       "integrity": "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/http-client": "^4.2.0",
         "canonicalize": "^2.1.0",
@@ -4054,6 +4077,7 @@
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
       "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -4065,6 +4089,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4076,6 +4101,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
       "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "setimmediate": "^1.0.5"
       },
@@ -4087,6 +4113,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
       "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
@@ -4099,6 +4126,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -4106,12 +4134,14 @@
     "node_modules/@digitalbazaar/di-sd-primitives/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/@digitalbazaar/ecdsa-multikey": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/ecdsa-multikey/-/ecdsa-multikey-1.8.0.tgz",
       "integrity": "sha512-Xo4oBCb0bJv6PYNBrLBZfR/jA2uNd9Bi+YTnadFtxTbhMQrSN0nTw3OnTBOOC7zxtL3t4N00ZweQM4zhsV6gVQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "base58-universal": "^2.0.0",
         "base64url-universal": "^2.0.0"
@@ -4124,6 +4154,7 @@
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/ecdsa-sd-2023-cryptosuite/-/ecdsa-sd-2023-cryptosuite-3.4.1.tgz",
       "integrity": "sha512-PzKQneakxUUS/kzDgUZ0ZcZKuHhMhAelW2Bp/rryHEV43VeI3meoJkuQ0s7sfMlD1OWkKWrNClMr1znwBaQiLQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/di-sd-primitives": "^3.0.4",
         "@digitalbazaar/ecdsa-multikey": "^1.1.3",
@@ -4152,7 +4183,8 @@
     "node_modules/@digitalbazaar/security-context": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/security-context/-/security-context-1.0.1.tgz",
-      "integrity": "sha512-0WZa6tPiTZZF8leBtQgYAfXQePFQp2z5ivpCEN/iZguYYZ0TB9qRmWtan5XH6mNFuusHtMcyIzAcReyE6rZPhA=="
+      "integrity": "sha512-0WZa6tPiTZZF8leBtQgYAfXQePFQp2z5ivpCEN/iZguYYZ0TB9qRmWtan5XH6mNFuusHtMcyIzAcReyE6rZPhA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -14509,10 +14541,17 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/@trustvc/document-store": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@trustvc/document-store/-/document-store-1.0.3.tgz",
+      "integrity": "sha512-YIECQwcoreIfyTbol1/5u9CGK6mbg0Q0bSN2/Ks388zLus1IXELWK5EHYuyrFPbb9d8ajsvz7m+ySsMIY9574w==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@trustvc/trustvc": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@trustvc/trustvc/-/trustvc-2.6.1.tgz",
-      "integrity": "sha512-S+hXMFmuxHsyLPqB7d3Rt3xRV4mnJ0DgRcAR/fSOadWzBKhhXOc3dZ7GOX5uwKjRnkhdbazNHtigE7w9QF5Pkw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@trustvc/trustvc/-/trustvc-2.11.0.tgz",
+      "integrity": "sha512-HRB+h3pVqxOpp8MuYjz/NFP9ghLw6GYwiLSQnaNA3STek0S+5FG8mtmAd5n7x5cuVN+vYYCXReN3wVSjuJViNg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@tradetrust-tt/dnsprove": "^2.18.0",
         "@tradetrust-tt/ethers-aws-kms-signer": "^2.1.4",
@@ -14520,6 +14559,7 @@
         "@tradetrust-tt/token-registry-v5": "npm:@tradetrust-tt/token-registry@^5.5.0",
         "@tradetrust-tt/tradetrust": "^6.10.2",
         "@tradetrust-tt/tt-verify": "^9.6.0",
+        "@trustvc/document-store": "^1.0.3",
         "@trustvc/w3c": "^2.0.0",
         "@trustvc/w3c-context": "^2.0.0",
         "@trustvc/w3c-credential-status": "^2.0.0",
@@ -14529,6 +14569,7 @@
         "ethersV6": "npm:ethers@^6.14.4",
         "js-sha3": "^0.9.3",
         "node-fetch": "^2.7.0",
+        "node-forge": "^1.3.3",
         "ts-chacha20": "^1.2.0"
       },
       "engines": {
@@ -14545,6 +14586,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.3.0.tgz",
       "integrity": "sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "ky": "^1.14.2",
         "undici": "^6.23.0"
@@ -14557,6 +14599,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@trustvc/w3c-context/-/w3c-context-2.0.2.tgz",
       "integrity": "sha512-2DM73n1z2FXML9/suGHea6BcJqs7GKiJsvpozRf6lE9d3ZyFRmCd6H84f7Z7zGvacuLXMRnPX2A9DKE0ETs8HA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "did-resolver": "^4.1.0",
         "jsonld-signatures": "^11.5.0"
@@ -14569,6 +14612,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@trustvc/w3c-credential-status/-/w3c-credential-status-2.0.2.tgz",
       "integrity": "sha512-8f5sHoDAT8YqLlHm82t/wh1HrZdmR3PgRGfDcgbKWrJtA+X2769kk6qVXCNP6tq1Ghyqe8v/HLortrXp9JSdGw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@trustvc/w3c-context": "^2.0.2",
         "@trustvc/w3c-issuer": "^2.0.2",
@@ -14583,6 +14627,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@trustvc/w3c-issuer/-/w3c-issuer-2.0.2.tgz",
       "integrity": "sha512-NDtEcGV7ryuWHbaX3hwlz2cN/hhDWHzA+D2AF56I7teNfev+X62pro+HrXYAa3EclPET7BI+fYmLgh61/DAl7w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@digitalbazaar/bls12-381-multikey": "^2.1.0",
         "@digitalbazaar/ecdsa-multikey": "^1.8.0",
@@ -14600,6 +14645,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@trustvc/w3c-vc/-/w3c-vc-2.0.2.tgz",
       "integrity": "sha512-3A488DgukqrKXDSNdtZE02tOfj6V9C6uRJAEKEnMiaUevxNzFO9TFpqXkeOdxNhg9yHEH7m68b6SqfwU/tbVXQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@digitalbazaar/bbs-2023-cryptosuite": "^2.0.1",
         "@digitalbazaar/bls12-381-multikey": "^2.1.0",
@@ -14628,6 +14674,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
       "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
       "bin": {
         "canonicalize": "bin/canonicalize.js"
       }
@@ -14635,12 +14682,14 @@
     "node_modules/@trustvc/trustvc/node_modules/js-sha3": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.9.3.tgz",
-      "integrity": "sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg=="
+      "integrity": "sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==",
+      "license": "MIT"
     },
     "node_modules/@trustvc/trustvc/node_modules/jsonld-signatures": {
       "version": "11.6.0",
       "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.6.0.tgz",
       "integrity": "sha512-hzYNZXnfy4cUFf9aiFBtduUz+cknbfBLWtTKvoqVyP2ECPwqfsfkHWFlhccWfAKV/LJkPLyKZRwC1B4T5LO4ZQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/security-context": "^1.0.0",
         "jsonld": "^9.0.0",
@@ -14655,6 +14704,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz",
       "integrity": "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/http-client": "^4.2.0",
         "canonicalize": "^2.1.0",
@@ -14669,6 +14719,7 @@
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
       "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -14680,6 +14731,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14687,15 +14739,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/@trustvc/trustvc/node_modules/node-forge": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/@trustvc/trustvc/node_modules/pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/@trustvc/trustvc/node_modules/rdf-canonize": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
       "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "setimmediate": "^1.0.5"
       },
@@ -14707,6 +14770,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
       "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -14721,6 +14785,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -14732,6 +14797,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
       "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
@@ -14744,6 +14810,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -14751,12 +14818,14 @@
     "node_modules/@trustvc/trustvc/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/@trustvc/w3c": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@trustvc/w3c/-/w3c-2.0.2.tgz",
       "integrity": "sha512-xWgyhdVjw1mR0GdLjzeoH1s4jseaEJpmJ2ndM0Xcn0zCzqeUql2C1ijnb0Sb/76R7XLUuc0hgAo1CzLp27lQKw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@trustvc/w3c-context": "^2.0.2",
         "@trustvc/w3c-credential-status": "^2.0.2",
@@ -14849,6 +14918,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.3.0.tgz",
       "integrity": "sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "ky": "^1.14.2",
         "undici": "^6.23.0"
@@ -14861,6 +14931,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@trustvc/w3c-context/-/w3c-context-2.0.2.tgz",
       "integrity": "sha512-2DM73n1z2FXML9/suGHea6BcJqs7GKiJsvpozRf6lE9d3ZyFRmCd6H84f7Z7zGvacuLXMRnPX2A9DKE0ETs8HA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "did-resolver": "^4.1.0",
         "jsonld-signatures": "^11.5.0"
@@ -14873,6 +14944,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@trustvc/w3c-credential-status/-/w3c-credential-status-2.0.2.tgz",
       "integrity": "sha512-8f5sHoDAT8YqLlHm82t/wh1HrZdmR3PgRGfDcgbKWrJtA+X2769kk6qVXCNP6tq1Ghyqe8v/HLortrXp9JSdGw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@trustvc/w3c-context": "^2.0.2",
         "@trustvc/w3c-issuer": "^2.0.2",
@@ -14887,6 +14959,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@trustvc/w3c-issuer/-/w3c-issuer-2.0.2.tgz",
       "integrity": "sha512-NDtEcGV7ryuWHbaX3hwlz2cN/hhDWHzA+D2AF56I7teNfev+X62pro+HrXYAa3EclPET7BI+fYmLgh61/DAl7w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@digitalbazaar/bls12-381-multikey": "^2.1.0",
         "@digitalbazaar/ecdsa-multikey": "^1.8.0",
@@ -14904,6 +14977,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@trustvc/w3c-vc/-/w3c-vc-2.0.2.tgz",
       "integrity": "sha512-3A488DgukqrKXDSNdtZE02tOfj6V9C6uRJAEKEnMiaUevxNzFO9TFpqXkeOdxNhg9yHEH7m68b6SqfwU/tbVXQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@digitalbazaar/bbs-2023-cryptosuite": "^2.0.1",
         "@digitalbazaar/bls12-381-multikey": "^2.1.0",
@@ -14932,6 +15006,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
       "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
       "bin": {
         "canonicalize": "bin/canonicalize.js"
       }
@@ -14940,6 +15015,7 @@
       "version": "11.6.0",
       "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.6.0.tgz",
       "integrity": "sha512-hzYNZXnfy4cUFf9aiFBtduUz+cknbfBLWtTKvoqVyP2ECPwqfsfkHWFlhccWfAKV/LJkPLyKZRwC1B4T5LO4ZQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/security-context": "^1.0.0",
         "jsonld": "^9.0.0",
@@ -14954,6 +15030,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz",
       "integrity": "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/http-client": "^4.2.0",
         "canonicalize": "^2.1.0",
@@ -14968,6 +15045,7 @@
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
       "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -14979,6 +15057,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14989,12 +15068,14 @@
     "node_modules/@trustvc/w3c/node_modules/pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/@trustvc/w3c/node_modules/rdf-canonize": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
       "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "setimmediate": "^1.0.5"
       },
@@ -15006,6 +15087,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
       "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -15020,6 +15102,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -15031,6 +15114,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
       "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.17"
       }
@@ -15043,6 +15127,7 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -15050,7 +15135,8 @@
     "node_modules/@trustvc/w3c/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -18770,6 +18856,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base58-universal/-/base58-universal-2.0.0.tgz",
       "integrity": "sha512-BgkgF8zVLOAygszG4W8NkLm7iXrw80VYAOcedrzANrIhS14+4W6zVqjyGTFUBM/FpqkHUt8aAYd4DbBBfn3zKg==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=14"
       }
@@ -19767,6 +19854,7 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/cbor/-/cbor-9.0.2.tgz",
       "integrity": "sha512-JPypkxsB10s9QOWwa6zwPzqE1Md3vqpPc+cai4sAecuCsRyAtAl/pMyhPlMbT/xtPnm2dznJZYRLui57qiRhaQ==",
+      "license": "MIT",
       "dependencies": {
         "nofilter": "^3.1.0"
       },
@@ -19778,6 +19866,7 @@
       "version": "4.5.8",
       "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.5.8.tgz",
       "integrity": "sha512-6/viltD51JklRhq4L7jC3zgy6gryuG5xfZ3kzpE+PravtyeQLeQmCYLREhQH7pWENg5pY4Yu/XCd6a7dKScVlw==",
+      "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
       }
@@ -33461,6 +33550,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-7.0.0.tgz",
       "integrity": "sha512-J/nA+llcYYjErPHG9WFpXvR82TOg5fbHk/7rXbx4Ts854DPReaKAAd0hAZ+s5/P2WIIAZPIHCqA+iz1QrOqeiQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "base64url": "^3.0.1",
         "crypto-ld": "^3.7.0",
@@ -33477,6 +33567,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-4.0.1.tgz",
       "integrity": "sha512-ltEqMQB37ZxZnsgmI+9rqHYkz1M6PqUykuS1t2aQNuH1oiLrUDYz5nyVkHQDgjFd7CFKTIWeLiNhwdwFrH5o5A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "canonicalize": "^1.0.1",
         "lru-cache": "^5.1.1",
@@ -33493,6 +33584,7 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
       "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.0.0"
       }
@@ -33501,6 +33593,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-2.0.1.tgz",
       "integrity": "sha512-/GVELjrfW8G/wS4QfDZ5Kq68cS1belVNJqZlcwiErerexeBUsgOINCROnP7UumWIBNdeCwTVLE9NVXMnRYK0lA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "semver": "^6.3.0",
         "setimmediate": "^1.0.5"
@@ -35683,6 +35776,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
       "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "license": "MIT",
       "engines": {
         "node": ">=12.19"
       }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@tradetrust-tt/address-identity-resolver": "^1.6.2",
     "@tradetrust-tt/decentralized-renderer-react-components": "^3.16.12",
     "@tradetrust-tt/document-store": "^4.1.1",
-    "@trustvc/trustvc": "^2.6.1",
+    "@trustvc/trustvc": "^2.11.0",
     "@types/gtag.js": "0.0.8",
     "buffer": "^6.0.3",
     "cross-env": "^7.0.3",

--- a/src/common/hooks/useDeployTokenRegistry.tsx
+++ b/src/common/hooks/useDeployTokenRegistry.tsx
@@ -46,8 +46,8 @@ export const useDeployTokenRegistry = (): useDeployTokenRegistryResult => {
           CHAIN_ID.local,
           "execute blockchain:contracts:testcafe before starting"
         );
-        tDocDeployerAddress = "0x3488EAA1bF4f606f758b24F5ef6eb2a1E32335be"; //process.env.ERC1967_PROXY_ADDRESS!;
-        implContractAddress = "0x0952a6817E00fc2455418a5303395760A9c4EE71"; //process.env.TOKEN_IMPLEMENTATION!;
+        tDocDeployerAddress = "0xfE442b75786c67E1e7a7146DAeD8943F0f2c23d2"; //process.env.ERC1967_PROXY_ADDRESS!;
+        implContractAddress = "0x547Ca63C8fB3Ccb856DEb7040D327dBfe4e7d20F"; //process.env.TOKEN_IMPLEMENTATION!;
       } else {
         tDocDeployerAddress = v5ContractAddress.Deployer[networkId];
         implContractAddress = v5ContractAddress.TokenImplementation[networkId];

--- a/src/common/hooks/useDeployTokenRegistry.tsx
+++ b/src/common/hooks/useDeployTokenRegistry.tsx
@@ -46,8 +46,8 @@ export const useDeployTokenRegistry = (): useDeployTokenRegistryResult => {
           CHAIN_ID.local,
           "execute blockchain:contracts:testcafe before starting"
         );
-        tDocDeployerAddress = "0xfE442b75786c67E1e7a7146DAeD8943F0f2c23d2"; //process.env.ERC1967_PROXY_ADDRESS!;
-        implContractAddress = "0x547Ca63C8fB3Ccb856DEb7040D327dBfe4e7d20F"; //process.env.TOKEN_IMPLEMENTATION!;
+        tDocDeployerAddress = "0x3488EAA1bF4f606f758b24F5ef6eb2a1E32335be"; //process.env.ERC1967_PROXY_ADDRESS!;
+        implContractAddress = "0x0952a6817E00fc2455418a5303395760A9c4EE71"; //process.env.TOKEN_IMPLEMENTATION!;
       } else {
         tDocDeployerAddress = v5ContractAddress.Deployer[networkId];
         implContractAddress = v5ContractAddress.TokenImplementation[networkId];

--- a/src/test/setup-contracts-testcafe.js
+++ b/src/test/setup-contracts-testcafe.js
@@ -129,7 +129,7 @@ const CHAIN_ID = { local: 1337 };
     signer
   );
   const addImplementationTx = await tDocDeployerThroughProxy.addImplementation(
-    TOKEN_IMPLEMENTATION_ADDRESS,
+    tokenImplementationContract.address,
     titleEscrowFactoryContract.address
   );
 
@@ -163,7 +163,7 @@ const CHAIN_ID = { local: 1337 };
       ...[
         "0x8f39d973ec500c1c0a510c3153707ee68d0889be9bdde3a8e3dfa40db266989c",
         "0x28c99df4a369856891f0ac3f7f3e093b3713bd5d9950c4580777d761590c52d4",
-        "598122e29c62235138e9f318cd26a287eacb0af86b1ed8ca65cc3ecfed40520a",
+        "0x598122e29c62235138e9f318cd26a287eacb0af86b1ed8ca65cc3ecfed40520a",
         "0x0102d39f774d3214cec087063cc9d3705db972926e892238a4a232d709274a39",
         "0x76f608c209f8e449d1ea57999bef458fff928d7967e13d71a0f2348b3d5be4b1",
         "0xe52a60e9c1308960bcf1d6c8531c58bf480aec373e1e3442a6af151475c3f89d",

--- a/src/test/setup-contracts-testcafe.js
+++ b/src/test/setup-contracts-testcafe.js
@@ -1,9 +1,23 @@
 const shell = require("shelljs");
 const path = require("path");
 const { ethers, Wallet } = require("ethers");
-const ERC1967Proxy_artifact = require("./fixture/artifacts/ERC1967Proxy.json"); // Assuming this is the correct deployable proxy artifact
+const ERC1967Proxy_artifact = require("./fixture/artifacts/ERC1967Proxy.json");
 
-// Import only the specific modules we need to avoid problematic ESM dependencies
+/**
+ * IMPORTANT: This script uses only contract artifacts from @trustvc/trustvc
+ * and avoids importing helper functions (deployTokenRegistry, mint) to prevent
+ * ESM module errors in Node.js/GitHub Actions environments.
+ *
+ * The helper functions have dependencies that include ESM-only modules
+ * (@digitalbazaar/bls12-381-multikey) which cannot be required() in CommonJS.
+ *
+ * Instead, we use direct ethers.js ContractFactory deployment and contract
+ * interaction, which is more reliable in CI/CD environments.
+ */
+
+const DocumentStore = path.resolve(__dirname, "../../node_modules/@trustvc/trustvc/dist/cjs/document-store/index.js");
+const { DocumentStore__factory } = require(DocumentStore);
+
 const v5ContractsPath = path.resolve(
   __dirname,
   "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/contracts.js"
@@ -14,7 +28,13 @@ const v5Contracts = require(v5ContractsPath);
 const CHAIN_ID = { local: 1337 };
 
 (async () => {
-  const { TDocDeployer__factory, TitleEscrowFactory__factory, TradeTrustTokenStandard__factory } = v5Contracts; // Remove ERC1967__factory from here
+  const {
+    TDocDeployer__factory,
+    TitleEscrowFactory__factory,
+    TradeTrustToken__factory,
+    TradeTrustTokenStandard__factory,
+    TitleEscrow__factory,
+  } = v5Contracts;
 
   // Note: Dummy test wallets — private keys for local development and CI/CD only.
   // These wallets are not for production and hold no funds or value on any network.
@@ -23,22 +43,51 @@ const CHAIN_ID = { local: 1337 };
   const ADDRESS_EXAMPLE_1 = "0xe0a71284ef59483795053266cb796b65e48b5124";
   const ADDRESS_EXAMPLE_2 = "0xcdfacbb428dd30ddf6d99875dcad04cbefcd6e60";
 
-  const oaCLI_PATH = "tradetrust";
-  shell.exec(`${oaCLI_PATH} deploy title-escrow-factory -n local -k ${ACCOUNT_KEY}`);
-  const TITLE_ESCROW_FACTORY_ADDRESS = "0x63A223E025256790E88778a01f480eBA77731D04";
-
-  shell.exec(
-    `${oaCLI_PATH} deploy token-registry "DEMO TOKEN REGISTRY" DTR -n local -k ${ACCOUNT_KEY} --factory-address ${TITLE_ESCROW_FACTORY_ADDRESS} --standalone`
-  );
-  const TOKEN_REGISTRY_ADDRESS = "0x9Eb613a88534E2939518f4ffBFE65F5969b491FF";
-
-  shell.exec(`${oaCLI_PATH} deploy document-store "My Document Store" -n local -k ${ACCOUNT_KEY}`);
-  const DOCUMENT_STORE_ADDRESS = "0x4Bf7E4777a8D1b6EdD5F2d9b8582e2817F0B0953";
-
-  // Setup TDoc Deployer
-
+  // Setup provider and signer
   const provider = new ethers.providers.JsonRpcProvider("http://127.0.0.1:8545/", Number(CHAIN_ID.local));
   const signer = new Wallet(ACCOUNT_KEY, provider);
+  const signer2 = new Wallet(ACCOUNT_KEY_2, provider);
+
+  console.log("Deploying Title Escrow Factory...");
+  // Deploy Title Escrow Factory
+  const titleEscrowFactoryForStandalone = new ethers.ContractFactory(
+    TitleEscrowFactory__factory.abi,
+    TitleEscrowFactory__factory.bytecode,
+    signer
+  );
+  const titleEscrowFactoryContractForStandalone = await titleEscrowFactoryForStandalone.deploy();
+  await titleEscrowFactoryContractForStandalone.deployed();
+  console.log(`Title Escrow Factory deployed at: ${titleEscrowFactoryContractForStandalone.address}`);
+  const TITLE_ESCROW_FACTORY_ADDRESS = titleEscrowFactoryContractForStandalone.address;
+
+  console.log("Deploying Token Registry (standalone)...");
+  // Deploy Token Registry (standalone mode)
+  const tokenRegistryFactory = new ethers.ContractFactory(
+    TradeTrustToken__factory.abi,
+    TradeTrustToken__factory.bytecode,
+    signer
+  );
+  const tokenRegistryContract = await tokenRegistryFactory.deploy(
+    "DEMO TOKEN REGISTRY",
+    "DTR",
+    titleEscrowFactoryContractForStandalone.address
+  );
+  await tokenRegistryContract.deployed();
+  console.log(`Token Registry deployed at: ${tokenRegistryContract.address}`);
+  const TOKEN_REGISTRY_ADDRESS = tokenRegistryContract.address;
+
+  // Deploy a dummy contract to maintain nonce count and keep addresses consistent
+  // This ensures TDoc Deployer and other contracts deploy at the same addresses
+  console.log("Deploying Document Store contract to maintain address consistency...");
+  const documentStoreFactory = new ethers.ContractFactory(
+    DocumentStore__factory.abi, // Reuse any simple contract ABI
+    DocumentStore__factory.bytecode,
+    signer
+  );
+  const documentStoreContract = await documentStoreFactory.deploy("DEMO DOCUMENT STORE", signer.address);
+  // await documentStoreContract.deployed();
+  console.log(`Document Store deployed at: ${documentStoreContract.address} (maintains nonce for address consistency)`);
+  const DOCUMENT_STORE_ADDRESS = documentStoreContract.address;
 
   const tDocDeployerFactory = new ethers.ContractFactory(
     TDocDeployer__factory.abi,
@@ -127,30 +176,55 @@ const CHAIN_ID = { local: 1337 };
     ],
   };
 
-  merkleRootToMint.tokenRegistry.forEach((element) => {
-    shell.exec(
-      `${oaCLI_PATH} token-registry issue --beneficiary ${element.owner} --holder ${element.holder} --address ${element.tokenRegistryAddress} --tokenId ${element.merkleRoot} -n local -k ${element.accountKey}`
-    );
-  });
+  // Mint tokens using direct contract interaction
+  console.log("Minting tokens...");
+  for (const element of merkleRootToMint.tokenRegistry) {
+    console.log(`Minting token ${element.merkleRoot}...`);
+    try {
+      const tx = await tokenRegistryContract.mint(element.owner, element.holder, element.merkleRoot, "0x");
+      await tx.wait();
+      console.log(`Token ${element.merkleRoot} minted successfully`);
+    } catch (error) {
+      console.error(`Failed to mint token ${element.merkleRoot}:`, error.message);
+    }
+  }
 
-  shell.exec(
-    `${oaCLI_PATH} title-escrow nominate-change-owner --newBeneficiary ${ADDRESS_EXAMPLE_2} --token-registry ${TOKEN_REGISTRY_ADDRESS} --tokenId ${MERKLE_ROOT_OF_ENDORSEMENT_CHAIN_DOCUMENT} -n local -k ${ACCOUNT_KEY}`
-  );
-  shell.exec(
-    `${oaCLI_PATH} title-escrow endorse-transfer-owner --newBeneficiary ${ADDRESS_EXAMPLE_2} --token-registry ${TOKEN_REGISTRY_ADDRESS} --tokenId ${MERKLE_ROOT_OF_ENDORSEMENT_CHAIN_DOCUMENT} -n local -k ${ACCOUNT_KEY}`
-  );
-  shell.exec(
-    `${oaCLI_PATH} title-escrow change-holder --token-registry ${TOKEN_REGISTRY_ADDRESS} --tokenId ${MERKLE_ROOT_OF_ENDORSEMENT_CHAIN_DOCUMENT} --newHolder ${ADDRESS_EXAMPLE_2} -n local -k ${ACCOUNT_KEY}`
-  );
-  shell.exec(
-    `${oaCLI_PATH} title-escrow endorse-change-owner --newBeneficiary ${ADDRESS_EXAMPLE_1} --newHolder ${ADDRESS_EXAMPLE_1} --token-registry ${TOKEN_REGISTRY_ADDRESS} --tokenId ${MERKLE_ROOT_OF_ENDORSEMENT_CHAIN_DOCUMENT} -n local -k ${ACCOUNT_KEY_2}`
-  );
-  shell.exec(
-    `${oaCLI_PATH} title-escrow return-to-issuer --token-registry ${TOKEN_REGISTRY_ADDRESS} --tokenId ${MERKLE_ROOT_OF_ENDORSEMENT_CHAIN_DOCUMENT} -n local -k ${ACCOUNT_KEY}`
-  );
-  shell.exec(
-    `${oaCLI_PATH} title-escrow accept-returned --token-registry ${TOKEN_REGISTRY_ADDRESS} --tokenId ${MERKLE_ROOT_OF_ENDORSEMENT_CHAIN_DOCUMENT} -n local -k ${ACCOUNT_KEY}`
-  );
+  // Perform endorsement chain operations using direct contract interaction
+  console.log("Performing endorsement chain operations...");
+
+  // Get the title escrow address for the token
+  const titleEscrowAddress = await tokenRegistryContract.ownerOf(MERKLE_ROOT_OF_ENDORSEMENT_CHAIN_DOCUMENT);
+  const TitleEscrow = new ethers.Contract(titleEscrowAddress, TitleEscrow__factory.abi, signer);
+
+  try {
+    console.log("1. Nominate change owner...");
+    let tx = await TitleEscrow.connect(signer).nominate(ADDRESS_EXAMPLE_2, "0x");
+    await tx.wait();
+
+    console.log("2. Endorse transfer owner...");
+    tx = await TitleEscrow.connect(signer).transferBeneficiary(ADDRESS_EXAMPLE_2, "0x");
+    await tx.wait();
+
+    console.log("3. Change holder...");
+    tx = await TitleEscrow.connect(signer).transferHolder(ADDRESS_EXAMPLE_2, "0x");
+    await tx.wait();
+
+    console.log("4. Endorse change owner (from signer2)...");
+    tx = await TitleEscrow.connect(signer2).transferOwners(ADDRESS_EXAMPLE_1, ADDRESS_EXAMPLE_1, "0x");
+    await tx.wait();
+
+    console.log("5. Return to issuer...");
+    tx = await TitleEscrow.connect(signer).returnToIssuer("0x");
+    await tx.wait();
+
+    console.log("6. Accept returned (shred)...");
+    tx = await tokenRegistryContract.connect(signer).burn(MERKLE_ROOT_OF_ENDORSEMENT_CHAIN_DOCUMENT, "0x");
+    await tx.wait();
+
+    console.log("Endorsement chain operations completed successfully");
+  } catch (error) {
+    console.error("Error during endorsement chain operations:", error.message);
+  }
 
   // prep for issuing document store
   const merkleRootToIssue = [
@@ -180,14 +254,23 @@ const CHAIN_ID = { local: 1337 };
     "0x9e29d92823624e164f1b30b5b2da43f9db1c0347f5ff3b80b576f1a0376de5af",
   ];
 
-  merkleRootToIssue.forEach((hash) => {
-    shell.exec(
-      `${oaCLI_PATH} document-store issue --address ${DOCUMENT_STORE_ADDRESS} --hash ${hash} -n local -k ${ACCOUNT_KEY}`
-    );
-  });
+  // These documents are for verifiable documents, not transferable documents
+  //add in issuance code
+  console.log("Issuing documents...");
+  for (const merkleRoot of merkleRootToIssue) {
+    console.log(`Issuing document ${merkleRoot}...`);
+    try {
+      const tx = await documentStoreContract.issue(merkleRoot);
+      await tx.wait();
+      console.log(`Document ${merkleRoot} issued successfully`);
+    } catch (error) {
+      console.error(`Failed to issue document ${merkleRoot}:`, error.message);
+    }
+  }
 
   // Generate self sign ssl for testcafe to verify w3c document.
   // Need to run testcafe with ssl. https://stackoverflow.com/questions/74067564/how-to-get-subtlecrypto-work-with-testcafe
+  console.log("\nGenerating SSL certificates for testcafe...");
   shell.exec(
     `openssl req -nodes -new -x509 -keyout src/test/ca/myCA.key -out src/test/ca/myCA.pem -subj "/C=SG/ST=SG/L=/O=/OU=/CN=www.example.com/emailAddress=dev@www.example.com"`
   );
@@ -201,4 +284,13 @@ const CHAIN_ID = { local: 1337 };
   shell.exec(
     `openssl pkcs12 -passout pass: -export -out src/test/ca/testingdomain.pfx -inkey src/test/ca/testingdomain.key -in src/test/ca/testingdomain.crt -certfile src/test/ca/myCA.pem`
   );
+
+  console.log("\n=== Contract Setup Complete ===");
+  console.log(`Title Escrow Factory: ${TITLE_ESCROW_FACTORY_ADDRESS}`);
+  console.log(`Token Registry: ${TOKEN_REGISTRY_ADDRESS}`);
+  console.log(`Dummy Contract (Document Store placeholder): ${DOCUMENT_STORE_ADDRESS}`);
+  console.log(`TDoc Deployer (Implementation): ${tDocDeployerFactoryContract.address}`);
+  console.log(`TDoc Deployer (Proxy): ${ERC1967ProxyFactoryContract.address}`);
+  console.log(`Token Implementation: ${tokenImplementationContract.address}`);
+  console.log(`Title Escrow Factory (V5): ${titleEscrowFactoryContract.address}`);
 })();

--- a/src/test/setup-contracts-testcafe.js
+++ b/src/test/setup-contracts-testcafe.js
@@ -118,10 +118,10 @@ const CHAIN_ID = { local: 1337 };
   const titleEscrowFactoryContract = await titleEscrowFactory.deploy();
   const tokenImplementationContract = await tokenImplementation.deploy();
 
-  const TOKEN_IMPLEMENTATION_ADDRESS = "0x0952a6817E00fc2455418a5303395760A9c4EE71"; //tokenImplementationContract.address
-  const TITLE_ESCROW_FACTORY_ADDRESS2 = "0x547Ca63C8fB3Ccb856DEb7040D327dBfe4e7d20F"; //titleEscrowFactoryContract.address;
-  const TDOC_DEPLOYER_ADDRESS = "0xfE442b75786c67E1e7a7146DAeD8943F0f2c23d2"; //tDocDeployerFactoryContract.address
-  const ERC1967_PROXY_ADDRESS2 = "0x3488EAA1bF4f606f758b24F5ef6eb2a1E32335be"; //ERC1967ProxyFactoryContract.address
+  // const TOKEN_IMPLEMENTATION_ADDRESS = "0x0952a6817E00fc2455418a5303395760A9c4EE71"; //tokenImplementationContract.address
+  // const TITLE_ESCROW_FACTORY_ADDRESS2 = "0x547Ca63C8fB3Ccb856DEb7040D327dBfe4e7d20F"; //titleEscrowFactoryContract.address;
+  // const TDOC_DEPLOYER_ADDRESS = "0xfE442b75786c67E1e7a7146DAeD8943F0f2c23d2"; //tDocDeployerFactoryContract.address
+  // const ERC1967_PROXY_ADDRESS2 = "0x3488EAA1bF4f606f758b24F5ef6eb2a1E32335be"; //ERC1967ProxyFactoryContract.address
 
   const tDocDeployerThroughProxy = new ethers.Contract(
     ERC1967ProxyFactoryContract.address,
@@ -133,7 +133,7 @@ const CHAIN_ID = { local: 1337 };
     titleEscrowFactoryContract.address
   );
 
-  const addImplementationReceipt = await addImplementationTx.wait();
+  await addImplementationTx.wait();
 
   // --- End TDoc Deployer Setup
 
@@ -186,6 +186,7 @@ const CHAIN_ID = { local: 1337 };
       console.log(`Token ${element.merkleRoot} minted successfully`);
     } catch (error) {
       console.error(`Failed to mint token ${element.merkleRoot}:`, error.message);
+      throw error;
     }
   }
 

--- a/tests/e2e/setup-contracts.js
+++ b/tests/e2e/setup-contracts.js
@@ -17,6 +17,11 @@ const v5ContractsPath = path.resolve(
   __dirname,
   "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/contracts.js"
 );
+const DocumentStore__factoryPath = path.resolve(
+  __dirname,
+  "../../node_modules/@trustvc/trustvc/dist/cjs/document-store/index.js"
+);
+const { DocumentStore__factory } = require(DocumentStore__factoryPath);
 const v5Contracts = require(v5ContractsPath);
 
 // Define local chain ID directly for local development
@@ -66,11 +71,15 @@ const CHAIN_ID = { local: 1337 };
   await tokenRegistryContract.deployed();
   console.log(`Token Registry deployed at: ${tokenRegistryContract.address}`);
 
-  console.log("Deploying Document Store...");
-  // Deploy Document Store (using artifact if available)
-  // Note: You may need to import DocumentStore artifact similar to how you're using it in the codebase
-  // For now, we'll skip this as it's not critical for the token registry tests
-  console.log("Document Store deployment skipped (not critical for token registry tests)");
+  console.log("Deploying Document Store...", DocumentStore__factory);
+  const documentStoreFactory = new ethers.ContractFactory(
+    DocumentStore__factory.abi,
+    DocumentStore__factory.bytecode,
+    signer
+  );
+  const documentStoreContract = await documentStoreFactory.deploy("My Document Store", signer.address);
+  await documentStoreContract.deployed();
+  console.log(`Document Store deployed at: ${documentStoreContract.address}`);
 
   const tDocDeployerFactory = new ethers.ContractFactory(
     TDocDeployer__factory.abi,

--- a/tests/e2e/setup-contracts.js
+++ b/tests/e2e/setup-contracts.js
@@ -107,10 +107,10 @@ const CHAIN_ID = { local: 1337 };
   const tokenImplementationContract = await tokenImplementation.deploy();
 
   // addresses are same when executed for the first time after blockchain node is started.
-  const TOKEN_IMPLEMENTATION_ADDRESS = "0x0952a6817E00fc2455418a5303395760A9c4EE71"; //tokenImplementationContract.address
-  const TITLE_ESCROW_FACTORY_ADDRESS2 = "0x547Ca63C8fB3Ccb856DEb7040D327dBfe4e7d20F"; //titleEscrowFactoryContract.address;
-  const TDOC_DEPLOYER_ADDRESS = "0xfE442b75786c67E1e7a7146DAeD8943F0f2c23d2"; //tDocDeployerFactoryContract.address
-  const ERC1967_PROXY_ADDRESS2 = "0x3488EAA1bF4f606f758b24F5ef6eb2a1E32335be"; //ERC1967ProxyFactoryContract.address
+  // const TOKEN_IMPLEMENTATION_ADDRESS = "0x0952a6817E00fc2455418a5303395760A9c4EE71"; //tokenImplementationContract.address
+  // const TITLE_ESCROW_FACTORY_ADDRESS2 = "0x547Ca63C8fB3Ccb856DEb7040D327dBfe4e7d20F"; //titleEscrowFactoryContract.address;
+  // const TDOC_DEPLOYER_ADDRESS = "0xfE442b75786c67E1e7a7146DAeD8943F0f2c23d2"; //tDocDeployerFactoryContract.address
+  // const ERC1967_PROXY_ADDRESS2 = "0x3488EAA1bF4f606f758b24F5ef6eb2a1E32335be"; //ERC1967ProxyFactoryContract.address
 
   const tDocDeployerThroughProxy = new ethers.Contract(
     ERC1967ProxyFactoryContract.address,
@@ -122,7 +122,7 @@ const CHAIN_ID = { local: 1337 };
     titleEscrowFactoryContract.address
   );
 
-  const addImplementationReceipt = await addImplementationTx.wait();
+  await addImplementationTx.wait();
 
   // --- End TDoc Deployer Setup
 
@@ -175,6 +175,7 @@ const CHAIN_ID = { local: 1337 };
       console.log(`Token ${element.tokenId} minted successfully`);
     } catch (error) {
       console.error(`Failed to mint token ${element.tokenId}:`, error.message);
+      throw error;
     }
   }
 

--- a/tests/e2e/setup-contracts.js
+++ b/tests/e2e/setup-contracts.js
@@ -2,24 +2,22 @@ const path = require("path");
 const { ethers, Wallet } = require("ethers");
 const ERC1967Proxy_artifact = require("../../src/test/fixture/artifacts/ERC1967Proxy.json");
 
-// Import @trustvc/trustvc modules directly from CJS dist to avoid ESM issues
+/**
+ * IMPORTANT: This script uses only contract artifacts from @trustvc/trustvc
+ * and avoids importing helper functions (deployTokenRegistry, mint) to prevent
+ * ESM module errors in Node.js/GitHub Actions environments.
+ * 
+ * The helper functions have dependencies that include ESM-only modules
+ * (@digitalbazaar/bls12-381-multikey) which cannot be required() in CommonJS.
+ * 
+ * Instead, we use direct ethers.js ContractFactory deployment and contract
+ * interaction, which is more reliable in CI/CD environments.
+ */
 const v5ContractsPath = path.resolve(
   __dirname,
   "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/contracts.js"
 );
 const v5Contracts = require(v5ContractsPath);
-
-const deployPath = path.resolve(
-  __dirname,
-  "../../node_modules/@trustvc/trustvc/dist/cjs/deploy/token-registry.js"
-);
-const { deployTokenRegistry } = require(deployPath);
-
-const mintPath = path.resolve(
-  __dirname,
-  "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-functions/mint.js"
-);
-const { mint } = require(mintPath);
 
 // Define local chain ID directly for local development
 const CHAIN_ID = { local: 1337 };
@@ -51,21 +49,20 @@ const CHAIN_ID = { local: 1337 };
   await titleEscrowFactoryContractForStandalone.deployed();
   console.log(`Title Escrow Factory deployed at: ${titleEscrowFactoryContractForStandalone.address}`);
 
-  console.log("Deploying Token Registry (standalone) using deployTokenRegistry...");
-  // Deploy Token Registry using @trustvc/trustvc helper function
-  const deployReceipt = await deployTokenRegistry("DEMO TOKEN REGISTRY", "DTR", signer, {
-    chainId: CHAIN_ID.local,
-    standalone: true,
-    factoryAddress: titleEscrowFactoryContractForStandalone.address,
-  });
-  console.log(`Token Registry deployed at: ${deployReceipt.contractAddress}`);
-
-  // Get the deployed contract instance
-  const tokenRegistryContract = new ethers.Contract(
-    deployReceipt.contractAddress,
+  console.log("Deploying Token Registry (standalone)...");
+  // Deploy Token Registry (standalone mode)
+  const tokenRegistryFactory = new ethers.ContractFactory(
     TradeTrustTokenStandard__factory.abi,
+    TradeTrustTokenStandard__factory.bytecode,
     signer
   );
+  const tokenRegistryContract = await tokenRegistryFactory.deploy(
+    "DEMO TOKEN REGISTRY",
+    "DTR",
+    titleEscrowFactoryContractForStandalone.address
+  );
+  await tokenRegistryContract.deployed();
+  console.log(`Token Registry deployed at: ${tokenRegistryContract.address}`);
 
   console.log("Deploying Document Store...");
   // Deploy Document Store (using artifact if available)
@@ -154,25 +151,23 @@ const CHAIN_ID = { local: 1337 };
     ],
   };
 
-  // Mint tokens using @trustvc/trustvc mint function
+  // Mint tokens using direct contract interaction
   console.log("Minting tokens...");
+  const tokenRegistryForMinting = new ethers.Contract(
+    TOKEN_REGISTRY_ADDRESS,
+    TradeTrustTokenStandard__factory.abi,
+    signer
+  );
 
   for (const element of tokensToMint.tokenRegistry) {
     console.log(`Minting token ${element.tokenId}...`);
     try {
-      const receipt = await mint(
-        { tokenRegistryAddress: TOKEN_REGISTRY_ADDRESS },
-        signer,
-        {
-          beneficiaryAddress: element.owner,
-          holderAddress: element.holder,
-          tokenId: element.tokenId,
-        },
-        {
-          chainId: CHAIN_ID.local,
-          titleEscrowVersion: "v5",
-        }
+      const tx = await tokenRegistryForMinting.mint(
+        element.owner,
+        element.holder,
+        element.tokenId
       );
+      await tx.wait();
       console.log(`Token ${element.tokenId} minted successfully`);
     } catch (error) {
       console.error(`Failed to mint token ${element.tokenId}:`, error.message);

--- a/tests/e2e/setup-contracts.js
+++ b/tests/e2e/setup-contracts.js
@@ -112,7 +112,7 @@ const CHAIN_ID = { local: 1337 };
     signer
   );
   const addImplementationTx = await tDocDeployerThroughProxy.addImplementation(
-    TOKEN_IMPLEMENTATION_ADDRESS,
+    tokenImplementationContract.address,
     titleEscrowFactoryContract.address
   );
 

--- a/tests/e2e/setup-contracts.js
+++ b/tests/e2e/setup-contracts.js
@@ -1,17 +1,25 @@
 const path = require("path");
 const { ethers, Wallet } = require("ethers");
-const { deployTokenRegistry, mint, v5Contracts } = require("@trustvc/trustvc");
 const ERC1967Proxy_artifact = require("../../src/test/fixture/artifacts/ERC1967Proxy.json");
 
-// // Import @trustvc/trustvc modules for contract deployment
-// const v5ContractsPath = path.resolve(
-//   __dirname,
-//   "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/contracts.js"
-// );
-// const v5Contracts = require(v5ContractsPath);
+// Import @trustvc/trustvc modules directly from CJS dist to avoid ESM issues
+const v5ContractsPath = path.resolve(
+  __dirname,
+  "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/contracts.js"
+);
+const v5Contracts = require(v5ContractsPath);
 
-// const v5UtilsPath = path.resolve(__dirname, "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/utils.js");
-// const v5Utils = require(v5UtilsPath);
+const deployPath = path.resolve(
+  __dirname,
+  "../../node_modules/@trustvc/trustvc/dist/cjs/deploy/token-registry.js"
+);
+const { deployTokenRegistry } = require(deployPath);
+
+const mintPath = path.resolve(
+  __dirname,
+  "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-functions/mint.js"
+);
+const { mint } = require(mintPath);
 
 // Define local chain ID directly for local development
 const CHAIN_ID = { local: 1337 };

--- a/tests/e2e/setup-contracts.js
+++ b/tests/e2e/setup-contracts.js
@@ -33,11 +33,8 @@ const CHAIN_ID = { local: 1337 };
   // Note: Dummy test wallets — private keys for local development and CI/CD only.
   // These wallets are not for production and hold no funds or value on any network.
   const ACCOUNT_KEY = "0xe82294532bcfcd8e0763ee5cef194f36f00396be59b94fb418f5f8d83140d9a7";
-  const TOKEN_REGISTRY_ADDRESS = "0x82524C1C34F52a2c42eA41daF08B27cB7711c9EE";
   const ADDRESS_EXAMPLE_1 = "0xe0a71284ef59483795053266cb796b65e48b5124";
   const ADDRESS_EXAMPLE_2 = "0xcdfacbb428dd30ddf6d99875dcad04cbefcd6e60";
-
-  const TITLE_ESCROW_FACTORY_ADDRESS = "0x63A223E025256790E88778a01f480eBA77731D04";
 
   // Setup provider and signer
   const provider = new ethers.providers.JsonRpcProvider("http://127.0.0.1:8545/", Number(CHAIN_ID.local));
@@ -125,7 +122,7 @@ const CHAIN_ID = { local: 1337 };
 
   const defaultToken = {
     accountKey: ACCOUNT_KEY,
-    tokenRegistryAddress: TOKEN_REGISTRY_ADDRESS,
+    tokenRegistryAddress: tokenRegistryContract.address, // Use the deployed contract address
     owner: ADDRESS_EXAMPLE_1,
     holder: ADDRESS_EXAMPLE_1,
   };
@@ -159,7 +156,7 @@ const CHAIN_ID = { local: 1337 };
   // Mint tokens using direct contract interaction
   console.log("Minting tokens...");
   const tokenRegistryForMinting = new ethers.Contract(
-    TOKEN_REGISTRY_ADDRESS,
+    tokenRegistryContract.address,
     TradeTrustTokenStandard__factory.abi,
     signer
   );

--- a/tests/e2e/setup-contracts.js
+++ b/tests/e2e/setup-contracts.js
@@ -17,11 +17,6 @@ const v5ContractsPath = path.resolve(
   __dirname,
   "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/contracts.js"
 );
-const DocumentStore__factoryPath = path.resolve(
-  __dirname,
-  "../../node_modules/@trustvc/trustvc/dist/cjs/document-store/index.js"
-);
-const { DocumentStore__factory } = require(DocumentStore__factoryPath);
 const v5Contracts = require(v5ContractsPath);
 
 // Define local chain ID directly for local development
@@ -71,15 +66,17 @@ const CHAIN_ID = { local: 1337 };
   await tokenRegistryContract.deployed();
   console.log(`Token Registry deployed at: ${tokenRegistryContract.address}`);
 
-  console.log("Deploying Document Store...", DocumentStore__factory);
-  const documentStoreFactory = new ethers.ContractFactory(
-    DocumentStore__factory.abi,
-    DocumentStore__factory.bytecode,
+  // Deploy a dummy contract to maintain nonce count and keep addresses consistent with testcafe setup
+  // This ensures TDoc Deployer and other contracts deploy at the same addresses
+  console.log("Deploying dummy contract to maintain address consistency...");
+  const dummyFactory = new ethers.ContractFactory(
+    TitleEscrowFactory__factory.abi, // Reuse any simple contract ABI
+    TitleEscrowFactory__factory.bytecode,
     signer
   );
-  const documentStoreContract = await documentStoreFactory.deploy("My Document Store", signer.address);
-  await documentStoreContract.deployed();
-  console.log(`Document Store deployed at: ${documentStoreContract.address}`);
+  const dummyContract = await dummyFactory.deploy();
+  await dummyContract.deployed();
+  console.log(`Dummy contract deployed at: ${dummyContract.address} (maintains nonce for address consistency)`);
 
   const tDocDeployerFactory = new ethers.ContractFactory(
     TDocDeployer__factory.abi,

--- a/tests/e2e/setup-contracts.js
+++ b/tests/e2e/setup-contracts.js
@@ -6,10 +6,10 @@ const ERC1967Proxy_artifact = require("../../src/test/fixture/artifacts/ERC1967P
  * IMPORTANT: This script uses only contract artifacts from @trustvc/trustvc
  * and avoids importing helper functions (deployTokenRegistry, mint) to prevent
  * ESM module errors in Node.js/GitHub Actions environments.
- * 
+ *
  * The helper functions have dependencies that include ESM-only modules
  * (@digitalbazaar/bls12-381-multikey) which cannot be required() in CommonJS.
- * 
+ *
  * Instead, we use direct ethers.js ContractFactory deployment and contract
  * interaction, which is more reliable in CI/CD environments.
  */
@@ -23,7 +23,12 @@ const v5Contracts = require(v5ContractsPath);
 const CHAIN_ID = { local: 1337 };
 
 (async () => {
-  const { TDocDeployer__factory, TitleEscrowFactory__factory, TradeTrustTokenStandard__factory } = v5Contracts; // Remove ERC1967__factory from here
+  const {
+    TDocDeployer__factory,
+    TitleEscrowFactory__factory,
+    TradeTrustToken__factory,
+    TradeTrustTokenStandard__factory,
+  } = v5Contracts; // Remove ERC1967__factory from here
 
   // Note: Dummy test wallets — private keys for local development and CI/CD only.
   // These wallets are not for production and hold no funds or value on any network.
@@ -52,8 +57,8 @@ const CHAIN_ID = { local: 1337 };
   console.log("Deploying Token Registry (standalone)...");
   // Deploy Token Registry (standalone mode)
   const tokenRegistryFactory = new ethers.ContractFactory(
-    TradeTrustTokenStandard__factory.abi,
-    TradeTrustTokenStandard__factory.bytecode,
+    TradeTrustToken__factory.abi,
+    TradeTrustToken__factory.bytecode,
     signer
   );
   const tokenRegistryContract = await tokenRegistryFactory.deploy(
@@ -162,11 +167,7 @@ const CHAIN_ID = { local: 1337 };
   for (const element of tokensToMint.tokenRegistry) {
     console.log(`Minting token ${element.tokenId}...`);
     try {
-      const tx = await tokenRegistryForMinting.mint(
-        element.owner,
-        element.holder,
-        element.tokenId
-      );
+      const tx = await tokenRegistryForMinting.mint(element.owner, element.holder, element.tokenId);
       await tx.wait();
       console.log(`Token ${element.tokenId} minted successfully`);
     } catch (error) {

--- a/tests/e2e/setup-contracts.js
+++ b/tests/e2e/setup-contracts.js
@@ -1,14 +1,17 @@
-const shell = require('shelljs');
-const path = require('path');
+const path = require("path");
 const { ethers, Wallet } = require("ethers");
-const ERC1967Proxy_artifact = require("../../src/test/fixture/artifacts/ERC1967Proxy.json"); // Assuming this is the correct deployable proxy artifact
+const { deployTokenRegistry, mint } = require("@trustvc/trustvc");
+const ERC1967Proxy_artifact = require("../../src/test/fixture/artifacts/ERC1967Proxy.json");
 
-// Import only the specific modules we need to avoid problematic ESM dependencies
+// Import @trustvc/trustvc modules for contract deployment
 const v5ContractsPath = path.resolve(
   __dirname,
   "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/contracts.js"
 );
 const v5Contracts = require(v5ContractsPath);
+
+const v5UtilsPath = path.resolve(__dirname, "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/utils.js");
+const v5Utils = require(v5UtilsPath);
 
 // Define local chain ID directly for local development
 const CHAIN_ID = { local: 1337 };
@@ -23,22 +26,44 @@ const CHAIN_ID = { local: 1337 };
   const ADDRESS_EXAMPLE_1 = "0xe0a71284ef59483795053266cb796b65e48b5124";
   const ADDRESS_EXAMPLE_2 = "0xcdfacbb428dd30ddf6d99875dcad04cbefcd6e60";
 
-  const oaCLI_PATH = "tradetrust";
-
   const TITLE_ESCROW_FACTORY_ADDRESS = "0x63A223E025256790E88778a01f480eBA77731D04";
 
-  shell.exec(`${oaCLI_PATH} deploy title-escrow-factory -n local -k ${ACCOUNT_KEY}`);
-
-  shell.exec(
-    `${oaCLI_PATH} deploy token-registry "DEMO TOKEN REGISTRY" DTR -n local -k ${ACCOUNT_KEY} --factory-address ${TITLE_ESCROW_FACTORY_ADDRESS} --standalone`
-  );
-
-  // Additional step to sync testcafe and synpress addresses
-  shell.exec(`${oaCLI_PATH} deploy document-store "My Document Store" -n local -k ${ACCOUNT_KEY}`);
-
-  // Setup TDoc Deployer
+  // Setup provider and signer
   const provider = new ethers.providers.JsonRpcProvider("http://127.0.0.1:8545/", Number(CHAIN_ID.local));
   const signer = new Wallet(ACCOUNT_KEY, provider);
+
+  console.log("Deploying Title Escrow Factory...");
+  // Deploy Title Escrow Factory
+  const titleEscrowFactoryForStandalone = new ethers.ContractFactory(
+    TitleEscrowFactory__factory.abi,
+    TitleEscrowFactory__factory.bytecode,
+    signer
+  );
+  const titleEscrowFactoryContractForStandalone = await titleEscrowFactoryForStandalone.deploy();
+  await titleEscrowFactoryContractForStandalone.deployed();
+  console.log(`Title Escrow Factory deployed at: ${titleEscrowFactoryContractForStandalone.address}`);
+
+  console.log("Deploying Token Registry (standalone) using deployTokenRegistry...");
+  // Deploy Token Registry using @trustvc/trustvc helper function
+  const deployReceipt = await deployTokenRegistry("DEMO TOKEN REGISTRY", "DTR", signer, {
+    chainId: CHAIN_ID.local,
+    standalone: true,
+    factoryAddress: titleEscrowFactoryContractForStandalone.address,
+  });
+  console.log(`Token Registry deployed at: ${deployReceipt.contractAddress}`);
+
+  // Get the deployed contract instance
+  const tokenRegistryContract = new ethers.Contract(
+    deployReceipt.contractAddress,
+    TradeTrustTokenStandard__factory.abi,
+    signer
+  );
+
+  console.log("Deploying Document Store...");
+  // Deploy Document Store (using artifact if available)
+  // Note: You may need to import DocumentStore artifact similar to how you're using it in the codebase
+  // For now, we'll skip this as it's not critical for the token registry tests
+  console.log("Document Store deployment skipped (not critical for token registry tests)");
 
   const tDocDeployerFactory = new ethers.ContractFactory(
     TDocDeployer__factory.abi,
@@ -87,14 +112,14 @@ const CHAIN_ID = { local: 1337 };
   const addImplementationReceipt = await addImplementationTx.wait();
 
   // --- End TDoc Deployer Setup
-  
+
   const defaultToken = {
     accountKey: ACCOUNT_KEY,
     tokenRegistryAddress: TOKEN_REGISTRY_ADDRESS,
     owner: ADDRESS_EXAMPLE_1,
     holder: ADDRESS_EXAMPLE_1,
   };
-    
+
   const tokensToMint = {
     tokenRegistry: [
       {
@@ -121,9 +146,35 @@ const CHAIN_ID = { local: 1337 };
     ],
   };
 
-  tokensToMint.tokenRegistry.forEach((element) => {
-    shell.exec(
-      `${oaCLI_PATH} token-registry issue --beneficiary ${element.owner} --holder ${element.holder} --address ${element.tokenRegistryAddress} --tokenId ${element.tokenId} -n local -k ${element.accountKey}`
-    );
-  });
-})()
+  // Mint tokens using @trustvc/trustvc mint function
+  console.log("Minting tokens...");
+
+  for (const element of tokensToMint.tokenRegistry) {
+    console.log(`Minting token ${element.tokenId}...`);
+    try {
+      const receipt = await mint(
+        { tokenRegistryAddress: TOKEN_REGISTRY_ADDRESS },
+        signer,
+        {
+          beneficiaryAddress: element.owner,
+          holderAddress: element.holder,
+          tokenId: element.tokenId,
+        },
+        {
+          chainId: CHAIN_ID.local,
+          titleEscrowVersion: "v5",
+        }
+      );
+      console.log(`Token ${element.tokenId} minted successfully`);
+    } catch (error) {
+      console.error(`Failed to mint token ${element.tokenId}:`, error.message);
+    }
+  }
+
+  console.log("\n=== Contract Setup Complete ===");
+  console.log(`Title Escrow Factory: ${titleEscrowFactoryContractForStandalone.address}`);
+  console.log(`Token Registry: ${tokenRegistryContract.address}`);
+  console.log(`TDoc Deployer (Proxy): ${ERC1967ProxyFactoryContract.address}`);
+  console.log(`Token Implementation: ${tokenImplementationContract.address}`);
+  console.log(`Title Escrow Factory (V5): ${titleEscrowFactoryContract.address}`);
+})();

--- a/tests/e2e/setup-contracts.js
+++ b/tests/e2e/setup-contracts.js
@@ -1,17 +1,17 @@
 const path = require("path");
 const { ethers, Wallet } = require("ethers");
-const { deployTokenRegistry, mint } = require("@trustvc/trustvc");
+const { deployTokenRegistry, mint, v5Contracts } = require("@trustvc/trustvc");
 const ERC1967Proxy_artifact = require("../../src/test/fixture/artifacts/ERC1967Proxy.json");
 
-// Import @trustvc/trustvc modules for contract deployment
-const v5ContractsPath = path.resolve(
-  __dirname,
-  "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/contracts.js"
-);
-const v5Contracts = require(v5ContractsPath);
+// // Import @trustvc/trustvc modules for contract deployment
+// const v5ContractsPath = path.resolve(
+//   __dirname,
+//   "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/contracts.js"
+// );
+// const v5Contracts = require(v5ContractsPath);
 
-const v5UtilsPath = path.resolve(__dirname, "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/utils.js");
-const v5Utils = require(v5UtilsPath);
+// const v5UtilsPath = path.resolve(__dirname, "../../node_modules/@trustvc/trustvc/dist/cjs/token-registry-v5/utils.js");
+// const v5Utils = require(v5UtilsPath);
 
 // Define local chain ID directly for local development
 const CHAIN_ID = { local: 1337 };

--- a/tests/e2e/setup-contracts.js
+++ b/tests/e2e/setup-contracts.js
@@ -33,7 +33,7 @@ const CHAIN_ID = { local: 1337 };
   // Note: Dummy test wallets — private keys for local development and CI/CD only.
   // These wallets are not for production and hold no funds or value on any network.
   const ACCOUNT_KEY = "0xe82294532bcfcd8e0763ee5cef194f36f00396be59b94fb418f5f8d83140d9a7";
-  const TOKEN_REGISTRY_ADDRESS = "0x9Eb613a88534E2939518f4ffBFE65F5969b491FF";
+  const TOKEN_REGISTRY_ADDRESS = "0x82524C1C34F52a2c42eA41daF08B27cB7711c9EE";
   const ADDRESS_EXAMPLE_1 = "0xe0a71284ef59483795053266cb796b65e48b5124";
   const ADDRESS_EXAMPLE_2 = "0xcdfacbb428dd30ddf6d99875dcad04cbefcd6e60";
 
@@ -167,7 +167,7 @@ const CHAIN_ID = { local: 1337 };
   for (const element of tokensToMint.tokenRegistry) {
     console.log(`Minting token ${element.tokenId}...`);
     try {
-      const tx = await tokenRegistryForMinting.mint(element.owner, element.holder, element.tokenId);
+      const tx = await tokenRegistryForMinting.mint(element.owner, element.holder, element.tokenId, "0x");
       await tx.wait();
       console.log(`Token ${element.tokenId} minted successfully`);
     } catch (error) {


### PR DESCRIPTION
## Summary

Removing the tradetrust cli commands and update the test functions with trustvc sdk commads


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a core dependency to v2.11.0.

* **Tests**
  * Migrated end-to-end setup to programmatic contract deployment and token minting, replacing shell/CLI flows.
  * Enhanced test logging with per-token mint reports, deployed contract addresses, and a final summary for clearer visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->