### PR TITLE
chore(deps): bump js-cookie 3.0.5 → 3.0.7 (GHSA-qjx8-664m-686j)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tradetrust-website",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradetrust-website",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
@@ -33169,11 +33169,12 @@
       "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-md4": {


### PR DESCRIPTION
## Summary
- Bumps `js-cookie` from **3.0.5** → **3.0.7** to resolve [GHSA-qjx8-664m-686j](https://github.com/advisories/GHSA-qjx8-664m-686j) / **CVE-2026-46625** (Prototype Pollution → cookie-attribute injection, CVSS 7.5 — **High**, disclosed 2026-05-21).
- Only `package-lock.json` changes — the existing caret `^3.0.5` in `package.json` already permits 3.0.7.

## Why
`js-cookie <= 3.0.5` contains a per-instance prototype hijack in `assign()`: when the `attributes` argument passed to `Cookies.set` originates from `JSON.parse` (e.g. remote config), an attacker-supplied `"__proto__"` key gets merged into the attribute object and emitted into the `Set-Cookie` header — allowing `domain`, `secure`, `samesite`, `expires`, `path` injection.

### Exploitability in this codebase
**Not currently exploitable.** The only call site is `src/components/CookieNotice.tsx` and it passes a hardcoded literal `{ expires: 30, path: "/" }` to `Cookies.set` — no JSON-parsed or attacker-influenced object reaches the attributes argument.

This PR is preventive: clears scanners (Dependabot, npm audit, Snyk) and guards against regression if a future change ever introduces a remote-derived attributes object.

## Verification
- `node -p "require('./node_modules/js-cookie/package.json').version"` → `3.0.7` ✓
- `npm audit` for `js-cookie` → `none` ✓
- Lint passed on commit (husky/pre-commit ran cleanly) ✓

## Test plan
- [ ] CI green
- [ ] Cookie notice banner still appears on a fresh session
- [ ] "Close" button on the banner persists the `cookieNotice=closed` cookie for 30 days

## References
- Advisory: https://github.com/advisories/GHSA-qjx8-664m-686j
- js-cookie release notes: https://github.com/js-cookie/js-cookie/releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)