### PR TITLE
feat: add XRPL EVM mainnet and testnet support

### DIFF
--- a/public/static/images/networks/xrplevm.svg
+++ b/public/static/images/networks/xrplevm.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="XRPL EVM placeholder">
+  <circle cx="16" cy="16" r="16" fill="#23292F"/>
+  <text x="16" y="20.5" text-anchor="middle" font-size="9" font-family="Arial, Helvetica, sans-serif" fill="#E5E7EB" font-weight="700">XRP</text>
+</svg>

--- a/src/config/chain-config.ts
+++ b/src/config/chain-config.ts
@@ -9,6 +9,7 @@ export const MAIN_NETWORKS = [
   ChainId.XDC,
   ChainId.Stability,
   ChainId.Astron,
+  ChainId.XRPLEVM,
 ];
 
 /**
@@ -20,4 +21,5 @@ export const TEST_NETWORKS = [
   ChainId.APOTHEM,
   ChainId.StabilityTestnet,
   ChainId.AstronTestnet,
+  ChainId.XRPLEVMTestnet,
 ];

--- a/src/constants/chain-info.ts
+++ b/src/constants/chain-info.ts
@@ -11,7 +11,9 @@ export type Network =
   | "stabilitytestnet"
   | "stability"
   | "astron"
-  | "astrontestnet";
+  | "astrontestnet"
+  | "xrplevm"
+  | "xrplevmtestnet";
 
 export interface ChainInfoObject {
   label: string;
@@ -31,8 +33,8 @@ export interface ChainInfoObject {
 export const InitialAddress = "0x0000000000000000000000000000000000000000";
 export const BurnAddress = "0x000000000000000000000000000000000000dEaD";
 
-export type AvailableBlockChains = "ETH" | "MATIC" | "POL" | "XDC" | "FREE" | "ASTRON";
-export const AvailableBlockChains: AvailableBlockChains[] = ["ETH", "MATIC", "POL", "XDC", "FREE", "ASTRON"];
+export type AvailableBlockChains = "ETH" | "MATIC" | "POL" | "XDC" | "FREE" | "ASTRON" | "XRP";
+export const AvailableBlockChains: AvailableBlockChains[] = ["ETH", "MATIC", "POL", "XDC", "FREE", "ASTRON", "XRP"];
 
 type ChainInfo = Record<ChainId, ChainInfoObject>;
 
@@ -59,6 +61,10 @@ export enum ChainId {
   // Astron
   Astron = 1338,
   AstronTestnet = 21002,
+
+  // XRPL EVM
+  XRPLEVM = 1440000,
+  XRPLEVMTestnet = 1449000,
 }
 
 export const CHAIN: Record<ChainId, AvailableBlockChains> = {
@@ -73,6 +79,8 @@ export const CHAIN: Record<ChainId, AvailableBlockChains> = {
   [ChainId.StabilityTestnet]: "FREE",
   [ChainId.Astron]: "ASTRON",
   [ChainId.AstronTestnet]: "ASTRON",
+  [ChainId.XRPLEVM]: "XRP",
+  [ChainId.XRPLEVMTestnet]: "XRP",
 };
 
 export const ChainInfo: ChainInfo = {
@@ -230,6 +238,34 @@ export const ChainInfo: ChainInfo = {
       decimals: 18,
     },
   },
+  [ChainId.XRPLEVM]: {
+    label: "XRPL EVM",
+    chainId: ChainId.XRPLEVM,
+    iconImage: "/static/images/networks/xrplevm.svg",
+    networkName: "xrplevm",
+    networkLabel: "XRPL EVM",
+    explorerUrl: "https://explorer.xrplevm.org",
+    rpcUrl: "https://rpc.xrplevm.org",
+    nativeCurrency: {
+      name: "XRP",
+      symbol: "XRP",
+      decimals: 18,
+    },
+  },
+  [ChainId.XRPLEVMTestnet]: {
+    label: "XRPL EVM Testnet",
+    chainId: ChainId.XRPLEVMTestnet,
+    iconImage: "/static/images/networks/xrplevm.svg",
+    networkName: "xrplevmtestnet",
+    networkLabel: "XRPL EVM Testnet",
+    explorerUrl: "https://explorer.testnet.xrplevm.org",
+    rpcUrl: "https://rpc.testnet.xrplevm.org",
+    nativeCurrency: {
+      name: "XRP",
+      symbol: "XRP",
+      decimals: 18,
+    },
+  },
 };
 export const supportedMainnet = [
   ChainInfo[ChainId.Ethereum].networkName,
@@ -237,6 +273,7 @@ export const supportedMainnet = [
   ChainInfo[ChainId.XDC].networkName,
   ChainInfo[ChainId.Stability].networkName,
   ChainInfo[ChainId.Astron].networkName,
+  ChainInfo[ChainId.XRPLEVM].networkName,
 ];
 
 export const supportedTestnet = [
@@ -245,4 +282,5 @@ export const supportedTestnet = [
   ChainInfo[ChainId.APOTHEM].networkName,
   ChainInfo[ChainId.StabilityTestnet].networkName,
   ChainInfo[ChainId.AstronTestnet].networkName,
+  ChainInfo[ChainId.XRPLEVMTestnet].networkName,
 ];

--- a/src/gasless/gaslessHelpers.test.ts
+++ b/src/gasless/gaslessHelpers.test.ts
@@ -49,6 +49,11 @@ describe("getRpcUrl", () => {
     expect(getRpcUrl(String(knownChainId))).toBe((ChainInfo as any)[knownChainId]?.rpcUrl);
   });
 
+  it("returns the public RPC URL for XRPL EVM mainnet and testnet", () => {
+    expect(getRpcUrl(ChainId.XRPLEVM)).toBe("https://rpc.xrplevm.org");
+    expect(getRpcUrl(ChainId.XRPLEVMTestnet)).toBe("https://rpc.testnet.xrplevm.org");
+  });
+
   it("returns undefined for an unknown chain id", () => {
     expect(getRpcUrl(999999999)).toBeUndefined();
   });

--- a/src/utils/shared.test.ts
+++ b/src/utils/shared.test.ts
@@ -32,6 +32,14 @@ describe("getChainId for v2 document", () => {
     expect(getChainId(document)).toStrictEqual(80002);
   });
 
+  it("should return the correct chainId for XRPL EVM testnet with XRP chain identifier", () => {
+    const document = {
+      ...invoiceV2,
+      data: { ...invoiceV2.data, network: { chain: "XRP", chainId: "1449000" } },
+    } as unknown as WrappedOrSignedOpenAttestationDocument;
+    expect(getChainId(document)).toStrictEqual(1449000);
+  });
+
   it("should throw an error when there is a network object in the document but the value is not valid", () => {
     const document = {
       ...invoiceV2,
@@ -95,6 +103,14 @@ describe("getChainId for v3 document", () => {
       network: { chain: "MATIC", chainId: "80002" },
     } as unknown as WrappedOrSignedOpenAttestationDocument;
     expect(getChainId(document)).toStrictEqual(80002);
+  });
+
+  it("should return the correct chainId for XRPL EVM testnet with XRP chain identifier", () => {
+    const document = {
+      ...invoiceV3,
+      network: { chain: "XRP", chainId: "1449000" },
+    } as unknown as WrappedOrSignedOpenAttestationDocument;
+    expect(getChainId(document)).toStrictEqual(1449000);
   });
 
   it("should throw an error when there is a network object in the document but the value is not valid", () => {
@@ -173,6 +189,17 @@ describe("getChainId for W3C v2 document", () => {
       },
     };
     expect(getChainId(documentWithPolygon as SignedVerifiableCredential)).toStrictEqual(80002);
+  });
+
+  it("should return the correct chainId when W3C v2.0 document has tokenNetwork with XRPL EVM testnet", () => {
+    const documentWithXrplEvm = {
+      ...w3cV2Document,
+      credentialStatus: {
+        ...w3cV2Document.credentialStatus,
+        tokenNetwork: { chain: "XRP", chainId: "1449000" },
+      },
+    };
+    expect(getChainId(documentWithXrplEvm as SignedVerifiableCredential)).toStrictEqual(1449000);
   });
 
   it("should throw an error when W3C v2.0 document has invalid chainId in tokenNetwork", () => {

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -137,7 +137,7 @@ export const getChainId = (
   const processOAChainId = (document: v2.OpenAttestationDocument | v3.OpenAttestationDocument): number | undefined => {
     const network = document.network;
     if (network) {
-      // Check for current blockchain, "ETH" or "POL", and chainId, if need cater for other blockchain and network, update this accordingly.
+      // Check for current blockchain identifier (ETH, POL, XDC, XRP, etc.) and chainId.
       if (!AvailableBlockChains.includes(network.chain as AvailableBlockChains) || !network.chainId) {
         throwError();
       }


### PR DESCRIPTION
## Summary

XRPL EVM is now a live EVM sidechain (mainnet `1440000`, testnet `1449000`) with TradeTrust Token Registry infrastructure deployed on both networks. This pull request registers those chains in the website so users can verify, issue, and manage transferable records on XRPL EVM in the same way as existing networks (Ethereum, Polygon, XDC, Stability, and Astron).

OpenAttestation / W3C documents on these chains use the `XRP` chain identifier. Public RPCs and explorers are used; no Infura (or other keyed) endpoint is required.

> **Do not merge yet.** This PR is not build-ready. Token Registry factory addresses are consumed from `@trustvc/trustvc`, which does not yet expose XRPL EVM. Merge is blocked until [TradeTrust/token-registry-community-sandbox#5](https://github.com/TradeTrust/token-registry-community-sandbox/pull/5) is merged **and** the updated package is published to npm (beta or production). After that publish, bump `@trustvc/trustvc` in this repository and re-verify create, mint, and verify flows before removing the draft status.

## Changes

- Register XRPL EVM mainnet (`1440000`) and testnet (`1449000`) in `chain-info` and `chain-config`, including public RPC URLs, explorers, native currency (`XRP`), and the `XRP` blockchain identifier.
- Surface both networks in the production and development network selectors so wallet add/switch, verification RPC selection, explorer links, and transferable-record issuance can target XRPL EVM.
- Add a placeholder network icon (`public/static/images/networks/xrplevm.svg`) until final artwork is available.
- Extend unit tests for `getChainId` (OA v2/v3 and W3C) and RPC URL resolution so `XRP` documents on testnet `1449000` are recognised.

## Dependencies

- [TradeTrust/token-registry-community-sandbox#5](https://github.com/TradeTrust/token-registry-community-sandbox/pull/5) — Token Registry addresses on XRPL EVM Testnet and Mainnet:
  - Title Escrow Factory, Token Implementation, TDocDeployer (proxy)
- Subsequent npm publish of the consuming package (`@trustvc/trustvc`, beta or latest) that includes those chain IDs and contract addresses

## Out of scope

- EIP-7702 gasless transfers (Pimlico is not configured for XRPL EVM)
- Final network icon artwork