### PR TITLE
refactor: update network name retrieval in CreatorContext

### DIFF
--- a/src/common/contexts/CreatorContext/CreatorContext.tsx
+++ b/src/common/contexts/CreatorContext/CreatorContext.tsx
@@ -163,8 +163,7 @@ export const CreatorContextProvider: any = ({ children }: CreatorContextProvider
     if (!signer || !chainId) return;
 
     if (displayRedeployTokenRegistry) setDisplayRedeployTokenRegistry(false); // Set redeploy state to false
-    let networkName = ChainInfo[chainId].networkName as string;
-    networkName = networkName.charAt(0).toUpperCase() + networkName.slice(1);
+    const networkName = ChainInfo[chainId].networkLabel as string;
     // Set loading state
     setTokenRegistryState(CreatorItemState.LOADING);
     setTokenRegistryStateMessage(STATE_MESSAGE.TOKEN_REGISTRY.FETCH_LOCAL_CACHE + networkName);


### PR DESCRIPTION
- Changed the method of obtaining the network name in CreatorContext from using the deprecated getNetworkDisplayName function to directly accessing networkLabel from ChainInfo for improved clarity in status messages.

## Summary

What is the background of this pull request?

## Changes

- What are the changes made in this pull request?
- Change this and that, etc...

## Issues

What are the related issues or stories?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal network name formatting in token registry processing for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->