### PR TITLE
feat: verifiable presentation support

### DIFF
--- a/.github/workflows/lint_and_unit_test.yml
+++ b/.github/workflows/lint_and_unit_test.yml
@@ -31,5 +31,12 @@ jobs:
         run: npm run lint
       - name: Test
         run: npm run test
+      # Verifiable Presentation verification against real fixtures, with real WebCrypto. Runs as
+      # its own step because it needs the node environment: under jsdom `node:crypto` is shimmed
+      # by crypto-browserify, which has no `webcrypto`, so every signature check fails and the
+      # suite would assert nothing. Some cases resolve a hosted did:web document and fetch a
+      # revocation status list, so this step reaches the network.
+      - name: Test (integration)
+        run: npm run test:integration
       - name: Build
         run: npm run build:prod # this MUST be run to ensure production site will be built without errors

--- a/_mocks_/nodeCryptoReal.js
+++ b/_mocks_/nodeCryptoReal.js
@@ -1,0 +1,7 @@
+// Node's real crypto, for the node-environment integration suite.
+//
+// The jsdom config maps `node:crypto` onto crypto-browserify, which does NOT export
+// `webcrypto`. @digitalbazaar/ecdsa-multikey reads `webcrypto.subtle` from it, so with that
+// shim in place every ECDSA verification fails with "Cannot read properties of undefined
+// (reading 'subtle')" — and a suite verifying real documents would assert on nothing.
+module.exports = require("crypto");

--- a/jest.config.js
+++ b/jest.config.js
@@ -49,6 +49,8 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/jest.dom.setup.ts"],
   testMatch: ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)test.[jt]s?(x)"],
   transformIgnorePatterns: ["node_modules/?!(@tradetrust-tt).*/"],
-  testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/tests/"],
+  // src/__integration__ verifies real documents and needs genuine WebCrypto, so it runs under
+  // the node environment via jest.integration.config.js rather than here.
+  testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/tests/", "<rootDir>/src/__integration__/"],
   testTimeout: 10000,
 };

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,0 +1,38 @@
+const base = require("./jest.config");
+
+// Entries that exist only to shim Node builtins for the jsdom/browser environment. Under the
+// node environment they are not just unnecessary but actively wrong: crypto-browserify has no
+// `webcrypto` export, and @digitalbazaar/ecdsa-multikey imports exactly that to reach
+// `webcrypto.subtle`. With the shim in place every ECDSA verification fails with "Cannot read
+// properties of undefined (reading 'subtle')" — which would make a suite that verifies real
+// documents assert on nothing.
+// Only `node:crypto` is swapped. The other node: shims are still needed — this Jest predates
+// `node:`-prefixed specifiers, so removing them leaves the specifier unresolvable entirely, and
+// a resolver cannot help either: Jest 26 requires an absolute path back and so cannot express
+// "this is a core module".
+const moduleNameMapper = {
+  ...base.moduleNameMapper,
+  "node:crypto": "<rootDir>/_mocks_/nodeCryptoReal.js",
+};
+
+/**
+ * Real verification of real documents — no mocked verifier.
+ *
+ * Runs under the node environment because ECDSA verification needs genuine WebCrypto; under
+ * jsdom the holder proof cannot be checked and every assertion about a valid presentation would
+ * pass for the wrong reason. Kept as its own project, scoped to src/__integration__, because the
+ * shared jest.setup.ts touches `document` and `window` (absent here) and because the repo's
+ * existing *.integration.test.tsx files are React tests that do need jsdom.
+ */
+module.exports = {
+  ...base,
+  displayName: "integration",
+  testEnvironment: "node",
+  moduleNameMapper,
+  setupFiles: ["<rootDir>/jest.integration.setup.ts"],
+  setupFilesAfterEnv: [],
+  roots: ["<rootDir>/src/__integration__"],
+  testMatch: ["**/*.test.[jt]s?(x)"],
+  testPathIgnorePatterns: ["<rootDir>/node_modules/"],
+  testTimeout: 120000,
+};

--- a/jest.integration.setup.ts
+++ b/jest.integration.setup.ts
@@ -1,0 +1,35 @@
+import { TextEncoder, TextDecoder } from "util";
+import { runInThisContext } from "vm";
+
+/**
+ * Re-exposes the Node globals that Jest 26's node sandbox omits.
+ *
+ * The sandbox is an old vm context and predates much of Node 18's global surface — Event,
+ * EventTarget, AbortSignal, fetch, ReadableStream and friends are all missing, and the verifier
+ * stack reaches for them. Enumerating them by hand turned into whack-a-mole (each fix surfaced
+ * the next ReferenceError), so the real global object is fetched through `vm` and anything
+ * absent from the sandbox is copied over.
+ *
+ * Only missing names are copied, so nothing Jest itself installs is clobbered. Unlike
+ * jest.setup.ts this touches no `document` or `window`: neither exists here, and this suite
+ * verifies real documents with real crypto rather than rendering anything.
+ */
+const realGlobal = runInThisContext("globalThis") as Record<string, unknown>;
+
+for (const name of Object.getOwnPropertyNames(realGlobal)) {
+  if ((global as Record<string, unknown>)[name] === undefined) {
+    try {
+      (global as Record<string, unknown>)[name] = realGlobal[name];
+    } catch {
+      // Some globals are non-writable accessors; skipping one is fine — the loop only fills
+      // gaps, and anything genuinely required will surface as a clear ReferenceError.
+    }
+  }
+}
+
+Object.assign(global, { TextDecoder, TextEncoder });
+
+// `self` is a browser alias for the global object. It is not a Node global, but the util module
+// under test transitively imports browser-oriented packages (address-identity-resolver via the
+// provider context) that reference it at module load.
+(global as Record<string, unknown>).self = global;

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "storybook:dev": "sleep 2 && storybook dev -p 6006",
     "storybook:build": "npm run build:css && sleep 2 && storybook build -o docs",
     "test": "jest",
+    "test:integration": "jest -c jest.integration.config.js",
+    "test:all": "run-s test test:integration",
     "test:coverage": "npm run test -- --collectCoverage",
     "test:watch": "npm run test -- --watchAll",
     "test:update": "npm run test -- -u",

--- a/src/__integration__/verifiablePresentation.test.ts
+++ b/src/__integration__/verifiablePresentation.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Real verification of Verifiable Presentations — nothing here is mocked.
+ *
+ * Every other VP test in this repo hands hand-built fragments to the code under test, which
+ * proves the mapping but not that a presentation actually verifies. This suite runs the real
+ * trustvc verifier over the real fixtures, so a change in the verifier's wording or verdicts
+ * breaks these tests instead of silently changing what users are told.
+ *
+ * Runs under the node environment (jest.integration.config.js) because ECDSA verification needs
+ * genuine WebCrypto. Under jsdom `node:crypto` is shimmed by crypto-browserify, which has no
+ * `webcrypto`, and every signature check fails with "reading 'subtle'" — a valid presentation
+ * would then look invalid and these assertions would pass for the wrong reason.
+ *
+ * A few cases reach the network (resolving a hosted did:web document, fetching a revocation
+ * status list), hence the generous timeout in the config.
+ */
+import fs from "fs";
+import path from "path";
+import { verifyDocument, isValid, VerificationFragment } from "@trustvc/trustvc";
+import {
+  getCredentialDownloadName,
+  getCredentialLabel,
+  getPresentationCredentials,
+  getPresentationHolder,
+  getW3CVersionLabel,
+  isVerifiablePresentation,
+} from "../utils/presentation";
+import { getPresentationError } from "../utils/presentationErrors";
+import { getAttachments, getOpenAttestationData } from "../utils/shared";
+
+const DIR = path.join(__dirname, "../test/fixture/w3c/presentations");
+const load = (name: string) => JSON.parse(fs.readFileSync(path.join(DIR, name), "utf8"));
+
+const twoCredentials = load("valid/two_credentials.json");
+const singleCredential = load("valid/single_credential.json");
+const withAttachments = load("valid/with_attachments.json");
+
+/** Verified once per fixture and shared — each run is several round trips. */
+const fragmentCache = new Map<string, VerificationFragment[]>();
+const verify = async (name: string): Promise<VerificationFragment[]> => {
+  if (!fragmentCache.has(name)) {
+    fragmentCache.set(name, (await verifyDocument(load(name) as never)) as VerificationFragment[]);
+  }
+  return fragmentCache.get(name)!;
+};
+
+const groupStatus = (frags: VerificationFragment[], type: string) => {
+  const group = frags.filter((f) => f.type === type && f.status !== "SKIPPED");
+  if (group.length === 0) return "MISSING";
+  return group.some((f) => f.status === "INVALID" || f.status === "ERROR") ? "INVALID" : "VALID";
+};
+
+const VALID_FIXTURES = [
+  "valid/single_credential.json",
+  "valid/two_credentials.json",
+  "valid/with_attachments.json",
+  "valid/mixed_suites.json",
+  "valid/didweb_issuer.json",
+];
+
+describe("Verifiable Presentation — detection", () => {
+  it.each(VALID_FIXTURES)("recognises %s as a presentation", (name) => {
+    expect(isVerifiablePresentation(load(name))).toBe(true);
+  });
+
+  it("does not mistake an embedded credential for a presentation", () => {
+    expect(isVerifiablePresentation(twoCredentials.verifiableCredential[0])).toBe(false);
+  });
+
+  it("ignores the proof, so an unsigned presentation is still routed in", () => {
+    const unsigned = { ...twoCredentials };
+    delete unsigned.proof;
+    expect(isVerifiablePresentation(unsigned)).toBe(true);
+  });
+});
+
+describe("Verifiable Presentation — a valid presentation", () => {
+  it.each(VALID_FIXTURES)("%s passes every check", async (name) => {
+    const frags = await verify(name);
+    expect(groupStatus(frags, "DOCUMENT_INTEGRITY")).toBe("VALID");
+    expect(groupStatus(frags, "DOCUMENT_STATUS")).toBe("VALID");
+    expect(groupStatus(frags, "ISSUER_IDENTITY")).toBe("VALID");
+    expect(isValid(frags)).toBe(true);
+  });
+
+  it("emits all three presentation fragments, so the envelope is genuinely checked", async () => {
+    const frags = await verify("valid/two_credentials.json");
+    const vpFragments = frags.filter((f) => f.name.startsWith("W3CVp"));
+    expect(vpFragments.map((f) => f.name).sort()).toEqual([
+      "W3CVpCredentialStatus",
+      "W3CVpIssuerIdentity",
+      "W3CVpSignatureIntegrity",
+    ]);
+    expect(vpFragments.every((f) => f.status === "VALID")).toBe(true);
+  });
+
+  it("reports no error at all", async () => {
+    expect(getPresentationError(await verify("valid/two_credentials.json"), twoCredentials)).toBeUndefined();
+  });
+});
+
+/**
+ * One case per way a presentation can fail. `type` is the error the UI reports; `match` is
+ * asserted against the copy the user actually sees.
+ */
+describe("Verifiable Presentation — how each failure is reported", () => {
+  const CASES: Array<{
+    fixture: string;
+    failing: "DOCUMENT_INTEGRITY" | "DOCUMENT_STATUS" | "ISSUER_IDENTITY";
+    type: string;
+    match: RegExp;
+  }> = [
+    {
+      fixture: "invalid/unsigned.json",
+      failing: "DOCUMENT_INTEGRITY",
+      type: "INVALID",
+      match: /not signed, so the presenter cannot prove they hold these credentials/i,
+    },
+    {
+      fixture: "invalid/holder_mismatch.json",
+      failing: "DOCUMENT_INTEGRITY",
+      type: "INVALID",
+      match: /signed by someone other than the holder it names/i,
+    },
+    {
+      fixture: "invalid/tampered_credential.json",
+      failing: "DOCUMENT_INTEGRITY",
+      type: "HASH",
+      match: /tampered/i,
+    },
+    {
+      fixture: "invalid/presentation_expired.json",
+      failing: "DOCUMENT_STATUS",
+      type: "INVALID",
+      match: /Ask the holder to present the credentials again/i,
+    },
+    {
+      fixture: "invalid/credential_expired.json",
+      failing: "DOCUMENT_STATUS",
+      type: "INVALID",
+      match: /Ask the issuer to reissue/i,
+    },
+    {
+      fixture: "invalid/credential_revoked.json",
+      failing: "DOCUMENT_STATUS",
+      type: "REVOKED",
+      match: /revoked by its issuer/i,
+    },
+    {
+      fixture: "invalid/unresolvable_issuer.json",
+      failing: "ISSUER_IDENTITY",
+      type: "IDENTITY",
+      match: /names an issuer that cannot be identified/i,
+    },
+  ];
+
+  it.each(CASES)("$fixture fails $failing and is reported as $type", async ({ fixture, failing, type, match }) => {
+    const frags = await verify(fixture);
+    expect(groupStatus(frags, failing)).toBe("INVALID");
+    expect(isValid(frags)).toBe(false);
+
+    const error = getPresentationError(frags, load(fixture));
+    expect(error?.type).toBe(type);
+    // HASH carries no override — the established copy already fits.
+    expect(error?.message ?? "Document has been tampered with").toMatch(match);
+  });
+
+  it("never leaks raw verifier wording to the user", async () => {
+    for (const { fixture } of CASES) {
+      const error = getPresentationError(await verify(fixture), load(fixture));
+      // These are the verifier's own strings; none should reach the UI verbatim.
+      expect(error?.message ?? "").not.toMatch(/Invalid signature\.|validUntil|status purpose|did:web:/);
+    }
+  });
+
+  it("never calls an expired or unsigned presentation tampered", async () => {
+    for (const fixture of ["invalid/presentation_expired.json", "invalid/unsigned.json"]) {
+      const error = getPresentationError(await verify(fixture), load(fixture));
+      expect(error?.type).not.toBe("HASH");
+    }
+  });
+
+  it("blames the unresolvable issuer rather than the signature failure it causes", async () => {
+    // This fixture fails BOTH integrity and identity: the signature cannot be checked without
+    // the issuer's key. Reported the other way round, an unpublished did:web reads as tampering.
+    const frags = await verify("invalid/unresolvable_issuer.json");
+    expect(groupStatus(frags, "DOCUMENT_INTEGRITY")).toBe("INVALID");
+    expect(groupStatus(frags, "ISSUER_IDENTITY")).toBe("INVALID");
+    expect(getPresentationError(frags, load("invalid/unresolvable_issuer.json"))?.type).toBe("IDENTITY");
+  });
+
+  it("names the credential at fault by the position and label its tab shows", async () => {
+    const fixture = "invalid/credential_revoked.json";
+    const [first] = getPresentationCredentials(load(fixture));
+    const label = getCredentialLabel(first, 0);
+    const error = getPresentationError(await verify(fixture), load(fixture));
+
+    expect(error?.message).toContain("Credential 1");
+
+    // This fixture's credential declares neither a renderer template nor a specific type, so its
+    // label IS the positional fallback. The copy must not then stutter as
+    // `Credential 1 ("Credential 1")` — the parenthetical is only worth adding when it says
+    // something the position does not. (The labelled path is covered in presentationErrors.test.)
+    expect(label).toBe("Credential 1");
+    expect(error?.message).not.toContain('("Credential 1")');
+  });
+});
+
+describe("Verifiable Presentation — document helpers against real fixtures", () => {
+  it("treats the presentation as its own document data instead of throwing", () => {
+    // getDocumentData throws on a presentation, taking every caller down with it.
+    expect(() => getOpenAttestationData(twoCredentials)).not.toThrow();
+    expect(getOpenAttestationData(twoCredentials)).toBe(twoCredentials);
+  });
+
+  it("reads the presentation expiry without throwing", () => {
+    const expired = load("invalid/presentation_expired.json");
+    const data = getOpenAttestationData(expired) as { validUntil?: string };
+    expect(new Date(data.validUntil!).getTime()).toBeLessThan(Date.now());
+  });
+
+  it("reports no attachments on the envelope even when a credential has them", () => {
+    expect(getAttachments(withAttachments)).toEqual([]);
+    const [credential] = getPresentationCredentials(withAttachments);
+    expect(getAttachments(credential)?.length).toBeGreaterThan(0);
+  });
+
+  it("extracts every embedded credential", () => {
+    expect(getPresentationCredentials(twoCredentials)).toHaveLength(2);
+    expect(getPresentationCredentials(singleCredential)).toHaveLength(1);
+  });
+
+  it("reads the holder, which is who the UI names as presenter", () => {
+    expect(getPresentationHolder(twoCredentials)).toBe(twoCredentials.holder.toUpperCase());
+  });
+
+  it("labels credentials distinctly, so the tabs can be told apart", () => {
+    const labels = getPresentationCredentials(twoCredentials).map(getCredentialLabel);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+
+  it("gives every credential a distinct download name", () => {
+    const names = getPresentationCredentials(twoCredentials).map((c, i) =>
+      getCredentialDownloadName("presentation.json", c, i)
+    );
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("tags the envelope by its own data model", () => {
+    expect(getW3CVersionLabel(twoCredentials)).toBe("V2.0");
+  });
+});

--- a/src/__integration__/verifiablePresentation.test.ts
+++ b/src/__integration__/verifiablePresentation.test.ts
@@ -16,7 +16,7 @@
  */
 import fs from "fs";
 import path from "path";
-import { verifyDocument, isValid, VerificationFragment } from "@trustvc/trustvc";
+import { verifyDocument, isValid, errorMessages, VerificationFragment } from "@trustvc/trustvc";
 import {
   getCredentialDownloadName,
   getCredentialLabel,
@@ -50,7 +50,19 @@ const groupStatus = (frags: VerificationFragment[], type: string) => {
   return group.some((f) => f.status === "INVALID" || f.status === "ERROR") ? "INVALID" : "VALID";
 };
 
-const VALID_FIXTURES = [
+/**
+ * Fixtures that reach the internet: didweb_issuer resolves a hosted did:web document, and
+ * credential_revoked fetches a revocation status list. Everything else is did:key and offline.
+ *
+ * They run by DEFAULT — they are the cases most worth having, and quietly skipping them would
+ * drop exactly the coverage this suite exists for. Set SKIP_NETWORK_TESTS=1 where there is no
+ * egress (a sandboxed runner, an offline laptop) to leave them out without failing the run.
+ */
+const skipNetwork = process.env.SKIP_NETWORK_TESTS === "1";
+const NETWORK_FIXTURES = ["valid/didweb_issuer.json", "invalid/credential_revoked.json"];
+const needsNetwork = (fixture: string) => NETWORK_FIXTURES.includes(fixture);
+
+const ALL_VALID_FIXTURES = [
   "valid/single_credential.json",
   "valid/two_credentials.json",
   "valid/with_attachments.json",
@@ -58,8 +70,11 @@ const VALID_FIXTURES = [
   "valid/didweb_issuer.json",
 ];
 
+/** Only VERIFICATION touches the network; detection is pure, so it is never gated. */
+const VALID_FIXTURES = ALL_VALID_FIXTURES.filter((fixture) => !(skipNetwork && needsNetwork(fixture)));
+
 describe("Verifiable Presentation — detection", () => {
-  it.each(VALID_FIXTURES)("recognises %s as a presentation", (name) => {
+  it.each(ALL_VALID_FIXTURES)("recognises %s as a presentation", (name) => {
     expect(isVerifiablePresentation(load(name))).toBe(true);
   });
 
@@ -154,19 +169,23 @@ describe("Verifiable Presentation — how each failure is reported", () => {
     },
   ];
 
-  it.each(CASES)("$fixture fails $failing and is reported as $type", async ({ fixture, failing, type, match }) => {
+  const RUNNABLE = CASES.filter(({ fixture }) => !(skipNetwork && needsNetwork(fixture)));
+
+  it.each(RUNNABLE)("$fixture fails $failing and is reported as $type", async ({ fixture, failing, type, match }) => {
     const frags = await verify(fixture);
     expect(groupStatus(frags, failing)).toBe("INVALID");
     expect(isValid(frags)).toBe(false);
 
     const error = getPresentationError(frags, load(fixture));
     expect(error?.type).toBe(type);
-    // HASH carries no override — the established copy already fits.
-    expect(error?.message ?? "Document has been tampered with").toMatch(match);
+    // Where getPresentationError sets no override (HASH), the established copy already fits and
+    // is what the UI renders. Resolve it from production rather than restating it here, so
+    // changing that copy fails this test instead of silently passing against a stale literal.
+    expect(error?.message ?? errorMessages.MESSAGES[error!.type].failureMessage).toMatch(match);
   });
 
   it("never leaks raw verifier wording to the user", async () => {
-    for (const { fixture } of CASES) {
+    for (const { fixture } of RUNNABLE) {
       const error = getPresentationError(await verify(fixture), load(fixture));
       // These are the verifier's own strings; none should reach the UI verbatim.
       expect(error?.message ?? "").not.toMatch(/Invalid signature\.|validUntil|status purpose|did:web:/);
@@ -190,7 +209,9 @@ describe("Verifiable Presentation — how each failure is reported", () => {
   });
 
   it("names the credential at fault by the position and label its tab shows", async () => {
-    const fixture = "invalid/credential_revoked.json";
+    // Deliberately an OFFLINE fixture: this assertion is about the copy, not about revocation,
+    // and naming a network fixture here would fail under SKIP_NETWORK_TESTS.
+    const fixture = "invalid/credential_expired.json";
     const [first] = getPresentationCredentials(load(fixture));
     const label = getCredentialLabel(first, 0);
     const error = getPresentationError(await verify(fixture), load(fixture));

--- a/src/components/AssetManagementPanel/AssetManagementTags/AssetManagementTags.test.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementTags/AssetManagementTags.test.tsx
@@ -267,4 +267,69 @@ describe("AssetManagementTags", () => {
       expect(trV5Tag).toHaveClass("bg-tangerine-500/[24%]", "text-tangerine-500", "rounded-full", "font-gilroy-bold");
     });
   });
+
+  describe("Verifiable Presentation Tags", () => {
+    // The colours carry meaning: blue marks the ENVELOPE (as it does Transferable/Negotiable),
+    // orange marks the credentials — so the count matches the "W3C VC" version tag each
+    // credential shows on its own tab. Asserting the classes keeps that relationship from
+    // silently drifting apart.
+    const BLUE = "bg-cerulean-300/[25%]";
+    const ORANGE = "bg-tangerine-500/[24%]";
+
+    it("shows the envelope version tag and a count of what is inside", () => {
+      const store = createMockStore(DOCUMENT_SCHEMA.W3C_VP_2_0);
+      renderWithProvider(store, { presentationCredentialCount: 2 });
+
+      expect(screen.getByText("W3C VP V2.0")).toBeInTheDocument();
+      expect(screen.getByText("2 Credentials")).toBeInTheDocument();
+    });
+
+    it("singularises the count for one credential", () => {
+      const store = createMockStore(DOCUMENT_SCHEMA.W3C_VP_2_0);
+      renderWithProvider(store, { presentationCredentialCount: 1 });
+
+      expect(screen.getByText("1 Credential")).toBeInTheDocument();
+    });
+
+    it("tags a v1.1 envelope by its own data model", () => {
+      const store = createMockStore(DOCUMENT_SCHEMA.W3C_VP_1_1);
+      renderWithProvider(store, { presentationCredentialCount: 1 });
+
+      expect(screen.getByText("W3C VP V1.1")).toBeInTheDocument();
+      expect(screen.queryByText("W3C VP V2.0")).not.toBeInTheDocument();
+    });
+
+    it("gives the count the credential colour, and the envelope a different one", () => {
+      const store = createMockStore(DOCUMENT_SCHEMA.W3C_VP_2_0);
+      renderWithProvider(store, { presentationCredentialCount: 2 });
+
+      expect(screen.getByText("2 Credentials")).toHaveClass(ORANGE);
+      expect(screen.getByText("W3C VP V2.0")).toHaveClass(BLUE);
+      expect(screen.getByText("W3C VP V2.0")).not.toHaveClass(ORANGE);
+    });
+
+    it("drops every credential-shaped tag — none of them describe an envelope", () => {
+      mockUseTokenRegistryVersion.mockReturnValue(TokenRegistryVersions.V5);
+      const store = createMockStore(DOCUMENT_SCHEMA.W3C_VP_2_0);
+      renderWithProvider(store, {
+        presentationCredentialCount: 2,
+        isTransferableDocument: true,
+        isObligation: true,
+      });
+
+      expect(screen.queryByText("Transferable")).not.toBeInTheDocument();
+      expect(screen.queryByText("Negotiable")).not.toBeInTheDocument();
+      expect(screen.queryByText("Obligation")).not.toBeInTheDocument();
+      expect(screen.queryByText("TR V5")).not.toBeInTheDocument();
+    });
+
+    it("leaves a plain credential's tags untouched", () => {
+      const store = createMockStore(DOCUMENT_SCHEMA.W3C_VC_2_0);
+      renderWithProvider(store, { isTransferableDocument: true });
+
+      expect(screen.getByText("Transferable")).toBeInTheDocument();
+      expect(screen.getByText("W3C VC V2.0")).toBeInTheDocument();
+      expect(screen.queryByText(/Credentials?$/)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/AssetManagementPanel/AssetManagementTags/AssetManagementTags.test.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementTags/AssetManagementTags.test.tsx
@@ -278,7 +278,7 @@ describe("AssetManagementTags", () => {
 
     it("shows the envelope version tag and a count of what is inside", () => {
       const store = createMockStore(DOCUMENT_SCHEMA.W3C_VP_2_0);
-      renderWithProvider(store, { presentationCredentialCount: 2 });
+      renderWithProvider(store, { presentationCredentialCount: 2, presentationVersionLabel: "V2.0" });
 
       expect(screen.getByText("W3C VP V2.0")).toBeInTheDocument();
       expect(screen.getByText("2 Credentials")).toBeInTheDocument();
@@ -293,7 +293,7 @@ describe("AssetManagementTags", () => {
 
     it("tags a v1.1 envelope by its own data model", () => {
       const store = createMockStore(DOCUMENT_SCHEMA.W3C_VP_1_1);
-      renderWithProvider(store, { presentationCredentialCount: 1 });
+      renderWithProvider(store, { presentationCredentialCount: 1, presentationVersionLabel: "V1.1" });
 
       expect(screen.getByText("W3C VP V1.1")).toBeInTheDocument();
       expect(screen.queryByText("W3C VP V2.0")).not.toBeInTheDocument();
@@ -301,11 +301,21 @@ describe("AssetManagementTags", () => {
 
     it("gives the count the credential colour, and the envelope a different one", () => {
       const store = createMockStore(DOCUMENT_SCHEMA.W3C_VP_2_0);
-      renderWithProvider(store, { presentationCredentialCount: 2 });
+      renderWithProvider(store, { presentationCredentialCount: 2, presentationVersionLabel: "V2.0" });
 
       expect(screen.getByText("2 Credentials")).toHaveClass(ORANGE);
       expect(screen.getByText("W3C VP V2.0")).toHaveClass(BLUE);
       expect(screen.getByText("W3C VP V2.0")).not.toHaveClass(ORANGE);
+    });
+
+    it("tags the envelope even when the store records no schema, as on the demo path", () => {
+      // The demo keeps its document in a different slice and records no documentSchema at all, so
+      // reading the version off the store showed the count with no version tag beside it.
+      const store = createMockStore(null);
+      renderWithProvider(store, { presentationCredentialCount: 2, presentationVersionLabel: "V2.0" });
+
+      expect(screen.getByText("W3C VP V2.0")).toBeInTheDocument();
+      expect(screen.getByText("2 Credentials")).toBeInTheDocument();
     });
 
     it("drops every credential-shaped tag — none of them describe an envelope", () => {

--- a/src/components/AssetManagementPanel/AssetManagementTags/AssetManagementTags.test.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementTags/AssetManagementTags.test.tsx
@@ -318,6 +318,25 @@ describe("AssetManagementTags", () => {
       expect(screen.getByText("2 Credentials")).toBeInTheDocument();
     });
 
+    it("tags the envelope from the document even when the store holds a STALE schema", () => {
+      // documentSchema is left over from a previously verified credential. Reading the version
+      // off the store showed no VP tag at all here, since the leftover matched neither VP value.
+      const store = createMockStore(DOCUMENT_SCHEMA.W3C_VC_2_0);
+      renderWithProvider(store, { presentationCredentialCount: 2, presentationVersionLabel: "V2.0" });
+
+      expect(screen.getByText("W3C VP V2.0")).toBeInTheDocument();
+      // And the stale credential tag must not leak onto an envelope.
+      expect(screen.queryByText("W3C VC V2.0")).not.toBeInTheDocument();
+    });
+
+    it("lets the document win over a stale VP schema of the wrong version", () => {
+      const store = createMockStore(DOCUMENT_SCHEMA.W3C_VP_1_1);
+      renderWithProvider(store, { presentationCredentialCount: 1, presentationVersionLabel: "V2.0" });
+
+      expect(screen.getByText("W3C VP V2.0")).toBeInTheDocument();
+      expect(screen.queryByText("W3C VP V1.1")).not.toBeInTheDocument();
+    });
+
     it("drops every credential-shaped tag — none of them describe an envelope", () => {
       mockUseTokenRegistryVersion.mockReturnValue(TokenRegistryVersions.V5);
       const store = createMockStore(DOCUMENT_SCHEMA.W3C_VP_2_0);

--- a/src/components/AssetManagementPanel/AssetManagementTags/index.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementTags/index.tsx
@@ -10,11 +10,17 @@ interface AssetManagementTagsProps {
   isTransferableDocument?: boolean;
   /** Obligation record (e.g. BoE) — shows Obligation instead of Transferable. */
   isObligation?: boolean;
+  /**
+   * How many credentials a Verifiable Presentation carries. Undefined for anything that is not
+   * a presentation.
+   */
+  presentationCredentialCount?: number;
 }
 
 export const AssetManagementTags: FunctionComponent<AssetManagementTagsProps> = ({
   isTransferableDocument = false,
   isObligation = false,
+  presentationCredentialCount,
 }) => {
   const { documentSchema } = useSelector((state: RootState) => state.certificate);
   const tokenRegistryVersion = useTokenRegistryVersion();
@@ -22,6 +28,36 @@ export const AssetManagementTags: FunctionComponent<AssetManagementTagsProps> = 
   const tagCSSBlue = "bg-cerulean-300/[25%] text-cerulean-500 rounded-full font-gilroy-bold";
   const tagCSOrange = "bg-tangerine-500/[24%] text-tangerine-500 rounded-full font-gilroy-bold";
   const tagCSSGrey = "bg-cloud-100 text-cloud-500 rounded-full font-gilroy-bold";
+
+  // A presentation is an envelope, not a credential: none of the credential-shaped tags below
+  // (Transferable, Obligation, TR version, the VC data model) describe it. It gets its own
+  // version tag plus a count of what is inside.
+  //
+  // The two colours carry meaning and are not interchangeable. Blue marks the ENVELOPE, the way
+  // it marks the other whole-document properties above. The count is orange because it refers to
+  // what is INSIDE, tying it to the orange "W3C VC" version tag each credential shows on its own
+  // tab below — so the count and the tags it counts read as one family, and the envelope reads
+  // as something else.
+  if (presentationCredentialCount !== undefined) {
+    return (
+      <div className="flex flex-wrap py-2 gap-2">
+        {documentSchema === DOCUMENT_SCHEMA.W3C_VP_1_1 && (
+          <Tag rounded="rounded-full" className={tagCSSBlue}>
+            W3C VP V1.1
+          </Tag>
+        )}
+        {documentSchema === DOCUMENT_SCHEMA.W3C_VP_2_0 && (
+          <Tag rounded="rounded-full" className={tagCSSBlue}>
+            W3C VP V2.0
+          </Tag>
+        )}
+        <Tag rounded="rounded-full" className={tagCSOrange}>
+          {presentationCredentialCount} Credential{presentationCredentialCount === 1 ? "" : "s"}
+        </Tag>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-wrap py-2 gap-2">
       {isObligation ? (

--- a/src/components/AssetManagementPanel/AssetManagementTags/index.tsx
+++ b/src/components/AssetManagementPanel/AssetManagementTags/index.tsx
@@ -15,12 +15,20 @@ interface AssetManagementTagsProps {
    * a presentation.
    */
   presentationCredentialCount?: number;
+  /**
+   * The presentation envelope's data model ("V2.0"), read from the document rather than from the
+   * certificate slice's documentSchema. The demo path stores its document in a different slice
+   * and records no schema at all, so a presentation opened there would have shown the credential
+   * count with no version tag beside it.
+   */
+  presentationVersionLabel?: string;
 }
 
 export const AssetManagementTags: FunctionComponent<AssetManagementTagsProps> = ({
   isTransferableDocument = false,
   isObligation = false,
   presentationCredentialCount,
+  presentationVersionLabel,
 }) => {
   const { documentSchema } = useSelector((state: RootState) => state.certificate);
   const tokenRegistryVersion = useTokenRegistryVersion();
@@ -41,14 +49,9 @@ export const AssetManagementTags: FunctionComponent<AssetManagementTagsProps> = 
   if (presentationCredentialCount !== undefined) {
     return (
       <div className="flex flex-wrap py-2 gap-2">
-        {documentSchema === DOCUMENT_SCHEMA.W3C_VP_1_1 && (
+        {presentationVersionLabel && (
           <Tag rounded="rounded-full" className={tagCSSBlue}>
-            W3C VP V1.1
-          </Tag>
-        )}
-        {documentSchema === DOCUMENT_SCHEMA.W3C_VP_2_0 && (
-          <Tag rounded="rounded-full" className={tagCSSBlue}>
-            W3C VP V2.0
+            W3C VP {presentationVersionLabel}
           </Tag>
         )}
         <Tag rounded="rounded-full" className={tagCSOrange}>

--- a/src/components/CertificateViewer.test.tsx
+++ b/src/components/CertificateViewer.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import fs from "fs";
+import path from "path";
+import { act, render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "../store";
+import { CertificateViewer } from "./CertificateViewer";
+
+// The presentation branch is what is under test; everything below it mounts iframes, wallets or
+// chain calls that jsdom cannot provide.
+jest.mock("./CredentialTabs", () => ({
+  CredentialTabs: ({ presentation, fileName }: { presentation: any; fileName: string }) => (
+    <div data-testid="credential-tabs" data-file-name={fileName} data-holder={presentation?.holder} />
+  ),
+}));
+jest.mock("./DecentralisedTemplateRenderer/DecentralisedRenderer", () => ({
+  DecentralisedRendererContainer: () => <div data-testid="single-renderer" />,
+}));
+jest.mock("./AssetManagementPanel/AssetManagementApplication", () => ({
+  AssetManagementApplication: (props: any) => (
+    <div data-testid="asset-management" data-transferable={String(props.isTransferableDocument)} />
+  ),
+}));
+jest.mock("./EndorsementChain", () => ({ EndorsementChainContainer: () => <div /> }));
+
+const mockInitialize = jest.fn();
+jest.mock("../common/contexts/TokenInformationContext", () => ({
+  useTokenInformationContext: () => ({ initialize: mockInitialize, resetStates: jest.fn() }),
+}));
+jest.mock("../common/contexts/provider", () => ({
+  useProviderContext: () => ({ currentChainId: undefined }),
+  getCurrentProvider: () => undefined,
+}));
+
+const fixture = (name: string) =>
+  JSON.parse(fs.readFileSync(path.join(__dirname, "../test/fixture/w3c/presentations", name), "utf8"));
+
+const presentation = fixture("valid/two_credentials.json");
+const [credential] = presentation.verifiableCredential;
+
+const renderViewer = (document: any, filename = "presentation.json") =>
+  render(
+    <Provider store={configureStore()}>
+      <CertificateViewer document={document} filename={filename} />
+    </Provider>
+  );
+
+describe("CertificateViewer — Verifiable Presentation", () => {
+  beforeEach(() => mockInitialize.mockReset());
+
+  afterEach(async () => {
+    // ObfuscatedMessage starts an async isObfuscated check with no cancellation guard, so its
+    // state update can land after the test unmounts. Let it settle rather than leaking a warning
+    // into the next test.
+    await act(async () => undefined);
+  });
+
+  it("renders credential tabs instead of the single-document renderer", () => {
+    renderViewer(presentation);
+    expect(screen.getByTestId("credential-tabs")).toBeInTheDocument();
+    expect(screen.queryByTestId("single-renderer")).not.toBeInTheDocument();
+  });
+
+  it("passes the uploaded filename through, so each credential's download is distinct", () => {
+    renderViewer(presentation, "my-presentation.json");
+    expect(screen.getByTestId("credential-tabs")).toHaveAttribute("data-file-name", "my-presentation.json");
+  });
+
+  it("still shows the status panel, which reports on the envelope", () => {
+    renderViewer(presentation);
+    expect(screen.getByTestId("asset-management")).toHaveAttribute("data-transferable", "false");
+  });
+
+  it("never treats a presentation as a transferable record", () => {
+    // The envelope holds no token; initialising the token context would probe a registry that
+    // does not exist.
+    renderViewer(presentation);
+    expect(mockInitialize).not.toHaveBeenCalled();
+  });
+
+  it("does not throw on a presentation, whose document data would otherwise be unreadable", () => {
+    // getOpenAttestationData feeds the expiry check; without its presentation guard it falls
+    // through to getDocumentData, which throws.
+    expect(() => renderViewer(presentation)).not.toThrow();
+  });
+
+  it("keeps rendering a plain credential through the single-document path", () => {
+    renderViewer(credential);
+    expect(screen.getByTestId("single-renderer")).toBeInTheDocument();
+    expect(screen.queryByTestId("credential-tabs")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/CertificateViewer.test.tsx
+++ b/src/components/CertificateViewer.test.tsx
@@ -13,8 +13,12 @@ jest.mock("./CredentialTabs", () => ({
     <div data-testid="credential-tabs" data-file-name={fileName} data-holder={presentation?.holder} />
   ),
 }));
+const mockSingleRenderer = jest.fn();
 jest.mock("./DecentralisedTemplateRenderer/DecentralisedRenderer", () => ({
-  DecentralisedRendererContainer: () => <div data-testid="single-renderer" />,
+  DecentralisedRendererContainer: (props: any) => {
+    mockSingleRenderer(props);
+    return <div data-testid="single-renderer" />;
+  },
 }));
 jest.mock("./AssetManagementPanel/AssetManagementApplication", () => ({
   AssetManagementApplication: (props: any) => (
@@ -88,5 +92,21 @@ describe("CertificateViewer — Verifiable Presentation", () => {
     renderViewer(credential);
     expect(screen.getByTestId("single-renderer")).toBeInTheDocument();
     expect(screen.queryByTestId("credential-tabs")).not.toBeInTheDocument();
+  });
+});
+
+describe("CertificateViewer — renderer reports no usable template", () => {
+  it("does not throw when every template is filtered out", () => {
+    // The renderer's template list is filtered to the renderable types; a document whose renderer
+    // offers none leaves an empty array, and reading [0].id off it took the viewer down.
+    renderViewer(credential);
+    const { updateTemplates } = mockSingleRenderer.mock.calls[0][0];
+    expect(() => act(() => updateTemplates([{ id: "unsupported", label: "x", type: "something-else" }]))).not.toThrow();
+  });
+
+  it("does not throw on an empty template list", () => {
+    renderViewer(credential);
+    const { updateTemplates } = mockSingleRenderer.mock.calls[0][0];
+    expect(() => act(() => updateTemplates([]))).not.toThrow();
   });
 });

--- a/src/components/CertificateViewer.tsx
+++ b/src/components/CertificateViewer.tsx
@@ -21,6 +21,8 @@ import {
   WrappedOrSignedOpenAttestationDocument,
 } from "../utils/shared";
 import { isValidAttachmentData } from "../utils/attachmentValidation";
+import { isVerifiablePresentation } from "../utils/presentation";
+import { CredentialTabs } from "./CredentialTabs";
 import { AssetManagementApplication } from "./AssetManagementPanel/AssetManagementApplication";
 import { CertificateViewerErrorBoundary } from "./CertificateViewerErrorBoundary/CertificateViewerErrorBoundary";
 import { DecentralisedRendererContainer } from "./DecentralisedTemplateRenderer/DecentralisedRenderer";
@@ -41,6 +43,10 @@ interface CertificateViewerProps {
 }
 
 export const CertificateViewer: FunctionComponent<CertificateViewerProps> = ({ isMagicDemo, document, filename }) => {
+  // A presentation is a bundle, not a credential. None of the credential-shaped machinery below
+  // applies to the envelope: it holds no token, no renderer template and no attachments of its
+  // own, and each embedded credential is rendered on its own tab instead.
+  const isPresentation = isVerifiablePresentation(document);
   const isTransferableAssetVal = isTransferableRecord(document);
   const isObligationAssetVal = isObligationRecord(document);
   let tokenId = "";
@@ -166,6 +172,23 @@ export const CertificateViewer: FunctionComponent<CertificateViewerProps> = ({ i
     </div>
   );
 
+  const renderedPresentationViewer = (
+    <>
+      <div className="no-print mt-4">
+        <AssetManagementApplication
+          isMagicDemo={isMagicDemo}
+          isTransferableDocument={false}
+          isSampleDocument={isSampleDocument}
+          isExpired={isExpired}
+        />
+      </div>
+      <div id="preview-block">
+        <CredentialTabs presentation={document} fileName={filename} />
+      </div>
+      <ScrollTip targetId="preview-block" />
+    </>
+  );
+
   const renderedCertificateViewer = (
     <>
       <div className="no-print mt-4">
@@ -232,6 +255,10 @@ export const CertificateViewer: FunctionComponent<CertificateViewerProps> = ({ i
       <ScrollTip targetId="preview-block" />
     </>
   );
+
+  if (isPresentation) {
+    return <CertificateViewerErrorBoundary>{renderedPresentationViewer}</CertificateViewerErrorBoundary>;
+  }
 
   return (
     <CertificateViewerErrorBoundary>

--- a/src/components/CertificateViewer.tsx
+++ b/src/components/CertificateViewer.tsx
@@ -149,7 +149,11 @@ export const CertificateViewer: FunctionComponent<CertificateViewerProps> = ({ i
 
     // set modified templates
     setTemplates(templatesModified);
-    setSelectedTemplate(templatesModified[0].id);
+    // A renderer whose templates are all unsupported filters down to nothing, and reading [0].id
+    // off the empty array throws, taking the whole viewer down.
+    if (templatesModified.length > 0) {
+      setSelectedTemplate(templatesModified[0].id);
+    }
   }, []);
 
   const onPrint = () => {

--- a/src/components/CredentialTabs/CredentialDocumentView.test.tsx
+++ b/src/components/CredentialTabs/CredentialDocumentView.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import fs from "fs";
+import path from "path";
+import { act, render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "../../store";
+import { CredentialDocumentView } from "./CredentialDocumentView";
+
+// The renderer mounts an iframe and talks to a remote template over postMessage — neither works
+// in jsdom. Captured as props so the wiring can still be asserted.
+const mockRenderer = jest.fn();
+jest.mock("../DecentralisedTemplateRenderer/DecentralisedRenderer", () => ({
+  DecentralisedRenderer: (props: any) => {
+    mockRenderer(props);
+    return <div data-testid="renderer" />;
+  },
+}));
+
+const fixture = (name: string) =>
+  JSON.parse(fs.readFileSync(path.join(__dirname, "../../test/fixture/w3c/presentations", name), "utf8"));
+
+const [plainCredential] = fixture("valid/two_credentials.json").verifiableCredential;
+const [credentialWithAttachments] = fixture("valid/with_attachments.json").verifiableCredential;
+
+const renderView = (credential: any, downloadName = "presentation-chafta-coo") =>
+  render(
+    <Provider store={configureStore()}>
+      <CredentialDocumentView credential={credential} downloadName={downloadName} />
+    </Provider>
+  );
+
+describe("CredentialDocumentView", () => {
+  beforeEach(() => mockRenderer.mockReset());
+
+  it("renders the credential itself, not the presentation around it", () => {
+    renderView(plainCredential);
+    expect(screen.getByTestId("renderer")).toBeInTheDocument();
+    expect(mockRenderer).toHaveBeenCalledWith(expect.objectContaining({ rawDocument: plainCredential }));
+  });
+
+  it("drops OBFUSCATE messages instead of dispatching them at the store", () => {
+    // The connected container would dispatch applyPrivacyFilter, obfuscating the whole
+    // presentation held in the store — and obfuscateDocument throws on a presentation anyway.
+    renderView(plainCredential);
+    const { setPrivacyFilter } = mockRenderer.mock.calls[0][0];
+    expect(typeof setPrivacyFilter).toBe("function");
+    expect(() => setPrivacyFilter({ some: "path" })).not.toThrow();
+  });
+
+  it("shows this credential's own attachments", () => {
+    renderView(credentialWithAttachments);
+    expect(screen.getByTestId("tab-attachment")).toBeInTheDocument();
+  });
+
+  it("shows no attachment tab for a credential without any", () => {
+    renderView(plainCredential);
+    expect(screen.queryByTestId("tab-attachment")).not.toBeInTheDocument();
+  });
+
+  it("passes the credential-qualified download name to the utility bar", () => {
+    // Templates arrive from the renderer, so drive that to make DocumentUtility mount.
+    renderView(plainCredential);
+    const { updateTemplates } = mockRenderer.mock.calls[0][0];
+    act(() => updateTemplates([{ id: "custom-template", label: "Custom", type: "custom-template" }]));
+    expect(screen.getByLabelText("document-utility-download")).toHaveAttribute(
+      "download",
+      "presentation-chafta-coo.tt"
+    );
+  });
+
+  it("selects the first renderable template once the renderer reports them", () => {
+    renderView(plainCredential);
+    const { updateTemplates } = mockRenderer.mock.calls[0][0];
+    act(() =>
+      updateTemplates([
+        { id: "custom-template", label: "Custom", type: "custom-template" },
+        { id: "second", label: "Second", type: "custom-template" },
+      ])
+    );
+    expect(screen.getByTestId("custom-template")).toBeInTheDocument();
+    expect(screen.getByTestId("second")).toBeInTheDocument();
+  });
+});

--- a/src/components/CredentialTabs/CredentialDocumentView.test.tsx
+++ b/src/components/CredentialTabs/CredentialDocumentView.test.tsx
@@ -22,7 +22,7 @@ const fixture = (name: string) =>
 const [plainCredential] = fixture("valid/two_credentials.json").verifiableCredential;
 const [credentialWithAttachments] = fixture("valid/with_attachments.json").verifiableCredential;
 
-const renderView = (credential: any, downloadName = "presentation-chafta-coo") =>
+const renderView = (credential: any, downloadName = "presentation-chafta-coo-1") =>
   render(
     <Provider store={configureStore()}>
       <CredentialDocumentView credential={credential} downloadName={downloadName} />
@@ -64,7 +64,7 @@ describe("CredentialDocumentView", () => {
     act(() => updateTemplates([{ id: "custom-template", label: "Custom", type: "custom-template" }]));
     expect(screen.getByLabelText("document-utility-download")).toHaveAttribute(
       "download",
-      "presentation-chafta-coo.tt"
+      "presentation-chafta-coo-1.tt"
     );
   });
 

--- a/src/components/CredentialTabs/CredentialDocumentView.tsx
+++ b/src/components/CredentialTabs/CredentialDocumentView.tsx
@@ -1,0 +1,115 @@
+import React, { FunctionComponent, useCallback, useMemo, useRef, useState } from "react";
+import { TemplateProps } from "../../types";
+import { getAttachments } from "../../utils/shared";
+import { isValidAttachmentData } from "../../utils/attachmentValidation";
+import { DecentralisedRenderer } from "../DecentralisedTemplateRenderer/DecentralisedRenderer";
+import { MultiTabs } from "../DecentralisedTemplateRenderer/MultiTabs";
+import { DocumentUtility } from "../DocumentUtility";
+import { InvalidAttachmentsBanner } from "../InvalidAttachmentsBanner";
+import { TabPaneAttachments } from "../TabPaneAttachments";
+
+interface CredentialDocumentViewProps {
+  /** One credential lifted out of a presentation. */
+  credential: any;
+  /** Download name for this credential, unique across the presentation's tabs. */
+  downloadName: string;
+}
+
+/**
+ * Renders a single credential from a presentation: its own template tabs, attachments and
+ * utility bar, the same way the certificate viewer renders a standalone document.
+ *
+ * It deliberately does NOT use `DecentralisedRendererContainer`. That container is connected to
+ * the certificate slice and dispatches `applyPrivacyFilter` on an OBFUSCATE message from the
+ * frame, which would obfuscate the whole presentation held in the store rather than this
+ * credential — and `obfuscateDocument` throws on a presentation anyway. Obfuscating a
+ * credential that has already been presented is not a supported action, so the message is
+ * dropped instead.
+ */
+export const CredentialDocumentView: FunctionComponent<CredentialDocumentViewProps> = ({
+  credential,
+  downloadName,
+}) => {
+  const [templates, setTemplates] = useState<TemplateProps[]>([]);
+  const [selectedTemplate, setSelectedTemplate] = useState("");
+  const childRef = useRef<{ print: () => void }>();
+
+  const attachments = useMemo(() => getAttachments(credential), [credential]);
+  const hasAttachments = attachments ? attachments.length > 0 : false;
+
+  const invalidAttachments = useMemo(() => {
+    const filtered = attachments?.filter(
+      (attachment) => attachment.type === "custom-template" || attachment.type === "application/pdf" || !attachment.type
+    );
+    return (
+      filtered
+        ?.map((attachment, index) => ({
+          ...attachment,
+          index,
+          isInvalid:
+            typeof attachment.data === "string" ? !isValidAttachmentData(attachment.data, attachment.type) : false,
+        }))
+        .filter((attachment) => attachment.isInvalid) || []
+    );
+  }, [attachments]);
+
+  const updateTemplates = useCallback((templateList: TemplateProps[]) => {
+    // filter all templates that are renderable currently
+    const templatesModified = templateList.filter((item) => {
+      return item.type === "custom-template" || item.type === "application/pdf" || !item.type;
+    });
+    setTemplates(templatesModified);
+    if (templatesModified.length > 0) {
+      setSelectedTemplate(templatesModified[0].id);
+    }
+  }, []);
+
+  const onPrint = () => {
+    if (childRef.current) {
+      childRef.current.print();
+    }
+  };
+
+  return (
+    <>
+      <InvalidAttachmentsBanner
+        hasInvalidAttachments={invalidAttachments.length > 0}
+        invalidAttachments={invalidAttachments}
+      />
+      <div className="no-print mt-4">
+        <MultiTabs
+          hasAttachments={hasAttachments}
+          attachments={attachments}
+          templates={templates}
+          setSelectedTemplate={setSelectedTemplate}
+          selectedTemplate={selectedTemplate}
+          invalidAttachments={invalidAttachments}
+        />
+      </div>
+      <div className="bg-white py-6">
+        {attachments && (
+          <div className={`${selectedTemplate !== "attachmentTab" ? "hidden" : "block"}`}>
+            <TabPaneAttachments attachments={attachments} />
+          </div>
+        )}
+        <div className={`${selectedTemplate === "attachmentTab" ? "hidden" : "block"}`}>
+          {templates.length > 0 && (
+            <DocumentUtility
+              document={credential}
+              onPrint={onPrint}
+              selectedTemplate={selectedTemplate}
+              downloadName={downloadName}
+            />
+          )}
+          <DecentralisedRenderer
+            rawDocument={credential}
+            updateTemplates={updateTemplates}
+            selectedTemplate={selectedTemplate}
+            setPrivacyFilter={() => undefined}
+            forwardedRef={childRef}
+          />
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/components/CredentialTabs/CredentialTabs.test.tsx
+++ b/src/components/CredentialTabs/CredentialTabs.test.tsx
@@ -143,7 +143,7 @@ describe("CredentialTabs", () => {
     fireEvent.click(tabs[1]);
     const second = screen.getByTestId("credential-document").getAttribute("data-download-name");
 
-    expect(first).toBe("presentation-chafta-coo");
+    expect(first).toBe("presentation-chafta-coo-1");
     expect(second).not.toBe(first);
   });
 

--- a/src/components/CredentialTabs/CredentialTabs.test.tsx
+++ b/src/components/CredentialTabs/CredentialTabs.test.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import fs from "fs";
+import path from "path";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "../../store";
+import { CredentialTabs } from "./CredentialTabs";
+
+// The renderer mounts an iframe and talks to a remote template over postMessage; neither works
+// in jsdom, and neither is what these tests are about.
+jest.mock("./CredentialDocumentView", () => ({
+  CredentialDocumentView: ({ credential, downloadName }: { credential: any; downloadName: string }) => (
+    <div data-testid="credential-document" data-download-name={downloadName}>
+      {credential?.id}
+    </div>
+  ),
+}));
+
+// Must be `mock`-prefixed: jest.mock is hoisted above every other statement in the module.
+const mockVerifyDocument = jest.fn();
+jest.mock("../../services/verify", () => ({
+  verifyDocument: (...args: unknown[]) => mockVerifyDocument(...args),
+}));
+
+const fixture = (name: string) =>
+  JSON.parse(fs.readFileSync(path.join(__dirname, "../../test/fixture/w3c/presentations", name), "utf8"));
+
+const twoCredentials = fixture("valid/two_credentials.json");
+const singleCredential = fixture("valid/single_credential.json");
+
+const allValid = [
+  { name: "W3CSignatureIntegrity", type: "DOCUMENT_INTEGRITY", status: "VALID" },
+  { name: "W3CCredentialStatus", type: "DOCUMENT_STATUS", status: "VALID" },
+  { name: "W3CIssuerIdentity", type: "ISSUER_IDENTITY", status: "VALID" },
+];
+
+const renderTabs = (presentation: unknown) =>
+  render(
+    <Provider store={configureStore()}>
+      <CredentialTabs presentation={presentation} fileName="presentation.json" />
+    </Provider>
+  );
+
+describe("CredentialTabs", () => {
+  beforeEach(() => {
+    mockVerifyDocument.mockReset();
+    mockVerifyDocument.mockResolvedValue(allValid);
+  });
+
+  it("renders one tab per embedded credential, labelled by its renderer template", async () => {
+    renderTabs(twoCredentials);
+    const tabs = await screen.findAllByRole("tab");
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0]).toHaveTextContent("CHAFTA COO");
+    expect(tabs[1]).toHaveTextContent("BILL OF LADING");
+  });
+
+  it("renders nothing for a presentation with no credentials", () => {
+    const { container } = renderTabs({ type: ["VerifiablePresentation"], verifiableCredential: [] });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the selected credential's own issuer and version tag", async () => {
+    renderTabs(twoCredentials);
+    await waitFor(() => {
+      expect(screen.getByText(twoCredentials.verifiableCredential[0].issuer.toUpperCase())).toBeInTheDocument();
+    });
+    expect(screen.getByText("W3C VC V2.0")).toBeInTheDocument();
+  });
+
+  it("verifies each credential independently and reports its own three checks", async () => {
+    renderTabs(twoCredentials);
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-check-document_status")).toHaveAttribute("data-status", "VALID");
+    });
+    expect(screen.getByTestId("credential-check-issuer_identity")).toHaveAttribute("data-status", "VALID");
+    expect(screen.getByTestId("credential-check-document_integrity")).toHaveAttribute("data-status", "VALID");
+    expect(mockVerifyDocument).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows pending checks first, so no red cross flashes before the result arrives", () => {
+    renderTabs(singleCredential);
+    expect(screen.getByTestId("credential-check-document_status")).toHaveAttribute("data-status", "PENDING");
+  });
+
+  it("marks a credential that fails verification as invalid on every check", async () => {
+    mockVerifyDocument.mockRejectedValue(new Error("network down"));
+    renderTabs(singleCredential);
+    await waitFor(() => {
+      expect(screen.getByTestId("credential-check-issuer_identity")).toHaveAttribute("data-status", "INVALID");
+    });
+  });
+
+  it("switches panel content when another tab is chosen", async () => {
+    renderTabs(twoCredentials);
+    const tabs = await screen.findAllByRole("tab");
+    expect(screen.getByTestId("credential-document")).toHaveTextContent(twoCredentials.verifiableCredential[0].id);
+
+    fireEvent.click(tabs[1]);
+
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[0]).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByTestId("credential-document")).toHaveTextContent(twoCredentials.verifiableCredential[1].id);
+  });
+
+  it("moves between tabs with the arrow keys, per the ARIA tabs pattern", async () => {
+    renderTabs(twoCredentials);
+    const tabs = await screen.findAllByRole("tab");
+    tabs[0].focus();
+
+    fireEvent.keyDown(document.activeElement!, { key: "ArrowRight" });
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+
+    // Wraps around rather than stopping at the end.
+    fireEvent.keyDown(document.activeElement!, { key: "ArrowRight" });
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(document.activeElement!, { key: "End" });
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("keeps the strip to a single Tab stop with a roving tabIndex", async () => {
+    renderTabs(twoCredentials);
+    const tabs = await screen.findAllByRole("tab");
+    expect(tabs[0]).toHaveAttribute("tabIndex", "0");
+    expect(tabs[1]).toHaveAttribute("tabIndex", "-1");
+  });
+
+  it("points every tab at a panel that exists, including the unselected ones", async () => {
+    const { container } = renderTabs(twoCredentials);
+    const tabs = await screen.findAllByRole("tab");
+    tabs.forEach((tab) => {
+      const id = tab.getAttribute("aria-controls")!;
+      expect(container.querySelector(`#${id}`)).not.toBeNull();
+    });
+  });
+
+  it("gives each credential its own download name, so one tab cannot overwrite another", async () => {
+    renderTabs(twoCredentials);
+    const tabs = await screen.findAllByRole("tab");
+    const first = screen.getByTestId("credential-document").getAttribute("data-download-name");
+
+    fireEvent.click(tabs[1]);
+    const second = screen.getByTestId("credential-document").getAttribute("data-download-name");
+
+    expect(first).toBe("presentation-chafta-coo");
+    expect(second).not.toBe(first);
+  });
+
+  it("falls back to the first tab when a new presentation has fewer credentials", async () => {
+    const { rerender } = renderTabs(twoCredentials);
+    const tabs = await screen.findAllByRole("tab");
+    fireEvent.click(tabs[1]);
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+
+    // The stale index 1 would point past the end of the new set and hand the panel an
+    // undefined credential.
+    rerender(
+      <Provider store={configureStore()}>
+        <CredentialTabs presentation={singleCredential} fileName="presentation.json" />
+      </Provider>
+    );
+
+    const newTabs = screen.getAllByRole("tab");
+    expect(newTabs).toHaveLength(1);
+    expect(newTabs[0]).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/src/components/CredentialTabs/CredentialTabs.tsx
+++ b/src/components/CredentialTabs/CredentialTabs.tsx
@@ -1,0 +1,240 @@
+import React, { FunctionComponent, useMemo, useRef, useState } from "react";
+import { CheckCircle, XCircle } from "react-feather";
+import { errorMessages } from "@trustvc/trustvc";
+import {
+  getCredentialDownloadName,
+  getCredentialLabel,
+  getCredentialVersionTag,
+  getPresentationCredentials,
+} from "../../utils/presentation";
+import { LoaderSpinner } from "../UI/Loader";
+import { Tag } from "../UI/Tag";
+import { CredentialDocumentView } from "./CredentialDocumentView";
+import { useCredentialVerification } from "./useCredentialVerification";
+
+const { MESSAGES, TYPES } = errorMessages;
+
+/** The same three checks the document status panel reports, in the same order. */
+const CREDENTIAL_CHECKS = [
+  { type: "DOCUMENT_STATUS", messageSet: MESSAGES[TYPES.ISSUED] },
+  { type: "ISSUER_IDENTITY", messageSet: MESSAGES[TYPES.IDENTITY] },
+  { type: "DOCUMENT_INTEGRITY", messageSet: MESSAGES[TYPES.HASH] },
+];
+
+interface CredentialTabsProps {
+  presentation: unknown;
+  /** The uploaded file's name, used to name each credential's download uniquely. */
+  fileName: string;
+}
+
+/**
+ * Renders each credential embedded in a Verifiable Presentation on its own tab.
+ *
+ * A presentation is a bundle, so there is no single document to render: each credential carries
+ * its own renderer template, its own issuer and its own verification result. Each tab therefore
+ * shows that credential's identity and checks above the rendered document, while the document
+ * status panel above reports on the envelope.
+ */
+export const CredentialTabs: FunctionComponent<CredentialTabsProps> = ({ presentation, fileName }) => {
+  const credentials = useMemo(() => getPresentationCredentials(presentation), [presentation]);
+  const verifications = useCredentialVerification(credentials);
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  /**
+   * The selected tab, stamped with the presentation it was chosen in.
+   *
+   * Resetting this in an effect instead leaves one render in between: effects run after paint,
+   * so a newly loaded presentation would be rendered with the previous one's index still in
+   * place. When it holds fewer credentials that index points past the end and the panel is
+   * handed an undefined credential — a mislabelled tab, a version tag defaulted from nothing, an
+   * empty renderer. Deriving the index below means it is never out of range at all.
+   */
+  const [selection, setSelection] = useState<{ presentation: unknown; index: number }>({
+    presentation,
+    index: 0,
+  });
+
+  const selected =
+    selection.presentation === presentation && selection.index < credentials.length ? selection.index : 0;
+
+  const select = (index: number) => setSelection({ presentation, index });
+
+  /**
+   * Arrow/Home/End movement between tabs, per the ARIA tabs pattern. Without it the strip is
+   * reachable by Tab and activated by Enter, but cannot be moved through — and with the roving
+   * tabIndex below, Tab now leaves the strip rather than walking every credential.
+   */
+  const onTabKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const last = credentials.length - 1;
+    let next: number;
+    switch (event.key) {
+      case "ArrowRight":
+        next = selected === last ? 0 : selected + 1;
+        break;
+      case "ArrowLeft":
+        next = selected === 0 ? last : selected - 1;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      case "End":
+        next = last;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    select(next);
+    tabRefs.current[next]?.focus();
+  };
+
+  if (credentials.length === 0) return null;
+
+  const active = credentials[selected];
+  const activeResult = verifications[selected];
+  const issuer = activeResult?.issuer;
+
+  return (
+    <div data-testid="credential-tabs">
+      <div className="container">
+        {/* Font and size follow the "Presented by:" label in IssuedBy; the uppercase and the
+            0.04em tracking are the reference's own caption treatment. mt-8 separates it from the
+            status panel above, which it otherwise butted straight up against. */}
+        <div className="text-cloud-800 uppercase tracking-[0.04em] mt-8 mb-3">Credentials in this presentation</div>
+      </div>
+
+      <div className="container">
+        <div
+          className="flex overflow-x-auto items-end"
+          role="tablist"
+          aria-label="Credentials in this presentation"
+          onKeyDown={onTabKeyDown}
+        >
+          {credentials.map((credential, index) => {
+            const isActive = index === selected;
+            const result = verifications[index];
+            return (
+              <button
+                key={credential?.id ?? index}
+                id={`credential-tab-${index}`}
+                ref={(el) => {
+                  tabRefs.current[index] = el;
+                }}
+                role="tab"
+                aria-selected={isActive}
+                aria-controls={`credential-panel-${index}`}
+                // Roving tabIndex: the strip is one Tab stop and the arrow keys move within it,
+                // rather than every credential being its own Tab stop.
+                tabIndex={isActive ? 0 : -1}
+                data-testid={`credential-tab-${index}`}
+                className={`px-3 py-2 mr-2 multi-tab border-t border-r border-l rounded-t-xl border-cloud-100 flex items-center whitespace-nowrap ${
+                  isActive ? "bg-white text-cloud-800" : "bg-cloud-100 text-cloud-300"
+                }`}
+                onClick={() => select(index)}
+              >
+                <span className="mr-2 flex items-center" aria-hidden="true">
+                  {result?.loading ? (
+                    <LoaderSpinner width="16px" primary="#4DA6E8" secondary="#E7EAEC" />
+                  ) : result?.isValid ? (
+                    <CheckCircle className="text-forest-500 w-4 h-4" />
+                  ) : (
+                    <XCircle className="text-scarlet-500 w-4 h-4" />
+                  )}
+                </span>
+                <span className="truncate">{getCredentialLabel(credential, index)}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div
+        className="bg-white"
+        id={`credential-panel-${selected}`}
+        role="tabpanel"
+        aria-labelledby={`credential-tab-${selected}`}
+      >
+        {/* This credential's own identity and checks — the panel above covers the presentation
+            envelope, not what is inside it. */}
+        <div className="container">
+          {/* Same px-4 inset and same grid as DocumentStatus above, so this credential's issuer
+              and checks line up under the presentation's own — rather than the checks being
+              pushed to the far right by a space-between row. Extra padding on top only: the tab
+              strip butts directly against this panel, so a uniform p-4 left "Issued by:" sitting
+              tight under the active tab's border. */}
+          <div className="px-4 pt-6 pb-4">
+            <div className="flex-1 grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-3 grid-flow-row gap-2 justify-between">
+              <div className="col-span-1">
+                <div className="break-all text-cloud-800">Issued by:</div>
+                <h4 className="text-cloud-800 leading-none break-all">{issuer ?? "Unknown"}</h4>
+                {/* The data-model version, matching the tag a standalone credential gets. */}
+                <div className="flex flex-wrap py-2 gap-2">
+                  <Tag
+                    rounded="rounded-full"
+                    className="bg-tangerine-500/[24%] text-tangerine-500 rounded-full font-gilroy-bold"
+                  >
+                    {getCredentialVersionTag(active)}
+                  </Tag>
+                </div>
+              </div>
+
+              <div className="col-span-1 flex items-start flex-col" data-testid={`credential-checks-${selected}`}>
+                {CREDENTIAL_CHECKS.map(({ type, messageSet }) => {
+                  const status = activeResult?.status?.[type];
+                  const valid = status === "VALID";
+                  return (
+                    <div
+                      key={type}
+                      className="flex justify-start items-center py-2 h-9"
+                      data-testid={`credential-check-${type.toLowerCase()}`}
+                      data-status={activeResult?.loading ? "PENDING" : status}
+                    >
+                      <div className="w-5 h-5 flex-1 flex">
+                        {activeResult?.loading ? (
+                          <LoaderSpinner width="20px" primary="#4DA6E8" secondary="#E7EAEC" />
+                        ) : valid ? (
+                          <CheckCircle className="text-forest-500 w-5 h-5" />
+                        ) : (
+                          <XCircle className="text-scarlet-500 w-5 h-5" />
+                        )}
+                      </div>
+                      <div className="flex-grow">
+                        <p className="pl-2 mb-0 text-sm leading-5">
+                          {activeResult?.loading || valid ? messageSet.successTitle : messageSet.failureTitle}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Keyed so switching tabs remounts the renderer — the iframe holds the previous
+            credential's template and does not re-render on a prop change alone. */}
+        <CredentialDocumentView
+          key={selected}
+          credential={active}
+          downloadName={getCredentialDownloadName(fileName, active, selected)}
+        />
+      </div>
+
+      {/* Every tab's `aria-controls` must point at an element that exists, but only the selected
+          panel is rendered above — so the inactive tabs would reference nothing. These stand in
+          for them, empty and hidden. Rendering their content instead would mount a renderer, and
+          therefore an iframe, per credential. */}
+      {credentials.map((_, index) =>
+        index === selected ? null : (
+          <div
+            key={index}
+            id={`credential-panel-${index}`}
+            role="tabpanel"
+            aria-labelledby={`credential-tab-${index}`}
+            hidden
+          />
+        )
+      )}
+    </div>
+  );
+};

--- a/src/components/CredentialTabs/index.ts
+++ b/src/components/CredentialTabs/index.ts
@@ -1,0 +1,1 @@
+export * from "./CredentialTabs";

--- a/src/components/CredentialTabs/useCredentialVerification.test.tsx
+++ b/src/components/CredentialTabs/useCredentialVerification.test.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { useCredentialVerification } from "./useCredentialVerification";
+
+// Must be `mock`-prefixed: jest.mock is hoisted above every other statement in the module.
+const mockVerifyDocument = jest.fn();
+jest.mock("../../services/verify", () => ({
+  verifyDocument: (...args: unknown[]) => mockVerifyDocument(...args),
+}));
+
+const frags = (statuses: Record<string, string>) =>
+  Object.entries(statuses).map(([type, status]) => ({ name: type, type, status }));
+
+const ALL_VALID = frags({ DOCUMENT_STATUS: "VALID", ISSUER_IDENTITY: "VALID", DOCUMENT_INTEGRITY: "VALID" });
+
+/** Renders the hook's output as inspectable DOM. */
+const Probe: React.FC<{ credentials: any[] }> = ({ credentials }) => {
+  const results = useCredentialVerification(credentials);
+  return (
+    <ul>
+      {results.map((r, i) => (
+        <li
+          key={i}
+          data-testid={`result-${i}`}
+          data-loading={String(r.loading)}
+          data-valid={String(r.isValid)}
+          data-issuer={r.issuer ?? ""}
+          data-status={JSON.stringify(r.status)}
+        />
+      ))}
+    </ul>
+  );
+};
+
+const credential = (id: string, issuer: unknown = "did:key:abc") => ({ id, issuer, claim: id });
+
+describe("useCredentialVerification", () => {
+  beforeEach(() => {
+    mockVerifyDocument.mockReset();
+    mockVerifyDocument.mockResolvedValue(ALL_VALID);
+  });
+
+  it("returns one result per credential", async () => {
+    render(<Probe credentials={[credential("a"), credential("b")]} />);
+    await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-loading", "false"));
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("starts pending during render, so no red cross flashes before the verdict", () => {
+    render(<Probe credentials={[credential("a")]} />);
+    // Synchronous assertion — deliberately not awaited.
+    expect(screen.getByTestId("result-0")).toHaveAttribute("data-loading", "true");
+    expect(screen.getByTestId("result-0")).toHaveAttribute("data-valid", "false");
+  });
+
+  it("verifies each credential independently", async () => {
+    render(<Probe credentials={[credential("a"), credential("b")]} />);
+    await waitFor(() => expect(mockVerifyDocument).toHaveBeenCalledTimes(2));
+    expect(mockVerifyDocument).toHaveBeenCalledWith(expect.objectContaining({ id: "a" }));
+    expect(mockVerifyDocument).toHaveBeenCalledWith(expect.objectContaining({ id: "b" }));
+  });
+
+  it("reports the three check groups and an overall verdict", async () => {
+    render(<Probe credentials={[credential("a")]} />);
+    await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-loading", "false"));
+    expect(JSON.parse(screen.getByTestId("result-0").getAttribute("data-status")!)).toEqual({
+      DOCUMENT_STATUS: "VALID",
+      ISSUER_IDENTITY: "VALID",
+      DOCUMENT_INTEGRITY: "VALID",
+    });
+    expect(screen.getByTestId("result-0")).toHaveAttribute("data-valid", "true");
+  });
+
+  it("treats a group with no fragments as invalid rather than silently passing", async () => {
+    mockVerifyDocument.mockResolvedValue(frags({ DOCUMENT_STATUS: "VALID", ISSUER_IDENTITY: "VALID" }));
+    render(<Probe credentials={[credential("a")]} />);
+    await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-loading", "false"));
+    expect(JSON.parse(screen.getByTestId("result-0").getAttribute("data-status")!).DOCUMENT_INTEGRITY).toBe("INVALID");
+    expect(screen.getByTestId("result-0")).toHaveAttribute("data-valid", "false");
+  });
+
+  it("ignores SKIPPED fragments when judging a group", async () => {
+    mockVerifyDocument.mockResolvedValue([
+      { name: "a", type: "DOCUMENT_INTEGRITY", status: "SKIPPED" },
+      { name: "b", type: "DOCUMENT_INTEGRITY", status: "VALID" },
+      ...frags({ DOCUMENT_STATUS: "VALID", ISSUER_IDENTITY: "VALID" }),
+    ]);
+    render(<Probe credentials={[credential("a")]} />);
+    await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-valid", "true"));
+  });
+
+  it("fails a group when any fragment is INVALID or ERROR", async () => {
+    mockVerifyDocument.mockResolvedValue([
+      { name: "a", type: "DOCUMENT_INTEGRITY", status: "VALID" },
+      { name: "b", type: "DOCUMENT_INTEGRITY", status: "ERROR" },
+      ...frags({ DOCUMENT_STATUS: "VALID", ISSUER_IDENTITY: "VALID" }),
+    ]);
+    render(<Probe credentials={[credential("a")]} />);
+    await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-valid", "false"));
+  });
+
+  it("marks a credential that cannot be verified as failing every check", async () => {
+    mockVerifyDocument.mockRejectedValue(new Error("network down"));
+    render(<Probe credentials={[credential("a")]} />);
+    await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-loading", "false"));
+    expect(JSON.parse(screen.getByTestId("result-0").getAttribute("data-status")!)).toEqual({
+      DOCUMENT_STATUS: "INVALID",
+      ISSUER_IDENTITY: "INVALID",
+      DOCUMENT_INTEGRITY: "INVALID",
+    });
+  });
+
+  it("still reports the issuer of a credential that failed to verify", async () => {
+    mockVerifyDocument.mockRejectedValue(new Error("network down"));
+    render(<Probe credentials={[credential("a", "did:key:xyz")]} />);
+    await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-issuer", "DID:KEY:XYZ"));
+  });
+
+  it("upper-cases the issuer and reads the object form", async () => {
+    render(<Probe credentials={[credential("a", { id: "did:web:example.com" })]} />);
+    await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-issuer", "DID:WEB:EXAMPLE.COM"));
+  });
+
+  it("handles a credential that declares no issuer", async () => {
+    render(<Probe credentials={[{ id: "a" }]} />);
+    await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-loading", "false"));
+    expect(screen.getByTestId("result-0")).toHaveAttribute("data-issuer", "");
+  });
+
+  it("returns nothing, and verifies nothing, for an empty credential list", async () => {
+    render(<Probe credentials={[]} />);
+    await waitFor(() => expect(screen.queryAllByRole("listitem")).toHaveLength(0));
+    expect(mockVerifyDocument).not.toHaveBeenCalled();
+  });
+
+  it("does not re-verify when the caller passes a fresh array of the same credentials", async () => {
+    // The ordinary thing to write is a new array each render. Keying the effect on the array
+    // reference would re-verify, set state, re-render and loop until the heap gave out.
+    const { rerender } = render(<Probe credentials={[credential("a")]} />);
+    await waitFor(() => expect(mockVerifyDocument).toHaveBeenCalledTimes(1));
+    rerender(<Probe credentials={[credential("a")]} />);
+    rerender(<Probe credentials={[credential("a")]} />);
+    await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-loading", "false"));
+    expect(mockVerifyDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-verifies tampered content that kept the same id", async () => {
+    // Tampering edits the claims and leaves id and proof untouched, so keying on the id would
+    // let a tampered credential reuse the untampered one's VALID verdict.
+    const { rerender } = render(<Probe credentials={[{ id: "a", claim: "original" }]} />);
+    await waitFor(() => expect(mockVerifyDocument).toHaveBeenCalledTimes(1));
+    rerender(<Probe credentials={[{ id: "a", claim: "TAMPERED" }]} />);
+    await waitFor(() => expect(mockVerifyDocument).toHaveBeenCalledTimes(2));
+  });
+
+  it("never shows a previous credential set's verdicts against a new one", async () => {
+    const { rerender } = render(<Probe credentials={[credential("a"), credential("b")]} />);
+    await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-loading", "false"));
+
+    mockVerifyDocument.mockReturnValue(new Promise(() => {})); // never settles
+    rerender(<Probe credentials={[credential("c")]} />);
+
+    // The shorter new set must not read the stale results — one entry, pending.
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+    expect(screen.getByTestId("result-0")).toHaveAttribute("data-loading", "true");
+  });
+});

--- a/src/components/CredentialTabs/useCredentialVerification.test.tsx
+++ b/src/components/CredentialTabs/useCredentialVerification.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
+import { interpretFragments } from "@trustvc/trustvc";
 import { useCredentialVerification } from "./useCredentialVerification";
 
 // Must be `mock`-prefixed: jest.mock is hoisted above every other statement in the module.
@@ -125,6 +126,46 @@ describe("useCredentialVerification", () => {
     render(<Probe credentials={[{ id: "a" }]} />);
     await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-loading", "false"));
     expect(screen.getByTestId("result-0")).toHaveAttribute("data-issuer", "");
+  });
+
+  /**
+   * The per-credential tabs and the envelope panel above them must agree about what "valid"
+   * means, or the same document reads green in one place and red in the other. StatusChecks uses
+   * trustvc's interpretFragments; this hook aggregates the fragments itself, so the two policies
+   * are pinned together here rather than left to drift.
+   *
+   * The all-SKIPPED row is the interesting one. tt-verify's isValid requires at least one VALID
+   * fragment — `some(VALID) && every(VALID || SKIPPED)` — so a group where everything skipped is
+   * NOT valid. Treating it as valid, or as "not applicable", would make the tab disagree with the
+   * panel and show a green tick for a check that nothing actually performed.
+   */
+  describe("agrees with interpretFragments, which the envelope panel uses", () => {
+    const cases: Array<{ name: string; statuses: string[] }> = [
+      { name: "single VALID", statuses: ["VALID"] },
+      { name: "VALID alongside SKIPPED", statuses: ["VALID", "SKIPPED"] },
+      { name: "everything SKIPPED", statuses: ["SKIPPED"] },
+      { name: "several SKIPPED", statuses: ["SKIPPED", "SKIPPED"] },
+      { name: "single INVALID", statuses: ["INVALID"] },
+      { name: "VALID alongside INVALID", statuses: ["VALID", "INVALID"] },
+      { name: "single ERROR", statuses: ["ERROR"] },
+      { name: "SKIPPED alongside ERROR", statuses: ["SKIPPED", "ERROR"] },
+    ];
+
+    it.each(cases)("DOCUMENT_STATUS: $name", async ({ statuses }) => {
+      const fragments = [
+        ...statuses.map((status, i) => ({ name: `status-${i}`, type: "DOCUMENT_STATUS", status })),
+        { name: "identity", type: "ISSUER_IDENTITY", status: "VALID" },
+        { name: "integrity", type: "DOCUMENT_INTEGRITY", status: "VALID" },
+      ];
+      mockVerifyDocument.mockResolvedValue(fragments);
+
+      render(<Probe credentials={[credential("a")]} />);
+      await waitFor(() => expect(screen.getByTestId("result-0")).toHaveAttribute("data-loading", "false"));
+
+      const mine = JSON.parse(screen.getByTestId("result-0").getAttribute("data-status")!).DOCUMENT_STATUS;
+      const theirs = interpretFragments(fragments as never).issuedValid;
+      expect(mine).toBe(theirs ? "VALID" : "INVALID");
+    });
   });
 
   it("returns nothing, and verifies nothing, for an empty credential list", async () => {

--- a/src/components/CredentialTabs/useCredentialVerification.ts
+++ b/src/components/CredentialTabs/useCredentialVerification.ts
@@ -1,0 +1,181 @@
+import { useEffect, useState } from "react";
+import { VerificationFragment } from "@trustvc/trustvc";
+import { verifyDocument } from "../../services/verify";
+
+export type CheckStatus = "VALID" | "INVALID";
+
+export interface CredentialVerification {
+  /** Still verifying — checks are not known yet. */
+  loading: boolean;
+  /** Per-fragment-type verdict, keyed the same way the document status panel is. */
+  status: Record<string, CheckStatus>;
+  /** The credential's own issuer DID, or undefined when it declares none. */
+  issuer?: string;
+  /** Overall: every group valid. */
+  isValid: boolean;
+}
+
+const groupStatus = (fragments: VerificationFragment[], type: string): CheckStatus => {
+  const group = fragments.filter((f) => f.type === type && f.status !== "SKIPPED");
+  if (group.length === 0) return "INVALID";
+  if (group.some((f) => f.status === "INVALID" || f.status === "ERROR")) return "INVALID";
+  return group.some((f) => f.status === "VALID") ? "VALID" : "INVALID";
+};
+
+/**
+ * The credential's issuer DID, upper-cased to match how every other identity in the verify UI
+ * is rendered (IssuedBy does the same for a standalone credential and for the presentation
+ * holder).
+ */
+const readIssuer = (credential: any): string | undefined => {
+  const issuer = credential?.issuer;
+  const id = typeof issuer === "string" ? issuer : issuer?.id;
+  return id?.toUpperCase();
+};
+
+const PENDING: CredentialVerification = {
+  loading: true,
+  status: {},
+  isValid: false,
+};
+
+/**
+ * How long one credential's verification may run before it is reported as failed.
+ *
+ * verifyDocument resolves DID documents and fetches revocation status lists over the network,
+ * and takes no abort signal — so a request that never settles would otherwise leave the tab
+ * spinning for the life of the page. The ceiling is deliberately generous: a did:web issuer
+ * plus a status list is several round trips on a cold cache, and a timeout here is
+ * indistinguishable to the user from a genuine failure.
+ */
+const VERIFY_TIMEOUT_MS = 60_000;
+
+/**
+ * Rejects if `promise` has not settled within `ms`.
+ *
+ * The underlying work cannot be cancelled — verifyDocument exposes no signal — so this bounds
+ * only how long the UI waits on it, not the request itself.
+ */
+const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("verification timed out")), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+
+interface VerificationState {
+  /** The credential set `results` describes — see credentialsKey below. */
+  key: string;
+  results: CredentialVerification[];
+}
+
+const FAILED = (credential: any): CredentialVerification => ({
+  loading: false,
+  status: {
+    DOCUMENT_STATUS: "INVALID",
+    ISSUER_IDENTITY: "INVALID",
+    DOCUMENT_INTEGRITY: "INVALID",
+  },
+  issuer: readIssuer(credential),
+  isValid: false,
+});
+
+/**
+ * Verifies each credential embedded in a presentation on its own.
+ *
+ * The presentation's own fragments are aggregates — one verdict covering every embedded
+ * credential — so they cannot say which credential failed, or fill in a per-credential panel.
+ * Only DOCUMENT_INTEGRITY carries any per-credential detail, and none of them attribute status
+ * or issuer. Running each credential through verifyDocument gives the real three checks for
+ * each, which is what the per-credential panel reports.
+ *
+ * These results are for DISPLAY. The presentation's own fragments remain the source of truth
+ * for the overall verdict — they additionally check holder binding and the presentation proof,
+ * which verifying a credential in isolation cannot see.
+ */
+export const useCredentialVerification = (credentials: any[]): CredentialVerification[] => {
+  const [state, setState] = useState<VerificationState>({ key: "", results: [] });
+
+  /**
+   * Identity of the credential SET, not of the array holding it.
+   *
+   * Keying the effect on `credentials` itself means any caller passing a fresh array each
+   * render — the ordinary thing to write — re-runs verification, sets state, re-renders and
+   * loops until the heap gives out. This key only changes when the credentials do.
+   *
+   * It must cover the whole CONTENT, not an identifier. Keying on `id` (falling back to a slice
+   * of `proofValue`) lets a tampered credential reuse the verdict of the untampered one:
+   * tampering edits the claims and leaves the id and the proof untouched, so the key would be
+   * identical while the document was not, and the tab would keep showing the stale VALID.
+   *
+   * Stringifying a few KB per render costs nothing next to the verification it guards.
+   */
+  const credentialsKey = JSON.stringify(credentials);
+
+  useEffect(() => {
+    if (credentials.length === 0) {
+      setState({ key: credentialsKey, results: [] });
+      return;
+    }
+
+    let cancelled = false;
+
+    Promise.all(
+      credentials.map(async (credential) => {
+        try {
+          const fragments = (await withTimeout(
+            Promise.resolve(verifyDocument(credential)),
+            VERIFY_TIMEOUT_MS
+          )) as VerificationFragment[];
+          const status = {
+            DOCUMENT_STATUS: groupStatus(fragments, "DOCUMENT_STATUS"),
+            ISSUER_IDENTITY: groupStatus(fragments, "ISSUER_IDENTITY"),
+            DOCUMENT_INTEGRITY: groupStatus(fragments, "DOCUMENT_INTEGRITY"),
+          };
+          return {
+            loading: false,
+            status,
+            issuer: readIssuer(credential),
+            isValid: Object.values(status).every((s) => s === "VALID"),
+          };
+        } catch {
+          // A credential that cannot be verified at all — including one whose verification
+          // outran VERIFY_TIMEOUT_MS — is reported as failing every check rather than silently
+          // showing nothing or spinning forever.
+          return FAILED(credential);
+        }
+      })
+    ).then((settled) => {
+      if (!cancelled) setState({ key: credentialsKey, results: settled });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // Deliberately keyed on the derived identity rather than the array reference — see
+    // credentialsKey above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [credentialsKey]);
+
+  /**
+   * Pending is derived HERE, during render, not assigned in the effect above.
+   *
+   * Effects run after paint, so seeding the pending state there leaves one render with no
+   * results at all: every check reads `undefined`, falls through to its INVALID branch, and a
+   * red cross flashes before the spinner on every presentation. On a change of presentation it
+   * is worse than a flash — the state still holds the PREVIOUS set's verdicts, so a stale VALID
+   * sits against a new credential, and a shorter new set reads past the end.
+   *
+   * Stamping the results with the set they describe fixes both: they are returned only when
+   * they belong to the credentials being rendered, and everything else is pending.
+   */
+  return state.key === credentialsKey ? state.results : credentials.map(() => PENDING);
+};

--- a/src/components/DocumentDropzone/DetailedErrors/DetailedErrors.test.tsx
+++ b/src/components/DocumentDropzone/DetailedErrors/DetailedErrors.test.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import fs from "fs";
+import path from "path";
 import { render, screen } from "@testing-library/react";
 import { DetailedErrors } from "./DetailedErrors";
 import { errorMessages } from "@trustvc/trustvc";
@@ -197,5 +199,89 @@ describe("DetailedErrors", () => {
     expect(screen.queryByText(MESSAGES[TYPES.IDENTITY].failureMessage)).not.toBeInTheDocument();
     expect(screen.queryByText(MESSAGES[TYPES.CLIENT_NETWORK_ERROR].failureTitle)).toBeInTheDocument();
     expect(screen.queryByText(MESSAGES[TYPES.CLIENT_NETWORK_ERROR].failureMessage)).toBeInTheDocument();
+  });
+});
+
+describe("DetailedErrors — Verifiable Presentation", () => {
+  const presentation = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "../../../test/fixture/w3c/presentations/valid/two_credentials.json"), "utf8")
+  );
+
+  /** A presentation fragment set where the named fragment failed with `reason`. */
+  const vpFragments = (name: string, reason: string): VerificationFragment[] =>
+    [
+      { name: "W3CVpSignatureIntegrity", type: "DOCUMENT_INTEGRITY", status: "VALID" },
+      { name: "W3CVpCredentialStatus", type: "DOCUMENT_STATUS", status: "VALID" },
+      { name: "W3CVpIssuerIdentity", type: "ISSUER_IDENTITY", status: "VALID" },
+    ].map((f) => (f.name === name ? { ...f, status: "INVALID", reason: { message: reason } } : f)) as any;
+
+  it("reports exactly one error, not the OpenAttestation-shaped set", () => {
+    render(
+      <DetailedErrors
+        verificationStatus={vpFragments("W3CVpSignatureIntegrity", 'Presentation is not signed (no holder "proof").')}
+        verificationError={null}
+        document={presentation}
+      />
+    );
+    expect(screen.getAllByRole("heading")).toHaveLength(1);
+  });
+
+  it("does not call an unsigned presentation tampered", () => {
+    // errorMessageHandling was written for OpenAttestation: it sees an invalid DOCUMENT_INTEGRITY
+    // and returns HASH, which would tell the user the document was tampered with.
+    render(
+      <DetailedErrors
+        verificationStatus={vpFragments("W3CVpSignatureIntegrity", 'Presentation is not signed (no holder "proof").')}
+        verificationError={null}
+        document={presentation}
+      />
+    );
+    expect(screen.getByText(/not signed, so the presenter cannot prove/i)).toBeInTheDocument();
+    expect(screen.queryByText(errorMessages.MESSAGES[errorMessages.TYPES.HASH].failureMessage)).not.toBeInTheDocument();
+  });
+
+  it("names the credential at fault when the document is supplied", () => {
+    render(
+      <DetailedErrors
+        verificationStatus={vpFragments("W3CVpCredentialStatus", "Embedded credential at index 1 has been revoked.")}
+        verificationError={null}
+        document={presentation}
+      />
+    );
+    expect(screen.getByText(/Credential 2 \("BILL OF LADING"\)/)).toBeInTheDocument();
+  });
+
+  it("falls back to the position when no document is supplied", () => {
+    render(
+      <DetailedErrors
+        verificationStatus={vpFragments("W3CVpCredentialStatus", "Embedded credential at index 1 has been revoked.")}
+        verificationError={null}
+      />
+    );
+    expect(screen.getByText(/Credential 2/)).toBeInTheDocument();
+    expect(screen.queryByText(/BILL OF LADING/)).not.toBeInTheDocument();
+  });
+
+  it("uses the established copy where it already fits", () => {
+    render(
+      <DetailedErrors
+        verificationStatus={vpFragments("W3CVpSignatureIntegrity", "Invalid signature.")}
+        verificationError={null}
+        document={presentation}
+      />
+    );
+    const hash = errorMessages.MESSAGES[errorMessages.TYPES.HASH];
+    expect(screen.getByText(hash.failureTitle)).toBeInTheDocument();
+    expect(screen.getByText(hash.failureMessage)).toBeInTheDocument();
+  });
+
+  it("leaves credential documents on the existing path", () => {
+    render(
+      <DetailedErrors
+        verificationStatus={whenDocumentHashInvalidAndNotIssued as VerificationFragment[]}
+        verificationError={null}
+      />
+    );
+    expect(screen.getAllByRole("heading").length).toBeGreaterThan(1);
   });
 });

--- a/src/components/DocumentDropzone/DetailedErrors/DetailedErrors.tsx
+++ b/src/components/DocumentDropzone/DetailedErrors/DetailedErrors.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from "react";
 import { VerificationFragment } from "@trustvc/trustvc";
 import { errorMessages, errorMessageHandling } from "@trustvc/trustvc";
+import { getPresentationError } from "../../../utils/presentationErrors";
 
 export const DetailedError: FunctionComponent<{ title: string; message: string }> = ({ title, message }) => {
   return (
@@ -17,8 +18,33 @@ export const DetailedError: FunctionComponent<{ title: string; message: string }
 export const DetailedErrors: FunctionComponent<{
   verificationStatus: VerificationFragment[] | null;
   verificationError: string | null;
-}> = ({ verificationStatus, verificationError }) => {
+  /**
+   * The document that was verified. Only needed for a Verifiable Presentation, whose error copy
+   * names the embedded credential at fault by the label its tab shows.
+   */
+  document?: unknown;
+}> = ({ verificationStatus, verificationError, document }) => {
   const { MESSAGES } = errorMessages;
+
+  /**
+   * A failing presentation reports one accurate error rather than the OpenAttestation-shaped set
+   * below. errorMessageHandling was written for OpenAttestation: it sees an invalid
+   * DOCUMENT_INTEGRITY and returns HASH for every presentation failure, so an expired or unsigned
+   * presentation would be reported as "Document has been tampered with".
+   */
+  const presentationError = getPresentationError(verificationStatus, document);
+  if (presentationError) {
+    const messageSet = MESSAGES[presentationError.type];
+    return (
+      <div className="mb-8">
+        <DetailedError
+          title={messageSet.failureTitle}
+          message={presentationError.message ?? messageSet.failureMessage}
+        />
+      </div>
+    );
+  }
+
   const errors: string[] = [...(verificationStatus ? errorMessageHandling(verificationStatus) : [])];
   if (verificationError) {
     if (Array.isArray(verificationError)) {

--- a/src/components/DocumentDropzone/Views/ViewVerificationError.tsx
+++ b/src/components/DocumentDropzone/Views/ViewVerificationError.tsx
@@ -10,7 +10,7 @@ interface ViewVerificationErrorProps {
 }
 
 export const ViewVerificationError: FunctionComponent<ViewVerificationErrorProps> = ({ resetData }) => {
-  const { verificationStatus, verificationError } = useSelector((state: RootState) => state.certificate);
+  const { verificationStatus, verificationError, rawModified } = useSelector((state: RootState) => state.certificate);
 
   return (
     <div>
@@ -19,7 +19,11 @@ export const ViewVerificationError: FunctionComponent<ViewVerificationErrorProps
         alt="Document Dropzone TradeTrust"
         src="/static/images/dropzone/dropzone_illustration.svg"
       />
-      <DetailedErrors verificationStatus={verificationStatus} verificationError={verificationError} />
+      <DetailedErrors
+        verificationStatus={verificationStatus}
+        verificationError={verificationError}
+        document={rawModified}
+      />
 
       <div className="flex flex-col xs:flex-row justify-center gap-2 mt-4">
         <a

--- a/src/components/DocumentStatus/DocumentStatus.test.tsx
+++ b/src/components/DocumentStatus/DocumentStatus.test.tsx
@@ -1,10 +1,13 @@
 import { render, screen } from "@testing-library/react";
 import { SignedVerifiableCredential, v2, wrapOADocument } from "@trustvc/trustvc";
 import React from "react";
+import fs from "fs";
+import path from "path";
 import { Provider } from "react-redux";
 import { configureStore } from "../../store";
 import { WrappedOrSignedOpenAttestationDocument } from "../../utils/shared";
 import { DocumentStatus } from "./DocumentStatus";
+import { DOCUMENT_SCHEMA, DocumentSchemaType } from "../../reducers/certificate";
 import { ProviderContextProvider } from "../../common/contexts/provider";
 import { getSupportedChainInfo } from "../../common/utils/chain-utils";
 import w3cDoc from "../../test/fixture/local/w3c/v2_tr_er_ECDSA_Derived.json";
@@ -250,6 +253,58 @@ describe("DocumentStatus", () => {
 
         expect(screen.queryByText("Issued by:")).not.toBeInTheDocument();
       });
+    });
+  });
+
+  /**
+   * The demo keeps its document in demoVerify while AssetManagementTags reads documentSchema from
+   * the certificate slice, which the demo verification flow never populates. A presentation shown
+   * through the demo therefore had a correct credential count beside a missing version tag —
+   * the count is derived from the displayed document, the tag was not.
+   */
+  describe("Verifiable Presentation on the demo path", () => {
+    const presentation = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "../../test/fixture/w3c/presentations/valid/two_credentials.json"), "utf8")
+    );
+
+    const vpFragments = [
+      { name: "W3CVpSignatureIntegrity", type: "DOCUMENT_INTEGRITY", status: "VALID" },
+      { name: "W3CVpCredentialStatus", type: "DOCUMENT_STATUS", status: "VALID" },
+      { name: "W3CVpIssuerIdentity", type: "ISSUER_IDENTITY", status: "VALID" },
+    ];
+
+    /** The demo slice holds the document; the certificate slice holds whatever schema is left. */
+    const renderDemo = (certificateSchema: DocumentSchemaType) =>
+      render(
+        <ProviderContextProvider defaultChainId={1337} networks={getSupportedChainInfo()}>
+          <Provider
+            store={configureStore({
+              demoVerify: { rawModifiedDocument: presentation, verificationStatus: vpFragments },
+              certificate: { documentSchema: certificateSchema },
+            })}
+          >
+            <DocumentStatus isMagicDemo setShowEndorsementChain={mockSetShowEndorsementChain} />
+          </Provider>
+        </ProviderContextProvider>
+      );
+
+    it.each([
+      ["no schema recorded", null],
+      ["a stale credential schema", DOCUMENT_SCHEMA.W3C_VC_2_0],
+      ["a stale presentation schema of the wrong version", DOCUMENT_SCHEMA.W3C_VP_1_1],
+    ])("tags the envelope correctly with %s in the certificate slice", (_label, certificateSchema) => {
+      renderDemo(certificateSchema as DocumentSchemaType);
+
+      expect(screen.getByText("W3C VP V2.0")).toBeInTheDocument();
+      expect(screen.getByText("2 Credentials")).toBeInTheDocument();
+      expect(screen.queryByText("W3C VC V2.0")).not.toBeInTheDocument();
+      expect(screen.queryByText("W3C VP V1.1")).not.toBeInTheDocument();
+    });
+
+    it("names the holder as presenter rather than an issuer", () => {
+      renderDemo(null);
+      expect(screen.getByText("Presented by:")).toBeInTheDocument();
+      expect(screen.getByText(presentation.holder.toUpperCase())).toBeInTheDocument();
     });
   });
 });

--- a/src/components/DocumentStatus/DocumentStatus.tsx
+++ b/src/components/DocumentStatus/DocumentStatus.tsx
@@ -5,7 +5,7 @@ import { IssuedBy } from "./IssuedBy";
 import { StatusChecks } from "./StatusChecks";
 import { AssetManagementTags } from "../AssetManagementPanel/AssetManagementTags";
 import { AssetInformationPanel } from "../AssetManagementPanel/AssetInformationPanel";
-import { getPresentationCredentials, isVerifiablePresentation } from "../../utils/presentation";
+import { getPresentationCredentials, getW3CVersionLabel, isVerifiablePresentation } from "../../utils/presentation";
 
 interface DocumentStatusProps {
   isMagicDemo?: boolean;
@@ -47,6 +47,7 @@ export const DocumentStatus: FunctionComponent<DocumentStatusProps> = ({
           isTransferableDocument={isTransferableDocument}
           isObligation={isObligation}
           presentationCredentialCount={isPresentation ? getPresentationCredentials(document).length : undefined}
+          presentationVersionLabel={isPresentation ? getW3CVersionLabel(document) : undefined}
         />
       </div>
       <div className="col-span-1">

--- a/src/components/DocumentStatus/DocumentStatus.tsx
+++ b/src/components/DocumentStatus/DocumentStatus.tsx
@@ -5,6 +5,7 @@ import { IssuedBy } from "./IssuedBy";
 import { StatusChecks } from "./StatusChecks";
 import { AssetManagementTags } from "../AssetManagementPanel/AssetManagementTags";
 import { AssetInformationPanel } from "../AssetManagementPanel/AssetInformationPanel";
+import { getPresentationCredentials, isVerifiablePresentation } from "../../utils/presentation";
 
 interface DocumentStatusProps {
   isMagicDemo?: boolean;
@@ -29,6 +30,8 @@ export const DocumentStatus: FunctionComponent<DocumentStatusProps> = ({
 
   if (!document || !verificationStatus) return null;
 
+  const isPresentation = isVerifiablePresentation(document);
+
   return (
     <div
       id="document-status"
@@ -40,10 +43,14 @@ export const DocumentStatus: FunctionComponent<DocumentStatusProps> = ({
           verificationStatus={verificationStatus}
           document={document}
         />
-        <AssetManagementTags isTransferableDocument={isTransferableDocument} isObligation={isObligation} />
+        <AssetManagementTags
+          isTransferableDocument={isTransferableDocument}
+          isObligation={isObligation}
+          presentationCredentialCount={isPresentation ? getPresentationCredentials(document).length : undefined}
+        />
       </div>
       <div className="col-span-1">
-        <StatusChecks verificationStatus={verificationStatus} />
+        <StatusChecks verificationStatus={verificationStatus} isPresentation={isPresentation} />
       </div>
       {isTransferableDocument && (
         <div className="col-span-1">

--- a/src/components/DocumentStatus/IssuedBy.test.tsx
+++ b/src/components/DocumentStatus/IssuedBy.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { v2, wrapOADocument } from "@trustvc/trustvc";
 import React from "react";
+import fs from "fs";
+import path from "path";
 import { WrappedOrSignedOpenAttestationDocument } from "../../utils/shared";
 import { IssuedBy } from "./IssuedBy";
 
@@ -143,5 +145,39 @@ describe("IssuedBy", () => {
   it("should not render when verificationStatus is null", () => {
     const { container } = render(<IssuedBy verificationStatus={null as any} document={document} />);
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("IssuedBy — Verifiable Presentation", () => {
+  const presentation = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "../../test/fixture/w3c/presentations/valid/two_credentials.json"), "utf8")
+  );
+
+  // Any non-empty fragment set: IssuedBy only uses it to decide whether to render at all, and
+  // for a presentation it reads the holder off the document rather than off the fragments.
+  const fragments = [{ name: "W3CVpIssuerIdentity", type: "ISSUER_IDENTITY", status: "VALID" }] as any;
+
+  it('labels the identity "Presented by", because a presentation is asserted by its holder', () => {
+    render(<IssuedBy verificationStatus={fragments} document={presentation} />);
+    expect(screen.getByText("Presented by:")).toBeInTheDocument();
+    expect(screen.queryByText("Issued by:")).not.toBeInTheDocument();
+  });
+
+  it("shows the holder, not an issuer — the envelope has no issuer of its own", () => {
+    render(<IssuedBy verificationStatus={fragments} document={presentation} />);
+    expect(screen.getByText(presentation.holder.toUpperCase())).toBeInTheDocument();
+  });
+
+  it('overrides the caller\'s title, since "Issued by" would be wrong for a presentation', () => {
+    render(<IssuedBy verificationStatus={fragments} document={presentation} title="Demo issued by" />);
+    expect(screen.getByText("Presented by:")).toBeInTheDocument();
+    expect(screen.queryByText("Demo issued by:")).not.toBeInTheDocument();
+  });
+
+  it("falls back to Unknown when the presentation declares no holder", () => {
+    const noHolder = { ...presentation };
+    delete noHolder.holder;
+    render(<IssuedBy verificationStatus={fragments} document={noHolder as any} />);
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
   });
 });

--- a/src/components/DocumentStatus/IssuedBy.tsx
+++ b/src/components/DocumentStatus/IssuedBy.tsx
@@ -12,6 +12,7 @@ import {
 } from "@trustvc/trustvc";
 import React, { FunctionComponent } from "react";
 import { WrappedOrSignedOpenAttestationDocument } from "../../utils/shared";
+import { getPresentationHolder, isVerifiablePresentation } from "../../utils/presentation";
 
 interface VerificationFragmentData {
   did: string;
@@ -82,8 +83,15 @@ interface IssuedByProps {
 export const IssuedBy: FunctionComponent<IssuedByProps> = ({ title = "Issued by", verificationStatus, document }) => {
   if (!document || !verificationStatus) return null;
 
+  // A presentation has no issuer of its own: it is asserted by the HOLDER, and each embedded
+  // credential carries its own issuer, shown on its own tab. Name the holder here, since that is
+  // who is making the claim to the verifier.
+  const isPresentation = isVerifiablePresentation(document);
+
   let formattedDomainNames;
-  if (isWrappedV2Document(document)) {
+  if (isPresentation) {
+    formattedDomainNames = getPresentationHolder(document);
+  } else if (isWrappedV2Document(document)) {
     formattedDomainNames = getV2FormattedDomainNames(verificationStatus);
   } else if (isWrappedV3Document(document)) {
     formattedDomainNames = getV3IdentityVerificationText(document);
@@ -93,7 +101,7 @@ export const IssuedBy: FunctionComponent<IssuedByProps> = ({ title = "Issued by"
 
   return (
     <div id="issuedby" className="gap-2 flex flex-col">
-      <div className="break-all text-cloud-800">{title}:</div>
+      <div className="break-all text-cloud-800">{isPresentation ? "Presented by" : title}:</div>
       <h4 className="text-cloud-800 leading-none break-all">{formattedDomainNames}</h4>
     </div>
   );

--- a/src/components/DocumentStatus/StatusChecks.test.tsx
+++ b/src/components/DocumentStatus/StatusChecks.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { StatusChecks } from "./StatusChecks";
 import { errorMessages, interpretFragments } from "@trustvc/trustvc";
 import {
@@ -15,7 +15,7 @@ import { configureStore } from "../../store";
 import { v2, wrapOADocument } from "@trustvc/trustvc";
 import { WrappedOrSignedOpenAttestationDocument } from "../../utils/shared";
 
-const { MESSAGES } = errorMessages;
+const { MESSAGES, TYPES } = errorMessages;
 
 // Mock the interpretFragments function
 jest.mock("@trustvc/trustvc", () => {
@@ -171,5 +171,55 @@ describe("StatusChecks", () => {
     expect(screen.queryByText(MESSAGES["HASH"]["failureTitle"])).toBeInTheDocument();
     expect(screen.queryByText(MESSAGES["ISSUED"]["failureTitle"])).toBeInTheDocument();
     expect(screen.queryByText(MESSAGES["IDENTITY"]["failureTitle"])).toBeInTheDocument();
+  });
+});
+
+describe("StatusChecks — Verifiable Presentation", () => {
+  const mockInterpretFragments = interpretFragments as jest.MockedFunction<typeof interpretFragments>;
+  const fragments = [{ name: "W3CVpIssuerIdentity", type: "ISSUER_IDENTITY", status: "VALID" }] as any;
+
+  const renderChecks = (verdicts: { hashValid: boolean; issuedValid: boolean; identityValid: boolean }) => {
+    mockInterpretFragments.mockReturnValue(verdicts as any);
+    return render(<StatusChecks verificationStatus={fragments} isPresentation />);
+  };
+
+  const ALL_VALID = { hashValid: true, issuedValid: true, identityValid: true };
+
+  it("shows only two checks — issuance belongs to each credential, not to the envelope", () => {
+    renderChecks(ALL_VALID);
+    expect(screen.getByText("Presenter's identity has been identified")).toBeInTheDocument();
+    expect(screen.getByText("Presentation has not been tampered with")).toBeInTheDocument();
+    expect(screen.queryByText(MESSAGES[TYPES.ISSUED].successTitle)).not.toBeInTheDocument();
+  });
+
+  it("does not describe the envelope as a document", () => {
+    renderChecks(ALL_VALID);
+    expect(screen.queryByText(/^Document/)).not.toBeInTheDocument();
+  });
+
+  it("reports a failing presenter identity", () => {
+    renderChecks({ ...ALL_VALID, identityValid: false });
+    expect(screen.getByText("Presenter's identity has not been identified")).toBeInTheDocument();
+  });
+
+  it("reports a tampered presentation", () => {
+    renderChecks({ ...ALL_VALID, hashValid: false });
+    expect(screen.getByText("Presentation has been tampered with")).toBeInTheDocument();
+  });
+
+  it("ignores issuedValid entirely — the envelope makes no issuance claim", () => {
+    // A presentation's DOCUMENT_STATUS fragment reports on embedded credentials, so letting it
+    // drive an envelope-level "has been issued" row would misattribute the failure.
+    const { container: withIssued } = renderChecks(ALL_VALID);
+    const validMarkup = withIssued.innerHTML;
+    cleanup();
+    const { container: withoutIssued } = renderChecks({ ...ALL_VALID, issuedValid: false });
+    expect(withoutIssued.innerHTML).toBe(validMarkup);
+  });
+
+  it("still shows all three checks for a plain credential", () => {
+    mockInterpretFragments.mockReturnValue(ALL_VALID as any);
+    render(<StatusChecks verificationStatus={fragments} />);
+    expect(screen.getByText(MESSAGES[TYPES.ISSUED].successTitle)).toBeInTheDocument();
   });
 });

--- a/src/components/DocumentStatus/StatusChecks.tsx
+++ b/src/components/DocumentStatus/StatusChecks.tsx
@@ -6,13 +6,50 @@ import { StatusCheck } from "./StatusCheck";
 
 interface StatusChecksProps {
   verificationStatus: VerificationFragment[];
+  /**
+   * The document being reported on is a Verifiable Presentation envelope rather than a single
+   * credential.
+   */
+  isPresentation?: boolean;
 }
 
-export const StatusChecks: FunctionComponent<StatusChecksProps> = ({ verificationStatus }) => {
+export const StatusChecks: FunctionComponent<StatusChecksProps> = ({ verificationStatus, isPresentation = false }) => {
   if (!verificationStatus?.length) return null;
 
   const { hashValid, issuedValid, identityValid } = interpretFragments(verificationStatus);
   const { MESSAGES, TYPES } = errorMessages;
+
+  /**
+   * A presentation's envelope carries only two meaningful checks. "Document has been issued" is a
+   * per-credential question — issuance belongs to each embedded credential, which shows its own
+   * three checks on its tab — so it is deliberately absent here.
+   */
+  if (isPresentation) {
+    return (
+      <div className="flex items-start flex-col">
+        <div className="w-auto">
+          <StatusCheck
+            valid={identityValid}
+            messageSet={{
+              ...MESSAGES[TYPES.IDENTITY],
+              successTitle: "Presenter's identity has been identified",
+              failureTitle: "Presenter's identity has not been identified",
+            }}
+          />
+        </div>
+        <div className="w-auto">
+          <StatusCheck
+            valid={hashValid}
+            messageSet={{
+              ...MESSAGES[TYPES.HASH],
+              successTitle: "Presentation has not been tampered with",
+              failureTitle: "Presentation has been tampered with",
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex items-start flex-col">

--- a/src/components/DocumentUtility/DocumentUtility.test.tsx
+++ b/src/components/DocumentUtility/DocumentUtility.test.tsx
@@ -77,3 +77,43 @@ describe("DocumentUtility", () => {
     );
   });
 });
+
+describe("DocumentUtility — download name", () => {
+  const renderUtility = async (props: any) => {
+    await act(async () => {
+      render(<DocumentUtility onPrint={() => {}} selectedTemplate="custom-template" {...props} />);
+    });
+  };
+
+  it("names the download after the document by default", async () => {
+    const document = await wrapOADocument({ issuers, name: "bah bah black sheep" });
+    await renderUtility({ document });
+    expect(screen.getByLabelText("document-utility-download")).toHaveAttribute("download", "bah bah black sheep.tt");
+  });
+
+  it("falls back to Untitled when the document has no name", async () => {
+    const document = await wrapOADocument({ issuers });
+    await renderUtility({ document });
+    expect(screen.getByLabelText("document-utility-download")).toHaveAttribute("download", "Untitled.tt");
+  });
+
+  it("uses downloadName when given, so presentation tabs cannot overwrite each other", async () => {
+    // Two unnamed credentials in one presentation both fall back to "Untitled" while holding
+    // DIFFERENT content — the override is what keeps their downloads distinct.
+    const document = await wrapOADocument({ issuers });
+    await renderUtility({ document, downloadName: "presentation-chafta-coo" });
+    expect(screen.getByLabelText("document-utility-download")).toHaveAttribute(
+      "download",
+      "presentation-chafta-coo.tt"
+    );
+  });
+
+  it("lets downloadName win over the document's own name", async () => {
+    const document = await wrapOADocument({ issuers, name: "bah bah black sheep" });
+    await renderUtility({ document, downloadName: "presentation-bill-of-lading" });
+    expect(screen.getByLabelText("document-utility-download")).toHaveAttribute(
+      "download",
+      "presentation-bill-of-lading.tt"
+    );
+  });
+});

--- a/src/components/DocumentUtility/DocumentUtility.tsx
+++ b/src/components/DocumentUtility/DocumentUtility.tsx
@@ -10,6 +10,11 @@ interface DocumentUtilityProps {
   document: WrappedOrSignedOpenAttestationDocument | SignedVerifiableCredential;
   onPrint: () => void;
   selectedTemplate: string;
+  /**
+   * Overrides the download name (extension excluded). Used for a credential inside a
+   * presentation, where the document's own `name` is not unique across tabs.
+   */
+  downloadName?: string;
 }
 
 interface DocumentWithAdditionalMetadata extends v2.OpenAttestationDocument {
@@ -21,7 +26,12 @@ interface DocumentWithAdditionalMetadata extends v2.OpenAttestationDocument {
   };
 }
 
-export const DocumentUtility: FunctionComponent<DocumentUtilityProps> = ({ document, onPrint, selectedTemplate }) => {
+export const DocumentUtility: FunctionComponent<DocumentUtilityProps> = ({
+  document,
+  onPrint,
+  selectedTemplate,
+  downloadName,
+}) => {
   const [qrCodePopover, setQrCodePopover] = useState(false);
   const documentWithMetadata = getOpenAttestationData(
     document as WrappedOrSignedOpenAttestationDocument
@@ -30,7 +40,7 @@ export const DocumentUtility: FunctionComponent<DocumentUtilityProps> = ({ docum
   const { name } = (isRawV3Document(documentWithMetadata) as any)
     ? documentWithMetadata.credentialSubject
     : documentWithMetadata;
-  const fileName = name ?? "Untitled";
+  const fileName = downloadName ?? name ?? "Untitled";
   const qrcodeUrl = getQRCodeLink(document);
   const templateURL = getTemplateUrl(document);
   const imageSettings: ImageSettings = {

--- a/src/components/MagicDropzone/MagicDropzone.tsx
+++ b/src/components/MagicDropzone/MagicDropzone.tsx
@@ -21,7 +21,9 @@ interface MagicDropzoneViewProps {
 }
 
 const MagicDropzoneView: FunctionComponent<MagicDropzoneViewProps> = ({ isPending, isError, resetDocument }) => {
-  const { verificationStatus, verificationError } = useSelector((state: RootState) => state.demoVerify);
+  const { verificationStatus, verificationError, rawModifiedDocument } = useSelector(
+    (state: RootState) => state.demoVerify
+  );
 
   switch (true) {
     case isPending:
@@ -42,7 +44,11 @@ const MagicDropzoneView: FunctionComponent<MagicDropzoneViewProps> = ({ isPendin
               <p className="text-2xl">This document is not valid</p>
             </div>
           </div>
-          <DetailedErrors verificationStatus={verificationStatus} verificationError={verificationError} />
+          <DetailedErrors
+            verificationStatus={verificationStatus}
+            verificationError={verificationError}
+            document={rawModifiedDocument}
+          />
           <a
             href={URLS.FAQ}
             target="_blank"

--- a/src/components/ObfuscatedMessage/ObfuscatedMessage.race.test.tsx
+++ b/src/components/ObfuscatedMessage/ObfuscatedMessage.race.test.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import certificateReducer from "../../reducers/certificate";
+import { ObfuscatedMessage } from "./ObfuscatedMessage";
+import ObfuscatedDocument from "../../test/fixture/local/v2/invoice-obfuscated-document.json";
+import UnobfuscatedDocument from "../../test/fixture/local/v2/invoice.json";
+import { WrappedOrSignedOpenAttestationDocument } from "../../utils/shared";
+
+// The compiled @trustvc/trustvc exports are non-configurable getters — jest.spyOn on them throws.
+// Use a jest.mock factory instead (precedented in StatusChecks.test.tsx / sagas/certificate.test.js).
+// Kept in its own file so the sibling suite keeps exercising the real isObfuscated.
+const mockIsObfuscated = jest.fn();
+jest.mock("@trustvc/trustvc", () => {
+  const original = jest.requireActual("@trustvc/trustvc");
+  return { ...original, isObfuscated: (...args: unknown[]) => mockIsObfuscated(...args) };
+});
+
+const createStore = () =>
+  configureStore({
+    reducer: { certificate: certificateReducer },
+    preloadedState: {
+      certificate: {
+        raw: null,
+        rawModified: null,
+        filename: "",
+        providerOrSigner: null,
+        tokenRegistryVersion: null,
+        documentSchema: null,
+        verificationPending: false,
+        verificationStatus: null,
+        verificationError: null,
+        retrieveCertificateByActionState: "INITIAL" as const,
+        retrieveCertificateByActionError: null,
+        keyId: null,
+      },
+    },
+  });
+
+/** A promise that settles only when told to, so a check can be left deliberately in flight. */
+const deferred = () => {
+  let resolve!: (value: boolean) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<boolean>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const message = (document: unknown) => (
+  <Provider store={createStore()}>
+    <ObfuscatedMessage document={document as WrappedOrSignedOpenAttestationDocument} />
+  </Provider>
+);
+
+describe("ObfuscatedMessage — a result arriving for a document no longer shown", () => {
+  let consoleError: jest.SpyInstance;
+  let consoleWarn: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockIsObfuscated.mockReset();
+    consoleError = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+    consoleWarn.mockRestore();
+  });
+
+  const unmountWarnings = () =>
+    consoleError.mock.calls.filter((args) => String(args[0]).includes("unmounted component"));
+
+  it("does not set state after unmount", async () => {
+    const pending = deferred();
+    mockIsObfuscated.mockReturnValue(pending.promise);
+
+    const { unmount } = render(message(ObfuscatedDocument));
+    unmount();
+    await act(async () => {
+      pending.resolve(true);
+    });
+
+    expect(unmountWarnings()).toHaveLength(0);
+  });
+
+  it("does not set state after unmount when the check rejects", async () => {
+    const pending = deferred();
+    mockIsObfuscated.mockReturnValue(pending.promise);
+
+    const { unmount } = render(message(ObfuscatedDocument));
+    unmount();
+    await act(async () => {
+      pending.reject(new Error("unsupported document type"));
+    });
+
+    expect(unmountWarnings()).toHaveLength(0);
+  });
+
+  it("ignores a stale result that settles after the document changed", async () => {
+    // The first check is still in flight when the document changes. Whichever settled LAST used
+    // to win, so the OLD document's verdict could overwrite the new one's.
+    const first = deferred();
+    const second = deferred();
+    mockIsObfuscated.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const { rerender } = render(message(ObfuscatedDocument));
+    rerender(message(UnobfuscatedDocument));
+
+    // The NEW document is not obfuscated; the OLD one then resolves saying it was.
+    await act(async () => {
+      second.resolve(false);
+      first.resolve(true);
+    });
+
+    expect(mockIsObfuscated).toHaveBeenCalledTimes(2);
+    expect(screen.queryByTestId("obfuscation-info")).not.toBeInTheDocument();
+  });
+
+  it("ignores a stale rejection that settles after the document changed", async () => {
+    const first = deferred();
+    const second = deferred();
+    mockIsObfuscated.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const { rerender } = render(message(UnobfuscatedDocument));
+    rerender(message(ObfuscatedDocument));
+
+    await act(async () => {
+      second.resolve(true);
+      first.reject(new Error("boom"));
+    });
+
+    // The late failure must not clear the current document's notice.
+    expect(screen.getByTestId("obfuscation-info")).toBeInTheDocument();
+  });
+
+  it("still reports the current document normally", async () => {
+    mockIsObfuscated.mockResolvedValue(true);
+    render(message(ObfuscatedDocument));
+    await act(async () => undefined);
+    expect(screen.getByTestId("obfuscation-info")).toBeInTheDocument();
+  });
+});

--- a/src/components/ObfuscatedMessage/ObfuscatedMessage.race.test.tsx
+++ b/src/components/ObfuscatedMessage/ObfuscatedMessage.race.test.tsx
@@ -136,6 +136,30 @@ describe("ObfuscatedMessage — a result arriving for a document no longer shown
     expect(screen.getByTestId("obfuscation-info")).toBeInTheDocument();
   });
 
+  it("clears the previous notice while the new document is being checked", async () => {
+    // The cancellation guard stops a stale result overwriting a fresh one, but the last verdict
+    // stayed on screen while the new check ran — so switching documents briefly showed the
+    // previous document's obfuscation notice against the new one.
+    const first = deferred();
+    const second = deferred();
+    mockIsObfuscated.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+
+    const { rerender } = render(message(ObfuscatedDocument));
+    await act(async () => {
+      first.resolve(true);
+    });
+    expect(screen.getByTestId("obfuscation-info")).toBeInTheDocument();
+
+    // New document, check still in flight: the old notice must not describe it.
+    rerender(message(UnobfuscatedDocument));
+    expect(screen.queryByTestId("obfuscation-info")).not.toBeInTheDocument();
+
+    await act(async () => {
+      second.resolve(false);
+    });
+    expect(screen.queryByTestId("obfuscation-info")).not.toBeInTheDocument();
+  });
+
   it("still reports the current document normally", async () => {
     mockIsObfuscated.mockResolvedValue(true);
     render(message(ObfuscatedDocument));

--- a/src/components/ObfuscatedMessage/ObfuscatedMessage.tsx
+++ b/src/components/ObfuscatedMessage/ObfuscatedMessage.tsx
@@ -15,17 +15,32 @@ export const ObfuscatedMessage: FunctionComponent<ObfuscatedMessageProps> = ({ d
   const [isDocumentObfuscated, setIsDocumentObfuscated] = useState<boolean | null>(null);
 
   useEffect(() => {
+    /**
+     * Guards against a result arriving for a document that is no longer being shown.
+     *
+     * isObfuscated is async and takes no abort signal, so without this the effect had two
+     * faults. Unmounting mid-check set state on a dead component — React's "state update on an
+     * unmounted component" warning. Worse, changing document while a check was in flight left
+     * both running, and whichever settled LAST won: the older document's verdict could overwrite
+     * the newer one's, showing (or hiding) the obfuscation notice against the wrong document.
+     */
+    let cancelled = false;
+
     const checkObfuscation = async () => {
       try {
         const result = await isObfuscated(document);
-        setIsDocumentObfuscated(result);
+        if (!cancelled) setIsDocumentObfuscated(result);
       } catch (error) {
         console.warn("Error checking if document is obfuscated:", error);
-        setIsDocumentObfuscated(false);
+        if (!cancelled) setIsDocumentObfuscated(false);
       }
     };
 
     checkObfuscation();
+
+    return () => {
+      cancelled = true;
+    };
   }, [document]);
 
   // Return null while checking or if not obfuscated

--- a/src/components/ObfuscatedMessage/ObfuscatedMessage.tsx
+++ b/src/components/ObfuscatedMessage/ObfuscatedMessage.tsx
@@ -26,6 +26,13 @@ export const ObfuscatedMessage: FunctionComponent<ObfuscatedMessageProps> = ({ d
      */
     let cancelled = false;
 
+    // Clear the previous document's verdict before checking the new one. The guard below stops a
+    // stale result overwriting a fresh one, but the LAST result stayed on screen while the new
+    // check ran — so switching documents briefly showed the old one's obfuscation notice against
+    // the new document. Showing nothing for that moment is better than describing the wrong
+    // document; the effect only re-runs when the document actually changes.
+    setIsDocumentObfuscated(null);
+
     const checkObfuscation = async () => {
       try {
         const result = await isObfuscated(document);

--- a/src/reducers/certificate.ts
+++ b/src/reducers/certificate.ts
@@ -16,6 +16,10 @@ export const DOCUMENT_SCHEMA = {
   OA_V3: "OA",
   W3C_VC_1_1: "W3C VC 1.1",
   W3C_VC_2_0: "W3C VC 2.0",
+  // A presentation is an envelope, not a credential: it is tagged by the data model of the
+  // envelope itself, and the credentials inside carry their own version tags on their tabs.
+  W3C_VP_1_1: "W3C VP 1.1",
+  W3C_VP_2_0: "W3C VP 2.0",
 } as const;
 
 export type DocumentSchemaType = (typeof DOCUMENT_SCHEMA)[keyof typeof DOCUMENT_SCHEMA] | null;

--- a/src/sagas/certificate.test.js
+++ b/src/sagas/certificate.test.js
@@ -16,6 +16,9 @@ import {
   getObligationRegistryAddress,
 } from "@trustvc/trustvc";
 import { TokenRegistryVersions } from "../constants";
+import { history } from "../history";
+
+jest.mock("../history", () => ({ history: { push: jest.fn() } }));
 
 // The compiled @trustvc/trustvc exports are non-configurable getters — jest.spyOn on them
 // throws. Use a jest.mock factory instead (precedented in StatusChecks.test.tsx / useGaslessActions.test.tsx).
@@ -47,6 +50,25 @@ async function recordSaga(saga, initialAction) {
 
 const { TYPES } = errorMessages;
 
+/**
+ * A real signed credential, used wherever the saga needs a DOCUMENT.
+ *
+ * These tests previously passed `Promise.resolve(<verifier response>)` here, which was wrong
+ * twice over: getCertificate is a SELECTOR, so `yield select()` handed the saga the Promise
+ * itself rather than its value, and the value was a fragment array rather than a document. Every
+ * document predicate therefore read false and getKeyId threw, aborting the run with SERVER_ERROR
+ * — invisibly, because each test only asserted dispatches that happen before that point.
+ */
+const documentToVerify = JSON.parse(
+  require("fs").readFileSync(
+    require("path").join(__dirname, "../test/fixture/w3c/presentations/valid/two_credentials.json"),
+    "utf8"
+  )
+).verifiableCredential[0];
+
+/** getCertificate is a selector: its return value is used as-is, so it must not be a Promise. */
+const mockCertificate = (document) => jest.spyOn(certificate, "getCertificate").mockImplementation(() => document);
+
 describe("verifyCertificate", () => {
   beforeEach(() => {
     jest.resetAllMocks();
@@ -56,9 +78,7 @@ describe("verifyCertificate", () => {
 
   it("should verify the document and change the router to /viewer when verification passes", async () => {
     const initialAction = { type: certificate.types.UPDATE_CERTIFICATE };
-    const getCertificate = jest
-      .spyOn(certificate, "getCertificate")
-      .mockImplementation(() => Promise.resolve(whenDocumentValidAndIssuedByDns));
+    const getCertificate = mockCertificate(documentToVerify);
     const verifyDocument = jest
       .spyOn(verify, "verifyDocument")
       .mockImplementation(() => Promise.resolve(whenDocumentValidAndIssuedByDns));
@@ -70,13 +90,14 @@ describe("verifyCertificate", () => {
       type: certificate.types.VERIFYING_CERTIFICATE_COMPLETED,
       payload: whenDocumentValidAndIssuedByDns,
     });
+    // The test is named for this; it previously asserted nothing about it.
+    expect(history.push).toHaveBeenCalledWith("/viewer");
+    expect(dispatched.map((action) => action.type)).not.toContain(certificate.types.VERIFYING_CERTIFICATE_FAILURE);
   });
 
   it("should verify the document and do not update the router when verification fails", async () => {
     const initialAction = { type: certificate.types.UPDATE_CERTIFICATE };
-    const getCertificate = jest
-      .spyOn(certificate, "getCertificate")
-      .mockImplementation(() => Promise.resolve(whenDocumentHashInvalidAndNotIssued));
+    const getCertificate = mockCertificate(documentToVerify);
     const verifyDocument = jest
       .spyOn(verify, "verifyDocument")
       .mockImplementation(() => Promise.reject(new Error("Failed to verify document")));
@@ -88,13 +109,12 @@ describe("verifyCertificate", () => {
       type: certificate.types.VERIFYING_CERTIFICATE_FAILURE,
       payload: TYPES.SERVER_ERROR,
     });
+    expect(history.push).not.toHaveBeenCalled();
   });
 
   it("dispatches V5 version detection for an obligation document without probing isTokenRegistryV4", async () => {
     const initialAction = { type: certificate.types.UPDATE_CERTIFICATE };
-    jest
-      .spyOn(certificate, "getCertificate")
-      .mockImplementation(() => Promise.resolve(whenDocumentValidAndIssuedByDns));
+    mockCertificate(documentToVerify);
     jest.spyOn(verify, "verifyDocument").mockImplementation(() => Promise.resolve(whenDocumentValidAndIssuedByDns));
     const isTokenRegistryV4Spy = jest.spyOn(shared, "isTokenRegistryV4");
 
@@ -111,9 +131,7 @@ describe("verifyCertificate", () => {
 
   it("keeps classic transferable-record V4/V5 detection unchanged", async () => {
     const initialAction = { type: certificate.types.UPDATE_CERTIFICATE };
-    jest
-      .spyOn(certificate, "getCertificate")
-      .mockImplementation(() => Promise.resolve(whenDocumentValidAndIssuedByDns));
+    mockCertificate(documentToVerify);
     jest.spyOn(verify, "verifyDocument").mockImplementation(() => Promise.resolve(whenDocumentValidAndIssuedByDns));
     const isTokenRegistryV4Spy = jest
       .spyOn(shared, "isTokenRegistryV4")
@@ -128,5 +146,58 @@ describe("verifyCertificate", () => {
     expect(isTokenRegistryV4Spy).toHaveBeenCalledWith("0xTokenRegistryAddress", "0xTokenId");
     expect(getObligationRegistryAddress).not.toHaveBeenCalled();
     expect(dispatched).toContainEqual(certificate.detectingTRCertificateVersion(TokenRegistryVersions.V4));
+  });
+});
+
+describe("verifyCertificate — Verifiable Presentation", () => {
+  const fs = require("fs");
+  const path = require("path");
+  const loadVp = (name) =>
+    JSON.parse(fs.readFileSync(path.join(__dirname, "../test/fixture/w3c/presentations", name), "utf8"));
+
+  const runWith = async (document) => {
+    mockCertificate(document);
+    jest.spyOn(verify, "verifyDocument").mockImplementation(() => Promise.resolve(whenDocumentValidAndIssuedByDns));
+    return recordSaga(verifyCertificate, { type: certificate.types.UPDATE_CERTIFICATE });
+  };
+
+  const schemaOf = (dispatched) => dispatched.find((a) => a.type === certificate.types.UPDATE_DOCUMENT_SCHEMA)?.payload;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    isTransferableRecord.mockReturnValue(false);
+    isObligationRecord.mockReturnValue(false);
+  });
+
+  it("tags a v2.0 presentation envelope by its own data model", async () => {
+    expect(schemaOf(await runWith(loadVp("valid/two_credentials.json")))).toBe(certificate.DOCUMENT_SCHEMA.W3C_VP_2_0);
+  });
+
+  it("tags a v1.1 presentation envelope", async () => {
+    const vp = loadVp("valid/two_credentials.json");
+    vp["@context"] = ["https://www.w3.org/2018/credentials/v1"];
+    expect(schemaOf(await runWith(vp))).toBe(certificate.DOCUMENT_SCHEMA.W3C_VP_1_1);
+  });
+
+  it("does not mistake a presentation for a credential", async () => {
+    const schema = schemaOf(await runWith(loadVp("valid/two_credentials.json")));
+    expect(schema).not.toBe(certificate.DOCUMENT_SCHEMA.W3C_VC_2_0);
+    expect(schema).not.toBe(certificate.DOCUMENT_SCHEMA.OA_V2);
+  });
+
+  it("gets through verification without throwing on a presentation", async () => {
+    // getKeyId reaches getOpenAttestationData, which without its presentation guard falls
+    // through to OpenAttestation's getDocumentData and throws — failing the whole run.
+    const dispatched = await runWith(loadVp("valid/two_credentials.json"));
+    expect(dispatched).toContainEqual({
+      type: certificate.types.VERIFYING_CERTIFICATE_COMPLETED,
+      payload: whenDocumentValidAndIssuedByDns,
+    });
+    expect(dispatched.map((a) => a.type)).not.toContain(certificate.types.VERIFYING_CERTIFICATE_FAILURE);
+  });
+
+  it("still tags a plain credential as a credential", async () => {
+    const [credential] = loadVp("valid/two_credentials.json").verifiableCredential;
+    expect(schemaOf(await runWith(credential))).toBe(certificate.DOCUMENT_SCHEMA.W3C_VC_2_0);
   });
 });

--- a/src/sagas/certificate.ts
+++ b/src/sagas/certificate.ts
@@ -29,6 +29,7 @@ import { processQrCode } from "../services/qrProcessor";
 import { verifyDocument } from "../services/verify";
 import { getLogger } from "../utils/logger";
 import { getKeyId, isTokenRegistryV4 } from "../utils/shared";
+import { getW3CVersionLabel, isVerifiablePresentation } from "../utils/presentation";
 import { ActionPayload } from "./../types";
 import { TokenRegistryVersions } from "../constants";
 
@@ -110,6 +111,7 @@ export function* verifyCertificate(): any {
       isRawV3Document(certificate) || isSignedWrappedV3Document(certificate) || isWrappedV3Document(certificate);
     const isW3CVC = vc.isSignedDocument(certificate) || vc.isRawDocument(certificate);
     const isW3CVCVersion2_0 = isW3CVC ? vc.isSignedDocumentV2_0(certificate) : null;
+    const isW3CVP = isVerifiablePresentation(certificate);
     const keyId = getKeyId(certificate);
     yield put({
       type: types.UPDATE_KEY_ID, // store keyId in saga state
@@ -126,6 +128,10 @@ export function* verifyCertificate(): any {
         ? isW3CVCVersion2_0
           ? DOCUMENT_SCHEMA.W3C_VC_2_0
           : DOCUMENT_SCHEMA.W3C_VC_1_1
+        : isW3CVP
+        ? getW3CVersionLabel(certificate) === "V2.0"
+          ? DOCUMENT_SCHEMA.W3C_VP_2_0
+          : DOCUMENT_SCHEMA.W3C_VP_1_1
         : null,
     });
 

--- a/src/test/fixture/w3c/presentations/invalid/credential_expired.json
+++ b/src/test/fixture/w3c/presentations/invalid/credential_expired.json
@@ -1,0 +1,62 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2",
+    {
+      "validFrom": {
+        "@id": "https://www.w3.org/2018/credentials#validFrom",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "validUntil": {
+        "@id": "https://www.w3.org/2018/credentials#validUntil",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "issuanceDate": {
+        "@id": "https://www.w3.org/2018/credentials#issuanceDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "expirationDate": {
+        "@id": "https://www.w3.org/2018/credentials#expirationDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      }
+    }
+  ],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://trustvc.io/context/bill-of-lading.json"
+      ],
+      "id": "urn:uuid:01a00dce-98aa-7008-b486-91bfecddef3f",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "validUntil": "2026-08-17T03:40:46.441Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "type": ["BillOfLading"],
+        "blNumber": "BL-LAPSING"
+      },
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-17T03:40:38Z",
+        "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhABtxvse-KRbvfSIXdV_uWfSBXkUkOmocwdQlY8YjCpgRZAb_1H2YdRa3hTEuRzqJSNeuSXyQrWsSDszjreipsv1gjgCQDX4VwtIxmwcIQm1M2zHARoZkKGbuyFriKXhHj2jeqfuWDWECmac0txrKTQ2If5VvZh1pUHagL6qNkAyq762RCkh2ehOjDCnlizPhQ3bISMEQo3WrZpa2JspP4JJ5r8OKE--fxWEBp1aoSkYek5FCdptppc2YgDdIFocjAnyaP30ToAC4RRZm3pWVWvzmL9hNTUbc6n4QQ_dnWf-pvGdmalcnEO2GSWECsa0940s0WSgX-yEVgTHDRKSdej5SiMHamVCgGqzdPB6ARlayssMCL_xWHnK9LP4P1I-mRMhuOolRS5QRzbBAfoIQCBAUG"
+      }
+    }
+  ],
+  "holder": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+  "validFrom": "2026-08-17T03:40:38.463Z",
+  "validUntil": "2999-01-01T00:00:00Z",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2026-08-17T03:40:38Z",
+    "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+    "cryptosuite": "ecdsa-rdfc-2019",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "zKhiiEvTzsrddamvcaDnMoT9K34VyUNGtcpaUTSRYyVw2pb7kRWUwLn6QFiPYn4qJaBZRyEhg2fNiN4CEJXhfSYA"
+  }
+}

--- a/src/test/fixture/w3c/presentations/invalid/credential_revoked.json
+++ b/src/test/fixture/w3c/presentations/invalid/credential_revoked.json
@@ -1,0 +1,68 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2",
+    {
+      "validFrom": {
+        "@id": "https://www.w3.org/2018/credentials#validFrom",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "validUntil": {
+        "@id": "https://www.w3.org/2018/credentials#validUntil",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "issuanceDate": {
+        "@id": "https://www.w3.org/2018/credentials#issuanceDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "expirationDate": {
+        "@id": "https://www.w3.org/2018/credentials#expirationDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      }
+    }
+  ],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://trustvc.io/context/bill-of-lading.json"
+      ],
+      "id": "urn:uuid:01a00dce-9b43-7008-b486-e5336cab4e28",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialStatus": {
+        "id": "https://trustvc.github.io/did/credentials/statuslist/2#5",
+        "type": "BitstringStatusListEntry",
+        "statusPurpose": "revocation",
+        "statusListIndex": "5",
+        "statusListCredential": "https://trustvc.github.io/did/credentials/statuslist/2"
+      },
+      "credentialSubject": {
+        "id": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "type": ["BillOfLading"],
+        "blNumber": "BL-REVOKED"
+      },
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-17T03:40:39Z",
+        "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhANDIsGEKMbzPRRwhWpxXHZxmlhdG7kHw1w6dF9f9v0tHQ0azJOgyTIOXpXC-1X9xvEXmDGsBKy_nLUWkD1zyZr1gjgCQDrfSZlZNEFVki8LKDkphE_WE37PdZ_Su2QvfBbbLuGXqDWEBpaq6v2HYCOHyA_ERt85NTElO74SCYklbbHShOkhKmIM4SMQF18pibAOw8robxv3w-vzq62eXFm1eqnRYUt1B2WEAZihj0-bOlFExDNU1RZFNZPrJp8cXwkv4Mi4YJnKUSr8GlFZ2WZwdj49bWwCogEFIT3fzh6YzZi8r7-IXI8sAfWEByBwUhGWT3h0FCkvnAg6NyeSLMh42et3KJcq-aHW0brj4ep8myaDI0hsHPK7dJzsSL7eXYxAErJGn6MzUVuDuAoIgCAwQFBgcJCg"
+      }
+    }
+  ],
+  "holder": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+  "validFrom": "2026-08-17T03:40:39.122Z",
+  "validUntil": "2999-01-01T00:00:00Z",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2026-08-17T03:40:39Z",
+    "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+    "cryptosuite": "ecdsa-rdfc-2019",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z5ihJPXqkHQ1DDbJz51hwLV9ghNfvP4So3rrgL68si8yWXUd65mHmh2BmkdfSEBLEWPfkBzRS8PPNk6nrQ5xDcgnn"
+  }
+}

--- a/src/test/fixture/w3c/presentations/invalid/holder_mismatch.json
+++ b/src/test/fixture/w3c/presentations/invalid/holder_mismatch.json
@@ -1,0 +1,61 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2",
+    {
+      "validFrom": {
+        "@id": "https://www.w3.org/2018/credentials#validFrom",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "validUntil": {
+        "@id": "https://www.w3.org/2018/credentials#validUntil",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "issuanceDate": {
+        "@id": "https://www.w3.org/2018/credentials#issuanceDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "expirationDate": {
+        "@id": "https://www.w3.org/2018/credentials#expirationDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      }
+    }
+  ],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://trustvc.io/context/bill-of-lading.json"
+      ],
+      "id": "urn:uuid:01a00dce-984f-7008-b486-86b425825ae2",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "type": ["BillOfLading"],
+        "blNumber": "BL-0001"
+      },
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-17T03:40:38Z",
+        "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhAbI7S-hhN8ZbAlb6SCQjHN1quKW6tX6HnJxpKbCouNwdkGiYd2pQMdfvSgF6zSZeZ8lxmpOJL-nOiEWwxTGB7vVgjgCQCHpj1mcKE5KUucJehuggAtNRhZ91x__AZg0sBCkpsrQODWEDo1SnotTsxHdYZEPgCk5SaSgiordj3egYwuqLRvLg07Jj0MfbrFFwxE6d6-GNkWJ4pCxKtyDAnGy18uX5vmb9cWECMn7tCxn44TrYI1gddo93daJgEUXxoh_oEbWWD3ys1XbCHV8kNA6R3oZqQH2Jd0eY0P9ay5wDHceAV4eCGLw2vWEDP5rGwp1yCTp3qAK0KtMYvE5sHEGKXbLvx6_XfC6LsGFtXgiybJoeuOeNXs3NieJBlqCOK7g5M_VKYxkHb-ML8oIMCBAU"
+      }
+    }
+  ],
+  "holder": "did:key:zDnaefViN27kW29WAj2kNTzLfux6KXDQCh4MWAvatzRdvVJq3",
+  "validFrom": "2026-08-17T03:40:39.136Z",
+  "validUntil": "2999-01-01T00:00:00Z",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2026-08-17T03:40:39Z",
+    "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+    "cryptosuite": "ecdsa-rdfc-2019",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z43BN5ZD8s2gL956kNKw8KMELhz1z7o21MZaYUxTkLaCakAuxRhJQC95McRjUKVM3xW3T1ZtyCYjMw9J91rKWruSs"
+  }
+}

--- a/src/test/fixture/w3c/presentations/invalid/presentation_expired.json
+++ b/src/test/fixture/w3c/presentations/invalid/presentation_expired.json
@@ -1,0 +1,71 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2",
+    {
+      "validFrom": {
+        "@id": "https://www.w3.org/2018/credentials#validFrom",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "validUntil": {
+        "@id": "https://www.w3.org/2018/credentials#validUntil",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "issuanceDate": {
+        "@id": "https://www.w3.org/2018/credentials#issuanceDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "expirationDate": {
+        "@id": "https://www.w3.org/2018/credentials#expirationDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      }
+    }
+  ],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://w3id.org/security/data-integrity/v2",
+        "https://trustvc.io/context/render-method-context-v2.json",
+        "https://trustvc.io/context/coo.json",
+        "https://trustvc.io/context/attachments-context.json",
+        "https://trustvc.io/context/qrcode-context.json"
+      ],
+      "id": "urn:uuid:019ff40c-5863-777e-a182-06c35732e51f",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zDnaedbEeTFNbJWHSdQ7iYnZFDxoUD7cSCozjeDttkjE7Asnx",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaedbEeTFNbJWHSdQ7iYnZFDxoUD7cSCozjeDttkjE7Asnx",
+        "type": ["Coo"]
+      },
+      "renderMethod": [
+        {
+          "type": "EMBEDDED_RENDERER",
+          "templateName": "CHAFTA_COO",
+          "id": "https://generic-templates.tradetrust.io"
+        }
+      ],
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-12T03:37:57Z",
+        "verificationMethod": "did:key:zDnaedbEeTFNbJWHSdQ7iYnZFDxoUD7cSCozjeDttkjE7Asnx#zDnaedbEeTFNbJWHSdQ7iYnZFDxoUD7cSCozjeDttkjE7Asnx",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhAXJgEanIhgG8jTpd-t4WWu3fN79X5olSyQX2dWMsRttendG-G4qqsvn7QTsxsVTHS_m8WCd-6CQEhfbavCqsBn1gjgCQCF-uTN8mqKy00JjrPHlqU9Keznvj_f9U45A2kO4b2Y4CFWED7O_EZdXWaCerd3anXkQygi1FEnP56rhMe_LABrK8lJe2-mGGhA4H3usiw9cWmAae3rGmjO7t-H7H1W9ih6ICCWECf-wro54nhE-ci5o02RXq2CJ7k2V5AP_eUKqQYd_nCRQN40SHSUje3HkYWMr1cKZ1eW1SdNHEibLTosV7iUy54WEDbWgvck08zB8t3yTjNzq4FlCu6PWod3-nOHoA0K0b0jRMV_9g1gcAJEBT8cMwufVgnWU3qeLZEZcjMaHtpseO2WEDF_gbj6eTvnco45PmUsKrmYz7DOE_tzSujxEyX1gYVcaPgmRK5wJXeMA8ZMlwPyKPgfaA-2Fl0-4CNEHmABisjWEB4iU8Pw-E8ZQK0lt_51zE6pfRT3kX9xAOLTyw4W_AF4BrAstt_Bwv71uK9UYuB_KYHqrLlN-YrUVijBy4ZXMBVoIMDBQc"
+      }
+    }
+  ],
+  "holder": "did:key:zDnaedbEeTFNbJWHSdQ7iYnZFDxoUD7cSCozjeDttkjE7Asnx",
+  "validFrom": "2020-01-01T00:00:00Z",
+  "validUntil": "2021-01-01T00:00:00Z",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2026-08-12T03:37:57Z",
+    "verificationMethod": "did:key:zDnaedbEeTFNbJWHSdQ7iYnZFDxoUD7cSCozjeDttkjE7Asnx#zDnaedbEeTFNbJWHSdQ7iYnZFDxoUD7cSCozjeDttkjE7Asnx",
+    "cryptosuite": "ecdsa-rdfc-2019",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z5oVc1678TLW6crrR52eyt2LGtoRKNBq6sSjwukqu9c8WEXVqRUPPvgTNxZa6RxHkta824v963nLqMn3myyFYG79x"
+  }
+}

--- a/src/test/fixture/w3c/presentations/invalid/tampered_credential.json
+++ b/src/test/fixture/w3c/presentations/invalid/tampered_credential.json
@@ -1,0 +1,61 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2",
+    {
+      "validFrom": {
+        "@id": "https://www.w3.org/2018/credentials#validFrom",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "validUntil": {
+        "@id": "https://www.w3.org/2018/credentials#validUntil",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "issuanceDate": {
+        "@id": "https://www.w3.org/2018/credentials#issuanceDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "expirationDate": {
+        "@id": "https://www.w3.org/2018/credentials#expirationDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      }
+    }
+  ],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://trustvc.io/context/bill-of-lading.json"
+      ],
+      "id": "urn:uuid:01a00dce-984f-7008-b486-86b425825ae2",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "type": ["BillOfLading"],
+        "blNumber": "TAMPERED"
+      },
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-17T03:40:38Z",
+        "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhAbI7S-hhN8ZbAlb6SCQjHN1quKW6tX6HnJxpKbCouNwdkGiYd2pQMdfvSgF6zSZeZ8lxmpOJL-nOiEWwxTGB7vVgjgCQCHpj1mcKE5KUucJehuggAtNRhZ91x__AZg0sBCkpsrQODWEDo1SnotTsxHdYZEPgCk5SaSgiordj3egYwuqLRvLg07Jj0MfbrFFwxE6d6-GNkWJ4pCxKtyDAnGy18uX5vmb9cWECMn7tCxn44TrYI1gddo93daJgEUXxoh_oEbWWD3ys1XbCHV8kNA6R3oZqQH2Jd0eY0P9ay5wDHceAV4eCGLw2vWEDP5rGwp1yCTp3qAK0KtMYvE5sHEGKXbLvx6_XfC6LsGFtXgiybJoeuOeNXs3NieJBlqCOK7g5M_VKYxkHb-ML8oIMCBAU"
+      }
+    }
+  ],
+  "holder": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+  "validFrom": "2026-08-17T03:40:38.625Z",
+  "validUntil": "2999-01-01T00:00:00Z",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2026-08-17T03:40:38Z",
+    "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+    "cryptosuite": "ecdsa-rdfc-2019",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z3ssSMK9tqJg6T77tXjtb4rWzzyPKvTpDczivjjJY15WTmUjQPUv8L6NZLHsANeFHKRdbNZ34LGoUeZsWzDrgyCqb"
+  }
+}

--- a/src/test/fixture/w3c/presentations/invalid/unresolvable_issuer.json
+++ b/src/test/fixture/w3c/presentations/invalid/unresolvable_issuer.json
@@ -1,0 +1,61 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2",
+    {
+      "validFrom": {
+        "@id": "https://www.w3.org/2018/credentials#validFrom",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "validUntil": {
+        "@id": "https://www.w3.org/2018/credentials#validUntil",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "issuanceDate": {
+        "@id": "https://www.w3.org/2018/credentials#issuanceDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "expirationDate": {
+        "@id": "https://www.w3.org/2018/credentials#expirationDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      }
+    }
+  ],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://trustvc.io/context/bill-of-lading.json"
+      ],
+      "id": "urn:uuid:01a00dce-9940-7008-b486-cd8723af519e",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:web:nope.invalid",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "type": ["BillOfLading"],
+        "blNumber": "BL-GHOST"
+      },
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-17T03:40:38Z",
+        "verificationMethod": "did:web:nope.invalid#keys-1",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhA4QIQlmxfTxir3OyzH5HGhFIyEjW13wRw9TYF0HRfX8qdaZVLDiNnruYXbOc2WeBcN5CyUvt9VaB3vQf5c3tNPFgjgCQDO1uA08MwGEfrMmcjAvyKiOLjAmJE7NKQ-HhtTynpUo2DWEA7O_efLwu7nqnQ5t4i8vGB8nqBwHknZvXQ85mMW77Oi8zOHgSpwULKPdVY3pfsCvaLkQlKMkgQdHuKaQDd8LXMWECUeAJ2e_8PvLTndAmZsXu0BPv9bd8xCsgroq1hA1tKBW7dBYLvH_JGzblWGaEUW_LLEju4ka6hVZ2mZiy2cnEbWECp6zrY1EoiNjsu4_Bpa9Q0FTDVPZ35L86lD33BxfZr6ViV6_POv8YrvO9EIuakO5DHqZCZJh55S-rW8OgnkYcLoIMCBAU"
+      }
+    }
+  ],
+  "holder": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+  "validFrom": "2026-08-17T03:40:39.151Z",
+  "validUntil": "2999-01-01T00:00:00Z",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2026-08-17T03:40:39Z",
+    "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+    "cryptosuite": "ecdsa-rdfc-2019",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z4MMooHFop8rPbhNMUQzLMsofWfv8E78r62an3iUqqB8jhTDanAbsooqu2nfLvAQcC4aAgZXVahWcxE78YJNsEomE"
+  }
+}

--- a/src/test/fixture/w3c/presentations/invalid/unsigned.json
+++ b/src/test/fixture/w3c/presentations/invalid/unsigned.json
@@ -1,0 +1,53 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2",
+    {
+      "validFrom": {
+        "@id": "https://www.w3.org/2018/credentials#validFrom",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "validUntil": {
+        "@id": "https://www.w3.org/2018/credentials#validUntil",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "issuanceDate": {
+        "@id": "https://www.w3.org/2018/credentials#issuanceDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "expirationDate": {
+        "@id": "https://www.w3.org/2018/credentials#expirationDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      }
+    }
+  ],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://trustvc.io/context/bill-of-lading.json"
+      ],
+      "id": "urn:uuid:01a00dce-984f-7008-b486-86b425825ae2",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "type": ["BillOfLading"],
+        "blNumber": "BL-0001"
+      },
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-17T03:40:38Z",
+        "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhAbI7S-hhN8ZbAlb6SCQjHN1quKW6tX6HnJxpKbCouNwdkGiYd2pQMdfvSgF6zSZeZ8lxmpOJL-nOiEWwxTGB7vVgjgCQCHpj1mcKE5KUucJehuggAtNRhZ91x__AZg0sBCkpsrQODWEDo1SnotTsxHdYZEPgCk5SaSgiordj3egYwuqLRvLg07Jj0MfbrFFwxE6d6-GNkWJ4pCxKtyDAnGy18uX5vmb9cWECMn7tCxn44TrYI1gddo93daJgEUXxoh_oEbWWD3ys1XbCHV8kNA6R3oZqQH2Jd0eY0P9ay5wDHceAV4eCGLw2vWEDP5rGwp1yCTp3qAK0KtMYvE5sHEGKXbLvx6_XfC6LsGFtXgiybJoeuOeNXs3NieJBlqCOK7g5M_VKYxkHb-ML8oIMCBAU"
+      }
+    }
+  ],
+  "holder": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+  "validFrom": "2026-08-17T03:40:38.625Z",
+  "validUntil": "2999-01-01T00:00:00Z"
+}

--- a/src/test/fixture/w3c/presentations/valid/didweb_issuer.json
+++ b/src/test/fixture/w3c/presentations/valid/didweb_issuer.json
@@ -1,0 +1,123 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2",
+    {
+      "validFrom": {
+        "@id": "https://www.w3.org/2018/credentials#validFrom",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "validUntil": {
+        "@id": "https://www.w3.org/2018/credentials#validUntil",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "issuanceDate": {
+        "@id": "https://www.w3.org/2018/credentials#issuanceDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "expirationDate": {
+        "@id": "https://www.w3.org/2018/credentials#expirationDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      }
+    }
+  ],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://w3id.org/security/data-integrity/v2",
+        "https://trustvc.io/context/render-method-context-v2.json",
+        "https://trustvc.io/context/coo.json",
+        "https://trustvc.io/context/attachments-context.json",
+        "https://trustvc.io/context/qrcode-context.json"
+      ],
+      "id": "urn:uuid:019ff4fe-19ee-7aa0-9b15-5d370d549ade",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:web:trustvc.github.io:did:1",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaeT51jHPNCgWngN7JGS38tGYipQsvjtGJYmDT5wuRzPFXr",
+        "type": ["Coo"],
+        "attachments": [
+          {
+            "filename": "certificate-of-origin.pdf",
+            "mimeType": "application/pdf",
+            "data": "JVBERi0xLjQKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2JqCjIgMCBvYmo8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iagozIDAgb2JqPDwvVHlwZS9QYWdlL1BhcmVudCAyIDAgUi9NZWRpYUJveFswIDAgMjAwIDEwMF0vQ29udGVudHMgNCAwIFIvUmVzb3VyY2VzPDwvRm9udDw8L0YxIDUgMCBSPj4+Pj4+ZW5kb2JqCjQgMCBvYmo8PC9MZW5ndGggNjI+PnN0cmVhbQpCVCAvRjEgMTIgVGYgMjAgNTAgVGQgKFRydXN0VkMgc2FtcGxlIGF0dGFjaG1lbnQpIFRqIEVUCmVuZHN0cmVhbSBlbmRvYmoKNSAwIG9iajw8L1R5cGUvRm9udC9TdWJ0eXBlL1R5cGUxL0Jhc2VGb250L0hlbHZldGljYT4+ZW5kb2JqCnRyYWlsZXI8PC9Sb290IDEgMCBSPj4KJSVFT0Y="
+          },
+          {
+            "filename": "packing-list.txt",
+            "mimeType": "text/plain",
+            "data": "Q2FydG9uIDEtNTAwOiBtYXJpbmUtZ3JhZGUgZWxlY3Ryb25pY3MKR3Jvc3Mgd2VpZ2h0OiA4LDQ1MCBLR1MK"
+          }
+        ]
+      },
+      "renderMethod": [
+        {
+          "type": "EMBEDDED_RENDERER",
+          "templateName": "CHAFTA_COO",
+          "id": "https://generic-templates.tradetrust.io"
+        }
+      ],
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-12T08:02:01Z",
+        "verificationMethod": "did:web:trustvc.github.io:did:1#multikey-1",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhAz1Q57Vmzwi_bWIS-dBHSv5HHLhMRc-Np_vyYnHwUiStnAaX8DuCjbjh0SX4nFkxKM7WYKKAvK-JDYwtEKMIpTVgjgCQDgk0sCj1q1XmlE_BN3k_0A4HOMeaLk407hSzVmTjjsTyNWEDg27rKr-qw-ySO_IO4bsW4zR65k0OfLlpkpm__ifrelNGl2xub73ulUqmw7lOm0JiLjgN6a6EAi2YPqwK0YAoqWEBjc6B3q8DF_yI90UXsVRJgIq92xzupxh1tdiAvK89Uuadr20hTPPNmfYideDufazj7URUfpkHnxu7zBsc212uEWEA6-BBmfUpZuQuoEk8euQmuM5sOHVAPDr2v_XG_66YMcUu_Y_42k_ZEhaFvhxXgw8cbFVco1IvkVnpohSrh13MVWEDAw5dVxaB_DEMHo92XqJH_6Q7JbMxyF_Z0v1LIjAam2VRDEwiZqwA1LwQgoE0am2LSZyYhpynh_RfOm_vqX9cOWECdfQM5evtlNYQdMvNWxr8oeY4XXsX4gMzfl_rSsoLHAhlu-JnJhmXNdxoMBq_mZ-I_Plpok3PYn0FkSs4rpgdDWEC1vXflHyEoRo940VPahJNf04WholdIbSbvgEqwTzKeoL4Hpqt99CXPalxcp7ApSFi3MOlu-6bWQZYT5BG1nZAaWEAB8rr72sOaB5cMFoIEpZAXUJO_oN05Hd-4qtsp67NVThFsWdBq76P41psNpSMoemizTOU9Glr_ZGILxxWJlKReWEALgb--EQKc9GXg2RU2Cqrvz9M_R5aNSstrRaRwrWcLkGwn8X4xN7hsoY_622kKqJoiZgvCj3ErHLDxEjbes_-VWECDe7SR1XxPdbH0TXXcTX-SPWiOyWlW_n2Dg6FKXdNRdeN2UpJmDfPm4Jqp6ToD92GxUluB1Scebw1crIQwYYdPWEDS6V7uiu2pI1xgJCxc8LMvlh5oGXQuF-gPlCTgWYEe12vUgeZQAgyBcmlt6NHDw3U4Zbs0RKxGohBwKeBxX4-MWEBFnrg0YZmxeRKesb8iaC7821ZmfJUkUdnl7g5BgOpZG4I1FLwlKu0IuuTkFUA0NIr2I8Jd5hBaHB4iOzbOiMjvWEBElH28Z--q-N3ARbQanYouz8MTSznzAL2VjUmz3eXUshDisWOyifCl5NnM-2G1Ev6TBsUMVLQRZZqUQ6haIsKXWEDPFBpBsuxqHju39FJvhrvn2CArL0TJc__rhmCG3leFJf1dJbdmJ-r-HEFGR1mBzmEawttNCGV-1l_2s8XYa5shogBYIMSjAO4t1vGW-jtm20229Q-qT8VZnKVbyiTpsh_-1I46AVgg4RIbWjoHuKFmRTiPNaUgoXUgb3X3z-iOqrpvVV8HL1-DBQcJ"
+      }
+    },
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://w3id.org/security/data-integrity/v2",
+        "https://trustvc.io/context/render-method-context-v2.json",
+        "https://trustvc.io/context/coo.json",
+        "https://trustvc.io/context/attachments-context.json",
+        "https://trustvc.io/context/qrcode-context.json"
+      ],
+      "id": "urn:uuid:019ff4fe-1a3f-7aa0-9b15-62b51345d9c3",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:web:trustvc.github.io:did:1",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaeT51jHPNCgWngN7JGS38tGYipQsvjtGJYmDT5wuRzPFXr",
+        "type": ["Coo"],
+        "attachments": [
+          {
+            "filename": "container-photo.png",
+            "mimeType": "image/png",
+            "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg=="
+          }
+        ]
+      },
+      "renderMethod": [
+        {
+          "type": "EMBEDDED_RENDERER",
+          "templateName": "BILL_OF_LADING",
+          "id": "https://generic-templates.tradetrust.io"
+        }
+      ],
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-12T08:02:01Z",
+        "verificationMethod": "did:web:trustvc.github.io:did:1#multikey-1",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhARW8y1zxjnKx5VVODeP9XxzfzAAUGfCtnX_tXACczYw8fGYPwScBFt02wXDs-_oFpLs70Cc-FQwen0zwAHOnFVFgjgCQCPM-E4gevEE9JIcEJgLxcRGwKsOp86DkBWNDTflDFmqiJWEDJkThKSL6XDOqi_BMbJruZ65WI0Ph4lo851hYpkwDNSxGgAy3Gz8mh0rxlEURDBiS5UXjBxJ1A5v7du2jIiPahWECsYrH0meWr2krPJ5BjFbRtkvV2kysIsazpHXL4c_8i3Tw8qOayg1KRkMWpUuAONNkdCkqIlpffbSJ0NJDEWe1yWEAySRoHwtMMeCnNvOI3X3oh2op5f28ux2F0nEScQBr3hxYmYeP9WHXcVlHlr7MvpFBaK905rkSD-pc9pfFrkGIKWEBbl5PFnQUYvyul_8jYoAe6bUK5SK0I84E229cb-PSklZ2qhkl2ftFsOmOZZJjyuaJhcE5GpZ68RZty9MHsEaK1WECaP_GrPkEFsoTyoI-v_fHcjgTKC2Ibs-Wt4QufH_jRb2gzFsOQ07OH8impmZa1TNa_hRQ23ywhmQjj9DFPIrlxWEDrsgX9dpkcZzVBHW9U8V6lRSGkDSiz_KNeL91HT8r3wtWIBXLxxJm3M4BCkbYV8rRVU6Ms0UTuHqfETePfhu1BWED7Y4mlwNkg3ZTbxGFgBNnyriWujKysTsXbnzjsOrhVMWS4-OfTFylTLagRBbin74vvVDJgKizcHmONORMvDFMCWEBlJUEc7FLuQb2tQEAfF3aDyndG1upqDkeK07KECxsVWMykSM2qf6AsAOErZ4lY_kKAHfxDM0-tDAlAOnMS7xytWEDb7eX4ujX9tdniw_yyN_RVrLLqY2d7Kag_NWE8IZiBQrypA2wTQiZdwYdOBc7Gq5rLTuiWa82T2SQ7uVtwBFtjoQBYIEPFv5tGU-DWhK3VCLDYRkHfxMqEm-gXmPN71nL3bKeSgwQGCA"
+      }
+    }
+  ],
+  "holder": "did:key:zDnaeT51jHPNCgWngN7JGS38tGYipQsvjtGJYmDT5wuRzPFXr",
+  "validFrom": "2026-08-12T08:02:01.446Z",
+  "validUntil": "2999-01-01T00:00:00Z",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2026-08-12T08:02:01Z",
+    "verificationMethod": "did:key:zDnaeT51jHPNCgWngN7JGS38tGYipQsvjtGJYmDT5wuRzPFXr#zDnaeT51jHPNCgWngN7JGS38tGYipQsvjtGJYmDT5wuRzPFXr",
+    "cryptosuite": "ecdsa-rdfc-2019",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z4AFSAhfn7pVhHAYmuJYrsigLEgWgdFNdbPFc3uZifY1HF4XEnKSD9TRM2vcTCynLSyMhmyxZxSrbtWKLHDJUCfHY"
+  }
+}

--- a/src/test/fixture/w3c/presentations/valid/mixed_suites.json
+++ b/src/test/fixture/w3c/presentations/valid/mixed_suites.json
@@ -1,0 +1,83 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2",
+    {
+      "validFrom": {
+        "@id": "https://www.w3.org/2018/credentials#validFrom",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "validUntil": {
+        "@id": "https://www.w3.org/2018/credentials#validUntil",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "issuanceDate": {
+        "@id": "https://www.w3.org/2018/credentials#issuanceDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "expirationDate": {
+        "@id": "https://www.w3.org/2018/credentials#expirationDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      }
+    }
+  ],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://trustvc.io/context/bill-of-lading.json"
+      ],
+      "id": "urn:uuid:01a00dce-984f-7008-b486-86b425825ae2",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "type": ["BillOfLading"],
+        "blNumber": "BL-0001"
+      },
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-17T03:40:38Z",
+        "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhAbI7S-hhN8ZbAlb6SCQjHN1quKW6tX6HnJxpKbCouNwdkGiYd2pQMdfvSgF6zSZeZ8lxmpOJL-nOiEWwxTGB7vVgjgCQCHpj1mcKE5KUucJehuggAtNRhZ91x__AZg0sBCkpsrQODWEDo1SnotTsxHdYZEPgCk5SaSgiordj3egYwuqLRvLg07Jj0MfbrFFwxE6d6-GNkWJ4pCxKtyDAnGy18uX5vmb9cWECMn7tCxn44TrYI1gddo93daJgEUXxoh_oEbWWD3ys1XbCHV8kNA6R3oZqQH2Jd0eY0P9ay5wDHceAV4eCGLw2vWEDP5rGwp1yCTp3qAK0KtMYvE5sHEGKXbLvx6_XfC6LsGFtXgiybJoeuOeNXs3NieJBlqCOK7g5M_VKYxkHb-ML8oIMCBAU"
+      }
+    },
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://trustvc.io/context/bill-of-lading.json"
+      ],
+      "id": "urn:uuid:01a00dce-9988-7008-b486-dfdad19f34e7",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zUC7K2N5KqxqmxsQvVQBL8zK2ZTG6RdYwd2zYt6uWeFLBX8VF6uCiZYoHsbrMNuNwzmLGhvsNKbM89zr2WpC3bfGkn15oeTHAgssH7YapybJMxLhsyrYd2GtcUFfUrruQWiTfmJ",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "type": ["BillOfLading"],
+        "blNumber": "BL-BBS-ISSUED"
+      },
+      "proof": {
+        "type": "DataIntegrityProof",
+        "verificationMethod": "did:key:zUC7K2N5KqxqmxsQvVQBL8zK2ZTG6RdYwd2zYt6uWeFLBX8VF6uCiZYoHsbrMNuNwzmLGhvsNKbM89zr2WpC3bfGkn15oeTHAgssH7YapybJMxLhsyrYd2GtcUFfUrruQWiTfmJ#zUC7K2N5KqxqmxsQvVQBL8zK2ZTG6RdYwd2zYt6uWeFLBX8VF6uCiZYoHsbrMNuNwzmLGhvsNKbM89zr2WpC3bfGkn15oeTHAgssH7YapybJMxLhsyrYd2GtcUFfUrruQWiTfmJ",
+        "cryptosuite": "bbs-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0DhVkBELdbYczJXikenIlArf_eyxKhVK4CJ8WrthVfnYq56lqRJQo9iCmioUmozSkaNBtZzrQc-PhGZAl7UzNPWUfTzwtIbvpkFeqHZ9U5s43Hdt8KpsQL8mQzuRe5MljL-8lYp4N5K9D1ejWycauJgreavlfYuWIOcLwb_6LlNrdN_gjX0TCijl0GjSSZjU5SQAmlx1TCZBYVfGjAl0WY5DQ40xfwia6v3oxghYku3YuvDGh_QixYeeyALXnn_eYpHpBpuQmsuN6byaYh-ML4mhipOG5rczBPPNX0PiHw3GY2g4nNT7wZXESb1bDVpHHODz2GVkINmQa9O5dIA9VxLrWYgWCpfSzRd4fkNwXqlwd0u_dpoIMCBAWDAAECQA"
+      }
+    }
+  ],
+  "holder": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+  "validFrom": "2026-08-17T03:40:38.875Z",
+  "validUntil": "2999-01-01T00:00:00Z",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2026-08-17T03:40:39Z",
+    "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+    "cryptosuite": "ecdsa-rdfc-2019",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "zxzg3rtfcAByKdhjSycKyEPM29iVvsdEkFj1HZPMkur2cE8UCgE39aBYE4RK8cB8QRuasnGcoGLf5wRgHSN1eLvg"
+  }
+}

--- a/src/test/fixture/w3c/presentations/valid/single_credential.json
+++ b/src/test/fixture/w3c/presentations/valid/single_credential.json
@@ -1,0 +1,61 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2",
+    {
+      "validFrom": {
+        "@id": "https://www.w3.org/2018/credentials#validFrom",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "validUntil": {
+        "@id": "https://www.w3.org/2018/credentials#validUntil",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "issuanceDate": {
+        "@id": "https://www.w3.org/2018/credentials#issuanceDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "expirationDate": {
+        "@id": "https://www.w3.org/2018/credentials#expirationDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      }
+    }
+  ],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://trustvc.io/context/bill-of-lading.json"
+      ],
+      "id": "urn:uuid:01a00dce-984f-7008-b486-86b425825ae2",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "type": ["BillOfLading"],
+        "blNumber": "BL-0001"
+      },
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-17T03:40:38Z",
+        "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhAbI7S-hhN8ZbAlb6SCQjHN1quKW6tX6HnJxpKbCouNwdkGiYd2pQMdfvSgF6zSZeZ8lxmpOJL-nOiEWwxTGB7vVgjgCQCHpj1mcKE5KUucJehuggAtNRhZ91x__AZg0sBCkpsrQODWEDo1SnotTsxHdYZEPgCk5SaSgiordj3egYwuqLRvLg07Jj0MfbrFFwxE6d6-GNkWJ4pCxKtyDAnGy18uX5vmb9cWECMn7tCxn44TrYI1gddo93daJgEUXxoh_oEbWWD3ys1XbCHV8kNA6R3oZqQH2Jd0eY0P9ay5wDHceAV4eCGLw2vWEDP5rGwp1yCTp3qAK0KtMYvE5sHEGKXbLvx6_XfC6LsGFtXgiybJoeuOeNXs3NieJBlqCOK7g5M_VKYxkHb-ML8oIMCBAU"
+      }
+    }
+  ],
+  "holder": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+  "validFrom": "2026-08-17T03:40:38.625Z",
+  "validUntil": "2999-01-01T00:00:00Z",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2026-08-17T03:40:38Z",
+    "verificationMethod": "did:key:zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P#zDnaeTxqNRyC14uDE5hAt6EHYCg2HtPDnoausRuZp4QohXX2P",
+    "cryptosuite": "ecdsa-rdfc-2019",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z3ssSMK9tqJg6T77tXjtb4rWzzyPKvTpDczivjjJY15WTmUjQPUv8L6NZLHsANeFHKRdbNZ34LGoUeZsWzDrgyCqb"
+  }
+}

--- a/src/test/fixture/w3c/presentations/valid/two_credentials.json
+++ b/src/test/fixture/w3c/presentations/valid/two_credentials.json
@@ -1,0 +1,104 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2",
+    {
+      "validFrom": {
+        "@id": "https://www.w3.org/2018/credentials#validFrom",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "validUntil": {
+        "@id": "https://www.w3.org/2018/credentials#validUntil",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "issuanceDate": {
+        "@id": "https://www.w3.org/2018/credentials#issuanceDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "expirationDate": {
+        "@id": "https://www.w3.org/2018/credentials#expirationDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      }
+    }
+  ],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://w3id.org/security/data-integrity/v2",
+        "https://trustvc.io/context/render-method-context-v2.json",
+        "https://trustvc.io/context/coo.json",
+        "https://trustvc.io/context/attachments-context.json",
+        "https://trustvc.io/context/qrcode-context.json"
+      ],
+      "id": "urn:uuid:019ff3d4-7b7f-766c-9a90-86996e4598b6",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zDnaemDj95TSneJNkmVSNZ8vBp4Az8w4w538tmAjHbcDVgsR8",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaemDj95TSneJNkmVSNZ8vBp4Az8w4w538tmAjHbcDVgsR8",
+        "type": ["Coo"]
+      },
+      "renderMethod": [
+        {
+          "type": "EMBEDDED_RENDERER",
+          "templateName": "CHAFTA_COO",
+          "id": "https://generic-templates.tradetrust.io"
+        }
+      ],
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-12T02:36:56Z",
+        "verificationMethod": "did:key:zDnaemDj95TSneJNkmVSNZ8vBp4Az8w4w538tmAjHbcDVgsR8#zDnaemDj95TSneJNkmVSNZ8vBp4Az8w4w538tmAjHbcDVgsR8",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhAluZ4Sv_Q5EYiiae7t_JI_x4vP36I0fs0GSbUaZXeuqVS85odCwIqjl3JdY8j_wfw-JaYqhDS5AGSLsJx8myuD1gjgCQDyIRBSkCq5QGuQTVUc4e07yRDMwoUbn8kUa15Wwp4wB-FWEBG6mWsFBBGm3VikFwOw6gqU9qZSpgFEY5FIfiSdM1w_AnfMWGmfkaCGmyzePJfvnl4uBhAN4U008JgOMGRanuSWECaRsP3S8PHiZLRAf1ppG510WLAYJQs8UBN3izym6MziGmmY7ExbNzcaoxYqlvcUSmf-Lw8tq3P2LHpaDac5rcSWEBlui-b6ymuWwwMExxgxRrmIGX4NEVcHkB5tiRFNY-aO6TAcOqzB9AipTEEAAs6XgH-AKd3z41QNnJ_qypgrLVXWEAQyc9MOtWON7MXQrwKxY1td-SzOykyiGU3x5eyAySd7rYr98pkuHv23YRTy45t9K0NfJ6bBRd3sy7BktznT6mTWECorrduLZphiMlG8LWq_Fsi2iLdfK6eBeJHghWnHbxQ5OQdZAVUML3fguxXanqV6XimzP7-QlAu0EoC2f_YGvgNoIMDBQc"
+      }
+    },
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://w3id.org/security/data-integrity/v2",
+        "https://trustvc.io/context/render-method-context-v2.json",
+        "https://trustvc.io/context/coo.json",
+        "https://trustvc.io/context/attachments-context.json",
+        "https://trustvc.io/context/qrcode-context.json"
+      ],
+      "id": "urn:uuid:019ff3d4-7bd6-766c-9a90-8faeac182787",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zDnaemDj95TSneJNkmVSNZ8vBp4Az8w4w538tmAjHbcDVgsR8",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaemDj95TSneJNkmVSNZ8vBp4Az8w4w538tmAjHbcDVgsR8",
+        "type": ["Coo"]
+      },
+      "renderMethod": [
+        {
+          "type": "EMBEDDED_RENDERER",
+          "templateName": "BILL_OF_LADING",
+          "id": "https://generic-templates.tradetrust.io"
+        }
+      ],
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-12T02:36:56Z",
+        "verificationMethod": "did:key:zDnaemDj95TSneJNkmVSNZ8vBp4Az8w4w538tmAjHbcDVgsR8#zDnaemDj95TSneJNkmVSNZ8vBp4Az8w4w538tmAjHbcDVgsR8",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhASkPyko29c_cGzibg8-gUa96yR-9rjnwIncytBocMk6V1L6LTCTg_qIV9YmrsioGQyM-OqyQZeOlj-7Kcbcl2FFgjgCQC7YI_zfJZsE94gw_rzRydpISIHNrE4xE0veK1TJJbEjqFWEBaAARZpDthe0lQa54wOpmMyohSVb5VPMt0Kk0PuYhdxcEIEZYGs-6LkJuM_UW3A6cRwwhMRbaOKi7O08hZOphzWEBRSz41Vwx4XRSRApnHobrnBi1lfkJwqPHnoDcnfQ8ZQmsyC9OqNYR1xVPNVwWGSMZZWT8dn6KQzZTrZPIsAoXAWECslTui99ABEEIJoKAloo0ev8AO8eSyGzemBzjPUlNMVHsSu27f0wymyQ61YaePRXAvpKO8QXRHpUXermEY0PBNWEC2CDcsHp7mmK-yx9cePjj67zcjZm2DE_wGvvIevHgHfyjI-7U85_LK3XNFC5_x3YsWAkNw4rkGiJIIgsneA7AdWEDeuuY45Odb75zJE4zA2AG-XWKE9Y5QWIGb3_55VngDx68kqK0SrqxTb9liFQtsCUINyx_t_K2Uk-zuvpwotWYWoIMDBQc"
+      }
+    }
+  ],
+  "holder": "did:key:zDnaemDj95TSneJNkmVSNZ8vBp4Az8w4w538tmAjHbcDVgsR8",
+  "validFrom": "2026-08-12T02:36:56.719Z",
+  "validUntil": "2999-01-01T00:00:00Z",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2026-08-12T02:36:56Z",
+    "verificationMethod": "did:key:zDnaemDj95TSneJNkmVSNZ8vBp4Az8w4w538tmAjHbcDVgsR8#zDnaemDj95TSneJNkmVSNZ8vBp4Az8w4w538tmAjHbcDVgsR8",
+    "cryptosuite": "ecdsa-rdfc-2019",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z2pqJzRzG6qnDCis5w4L6HMCchSVB1Ej7tp7LTvTpEDFT2L2tmLwcqJRsyVPPGfD6AVzdNsBuA1gW7snqjRsqdUCR"
+  }
+}

--- a/src/test/fixture/w3c/presentations/valid/with_attachments.json
+++ b/src/test/fixture/w3c/presentations/valid/with_attachments.json
@@ -1,0 +1,123 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://w3id.org/security/data-integrity/v2",
+    {
+      "validFrom": {
+        "@id": "https://www.w3.org/2018/credentials#validFrom",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "validUntil": {
+        "@id": "https://www.w3.org/2018/credentials#validUntil",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "issuanceDate": {
+        "@id": "https://www.w3.org/2018/credentials#issuanceDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      },
+      "expirationDate": {
+        "@id": "https://www.w3.org/2018/credentials#expirationDate",
+        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+      }
+    }
+  ],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://w3id.org/security/data-integrity/v2",
+        "https://trustvc.io/context/render-method-context-v2.json",
+        "https://trustvc.io/context/coo.json",
+        "https://trustvc.io/context/attachments-context.json",
+        "https://trustvc.io/context/qrcode-context.json"
+      ],
+      "id": "urn:uuid:019ff4e6-51b1-7ffc-97a8-fdb15b0fc7dd",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zDnaevx9quNxv1MQVYwGaomq7wPuL8e4uxwjjAeAXNZQUsSPq",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaevx9quNxv1MQVYwGaomq7wPuL8e4uxwjjAeAXNZQUsSPq",
+        "type": ["Coo"],
+        "attachments": [
+          {
+            "filename": "certificate-of-origin.pdf",
+            "mimeType": "application/pdf",
+            "data": "JVBERi0xLjQKMSAwIG9iajw8L1R5cGUvQ2F0YWxvZy9QYWdlcyAyIDAgUj4+ZW5kb2JqCjIgMCBvYmo8PC9UeXBlL1BhZ2VzL0tpZHNbMyAwIFJdL0NvdW50IDE+PmVuZG9iagozIDAgb2JqPDwvVHlwZS9QYWdlL1BhcmVudCAyIDAgUi9NZWRpYUJveFswIDAgMjAwIDEwMF0vQ29udGVudHMgNCAwIFIvUmVzb3VyY2VzPDwvRm9udDw8L0YxIDUgMCBSPj4+Pj4+ZW5kb2JqCjQgMCBvYmo8PC9MZW5ndGggNjI+PnN0cmVhbQpCVCAvRjEgMTIgVGYgMjAgNTAgVGQgKFRydXN0VkMgc2FtcGxlIGF0dGFjaG1lbnQpIFRqIEVUCmVuZHN0cmVhbSBlbmRvYmoKNSAwIG9iajw8L1R5cGUvRm9udC9TdWJ0eXBlL1R5cGUxL0Jhc2VGb250L0hlbHZldGljYT4+ZW5kb2JqCnRyYWlsZXI8PC9Sb290IDEgMCBSPj4KJSVFT0Y="
+          },
+          {
+            "filename": "packing-list.txt",
+            "mimeType": "text/plain",
+            "data": "Q2FydG9uIDEtNTAwOiBtYXJpbmUtZ3JhZGUgZWxlY3Ryb25pY3MKR3Jvc3Mgd2VpZ2h0OiA4LDQ1MCBLR1MK"
+          }
+        ]
+      },
+      "renderMethod": [
+        {
+          "type": "EMBEDDED_RENDERER",
+          "templateName": "CHAFTA_COO",
+          "id": "https://generic-templates.tradetrust.io"
+        }
+      ],
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-12T07:36:02Z",
+        "verificationMethod": "did:key:zDnaevx9quNxv1MQVYwGaomq7wPuL8e4uxwjjAeAXNZQUsSPq#zDnaevx9quNxv1MQVYwGaomq7wPuL8e4uxwjjAeAXNZQUsSPq",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhAz_9heAESN9Ve_wORSjcxcfSWJskaFqo_Kyx9BYZhPU9PX_6tzyHR2mJM59X9Q_6NXbzulKEKuGMy0GBWfR8stlgjgCQDbfMA91tNTAg5f5oKC9dPeoVycFFmwCzn5si6hjjIRwuNWEBjm7DnqLQ2IBYLCQCYCAfNDlod6oKO_FEMIXsVVF269HZnxnVBvzJydZQo-eBtzMqq0OwEZ8kKFOXTnfoiEWYVWEBD83orjjaLOSPmFS-rAKu6bUzMt-zP8ZmLvu2xxtVua-4CJ2qrt0ZcZc2gx2XBQDinRcix42u3Mvh3Ev1F9DOsWEDMamttC9unoIFqozqDdOy13reGyT9W7q6ngcjmw5UBmraOrMYZv7I3JKMJoNdkHdSMqQSooysxqVGCBGFzBtBaWED9ddeMg1gDKvF3VVVTxEHWTfwRRIfz4oO0KLU0QqwCk_bNNQigwjt4q8XfH5LnIxLX5crQ4XYTB3Vn8OkKjWMFWEBWT_dt26K6HNkH0tLLji8bCjqq5wjCawouRO5WTTbYK6bb28Iu0h0Wgv_ugn8HELWWFDa9XFhy73x1uJIlknEeWEC0BrdFNtsqAHCF1oWWW7i0Zcec99DtKSZXtZtM12p2fg9lhu86EVSRlqJPDPfdWyy5niIS-D9YmPumZDM7VzwJWEBJWquL8hG-POvr2lFvAc9CoFRri2rS91uZTlV8npZz0DCsFyFYy1TaPi6_Ppa-PggrdYM-eF-HK6MivO-a8AiPWECikPTq4u7dFkW3Z8rm0R42hx05mUFamlcrsTS3UXIZzSxAFBDzaJrSfQI02L4e39lvDLd6ozbONaB2S_u7CnMeWEAS0XRjB85ur4qx7mrCRIs9QoWRf9yI1S7p5S8H2hKLHaFCX7vSU_Ujc9ieuqLQtkVcWknWZ8rp4lDPFzkv8CF5WEC1fnYOA1AFlT5lQmSYL1jIE9nmYmYJ2YJdKwQCdCH1zPdthpXAASLAAkp3vAQYZlh3LVqEPsdVGk0NnUzzciqQWECR8RPbdm2alg-5nyawLaqs7WpQEKno480yAqt53otDpHyaJI3qycdS464IUv8NTtpA6eELIWbK2zf8B2bsi1jMWEBpSkMPzp_0tlbiGKJ01pJK_GxTc9qALwERNXADhBBKg-DEzN5Pzn8qRMAzLzfX61k9njXQr8IcLes97CR8yyJ_WEBcVTshCUUNuQL4M8MHITuL4kmWelH7FKbveka2Exog30ouKuC-wq2alZPJGRUuG4MsJteQpwp1wSMvhio9MlWSogBYIB2fxrA9eUucmdJqdxEjzJGFM4jUIhk_7dcVRJb5wzbsAVggiTNcBjQwHVWnYk-q502irEw4d6DG0_9nJPGQC3LYs_mDBQcJ"
+      }
+    },
+    {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://w3id.org/security/data-integrity/v2",
+        "https://trustvc.io/context/render-method-context-v2.json",
+        "https://trustvc.io/context/coo.json",
+        "https://trustvc.io/context/attachments-context.json",
+        "https://trustvc.io/context/qrcode-context.json"
+      ],
+      "id": "urn:uuid:019ff4e6-5205-7ffc-97a9-024f3a3702aa",
+      "type": ["VerifiableCredential"],
+      "issuer": "did:key:zDnaevx9quNxv1MQVYwGaomq7wPuL8e4uxwjjAeAXNZQUsSPq",
+      "validFrom": "2024-04-01T12:19:52Z",
+      "credentialSubject": {
+        "id": "did:key:zDnaevx9quNxv1MQVYwGaomq7wPuL8e4uxwjjAeAXNZQUsSPq",
+        "type": ["Coo"],
+        "attachments": [
+          {
+            "filename": "container-photo.png",
+            "mimeType": "image/png",
+            "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg=="
+          }
+        ]
+      },
+      "renderMethod": [
+        {
+          "type": "EMBEDDED_RENDERER",
+          "templateName": "BILL_OF_LADING",
+          "id": "https://generic-templates.tradetrust.io"
+        }
+      ],
+      "proof": {
+        "type": "DataIntegrityProof",
+        "created": "2026-08-12T07:36:02Z",
+        "verificationMethod": "did:key:zDnaevx9quNxv1MQVYwGaomq7wPuL8e4uxwjjAeAXNZQUsSPq#zDnaevx9quNxv1MQVYwGaomq7wPuL8e4uxwjjAeAXNZQUsSPq",
+        "cryptosuite": "ecdsa-sd-2023",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "u2V0BhVhAJDmnHChgFTL4RgMdkP4A8U3pjR_8WXl8YDIqxfjcpT2YIMS8YfFIJDC4YBkk7-ljfYoHtGRjPOu-0o20vF6y_1gjgCQCnYbam0rhHGdRE83VNoetFee2jaw_UXhgSaAuvyKrDHaJWEAPdIwnqft7wVHjeTJGkda1G9jLQzF16wsdux03fswsR23-cqG6tf4bgfmBrAGYyDhLAiZOF7cdraAgHCYJYhufWEDIzyrp_tJZ9e7L7iDXaZJlKM2iNGBQp24D3keVcVICkeiMIpWw9BF_ui8OXXGehVp-zOPW1n3Xw1gqBlJ7u0HXWEBSIoKwU8pMQYujXz9UVLQrZcZlaWxzKJR7i45aVCF-wYqEYoaBJWL-uTplCaX2JHgcvwKDxDHp-ZqlkWilQR4yWEAItMdJvpZqdxgP23QEK1U9mB3I9ApEOvQOH-J3_P5uAVu49NGUEVqJ4oC7dgJtrUCTwbpr93ydELIhLvdo9BbdWEB03W8SsqRA3Q8WuVvr_mC00_mmanXrzAPSQx-OtGLlu34rp1Aus6p2URAMJcHTeyI3VH_mmsxb0eVKcIfPVtxvWEDU8vsuJzLurMxPOHnbarI8TtGtu1g4Fq8ydybM6lh4ebCmGjJytGLj61Aqjt4Vm28xjUFiB0jZOaJGXvzAKYYpWEAvbKDFgh9P9vxVV2lbd4rAqoBG4WN_AS37NQ3EoJQ7AYKN3y5dY4BL2LNTPRpCs9DCAjLexxrm1dQ0jfCIteLlWEDnuFROLdRSwZ1hcq9taZud2A0Ms_AFWgO6lXoNwl3RBa1Kx4b_l8NFPexd0uSmgLHT80CiGUNIb8T87P1_UeyaWEAm3Q2l6YhgXJqYkRjaUghf6dWXbT9EP3VxjmQQ1ocIw0Ju0eGr17A25xOwGygpM7DIG9_jQKVq8a5fyH8nKy8EoQBYIGDjipA5P2M_KIQI3GOtX7fjzCYJgjF4v0d-0WxDIzragwQGCA"
+      }
+    }
+  ],
+  "holder": "did:key:zDnaevx9quNxv1MQVYwGaomq7wPuL8e4uxwjjAeAXNZQUsSPq",
+  "validFrom": "2026-08-12T07:36:02.855Z",
+  "validUntil": "2999-01-01T00:00:00Z",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "created": "2026-08-12T07:36:02Z",
+    "verificationMethod": "did:key:zDnaevx9quNxv1MQVYwGaomq7wPuL8e4uxwjjAeAXNZQUsSPq#zDnaevx9quNxv1MQVYwGaomq7wPuL8e4uxwjjAeAXNZQUsSPq",
+    "cryptosuite": "ecdsa-rdfc-2019",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z2SqW7r6dYPGwdrXghdVi9D9KjqZneHB74mSxSiX3hsB9XsbvGyjwBsgPuxS1KsYb33g7HnCBoHFrHVYpx8E8XHjG"
+  }
+}

--- a/src/utils/presentation.test.ts
+++ b/src/utils/presentation.test.ts
@@ -82,6 +82,22 @@ describe("getCredentialLabel", () => {
     expect(getCredentialLabel({ type: ["VerifiableCredential"] }, 1)).toBe("Credential 2");
     expect(getCredentialLabel({}, 0)).toBe("Credential 1");
   });
+
+  it("ignores non-string types rather than returning one", () => {
+    // A presentation is user-supplied JSON, so `type` can hold anything. A non-string entry used
+    // to survive the filter and be returned as the label, which then threw on the caller's
+    // .toLowerCase() and put a non-renderable value into the tab.
+    expect(getCredentialLabel({ type: [{ malformed: true }] }, 0)).toBe("Credential 1");
+    expect(getCredentialLabel({ type: [42, null, "BillOfLading"] }, 0)).toBe("BillOfLading");
+    expect(getCredentialLabel({ type: { not: "an array" } }, 2)).toBe("Credential 3");
+  });
+
+  it("does not throw building a download name from a malformed type", () => {
+    expect(() => getCredentialDownloadName("presentation.json", { type: [{ malformed: true }] }, 0)).not.toThrow();
+    expect(getCredentialDownloadName("presentation.json", { type: [{ malformed: true }] }, 0)).toBe(
+      "presentation-credential-1"
+    );
+  });
 });
 
 describe("getW3CVersionLabel / getCredentialVersionTag", () => {

--- a/src/utils/presentation.test.ts
+++ b/src/utils/presentation.test.ts
@@ -1,0 +1,123 @@
+import fs from "fs";
+import path from "path";
+import {
+  getCredentialDownloadName,
+  getCredentialLabel,
+  getCredentialVersionTag,
+  getPresentationCredentials,
+  getPresentationHolder,
+  getW3CVersionLabel,
+  isVerifiablePresentation,
+} from "./presentation";
+import { getAttachments, getOpenAttestationData } from "./shared";
+
+const fixture = (name: string) =>
+  JSON.parse(fs.readFileSync(path.join(__dirname, "../test/fixture/w3c/presentations", name), "utf8"));
+
+const twoCredentials = fixture("valid/two_credentials.json");
+const singleCredential = fixture("valid/single_credential.json");
+
+describe("isVerifiablePresentation", () => {
+  it("recognises a signed presentation", () => {
+    expect(isVerifiablePresentation(twoCredentials)).toBe(true);
+  });
+
+  it("recognises an unsigned presentation, so it can be reported invalid rather than read as a credential", () => {
+    expect(isVerifiablePresentation(fixture("invalid/unsigned.json"))).toBe(true);
+  });
+
+  it("recognises the loose shapes trustvc's own VP router accepts", () => {
+    // No @context, and an empty credential list — both rejected by the strict predicates but
+    // routed to the VP fragments, which report on them explicitly.
+    expect(isVerifiablePresentation({ type: ["VerifiablePresentation"], verifiableCredential: [] })).toBe(true);
+  });
+
+  it("rejects a credential, and anything that is not an object", () => {
+    expect(isVerifiablePresentation(twoCredentials.verifiableCredential[0])).toBe(false);
+    expect(isVerifiablePresentation(null)).toBe(false);
+    expect(isVerifiablePresentation("presentation")).toBe(false);
+    expect(isVerifiablePresentation({ type: ["VerifiablePresentation"] })).toBe(false);
+  });
+});
+
+describe("getPresentationCredentials", () => {
+  it("returns every embedded credential", () => {
+    expect(getPresentationCredentials(twoCredentials)).toHaveLength(2);
+    expect(getPresentationCredentials(singleCredential)).toHaveLength(1);
+  });
+
+  it("normalises a single credential object into an array", () => {
+    const vp = { ...singleCredential, verifiableCredential: singleCredential.verifiableCredential[0] };
+    expect(getPresentationCredentials(vp)).toHaveLength(1);
+  });
+
+  it("returns [] for anything that is not a presentation", () => {
+    expect(getPresentationCredentials(singleCredential.verifiableCredential[0])).toEqual([]);
+    expect(getPresentationCredentials(undefined)).toEqual([]);
+  });
+});
+
+describe("getPresentationHolder", () => {
+  it("upper-cases the holder DID, matching every other identity in the verify UI", () => {
+    expect(getPresentationHolder(twoCredentials)).toBe(twoCredentials.holder.toUpperCase());
+  });
+
+  it("reads an object-shaped holder", () => {
+    expect(getPresentationHolder({ holder: { id: "did:key:abc" } })).toBe("DID:KEY:ABC");
+  });
+
+  it("falls back to Unknown when no holder is declared", () => {
+    expect(getPresentationHolder({})).toBe("Unknown");
+  });
+});
+
+describe("getCredentialLabel", () => {
+  it("prefers the renderer template name, which is what tells credentials apart on screen", () => {
+    const [first] = getPresentationCredentials(twoCredentials);
+    expect(getCredentialLabel(first, 0)).toBe("CHAFTA COO");
+  });
+
+  it("falls back to the specific type, then to the position", () => {
+    expect(getCredentialLabel({ type: ["VerifiableCredential", "BillOfLading"] }, 0)).toBe("BillOfLading");
+    expect(getCredentialLabel({ type: ["VerifiableCredential"] }, 1)).toBe("Credential 2");
+    expect(getCredentialLabel({}, 0)).toBe("Credential 1");
+  });
+});
+
+describe("getW3CVersionLabel / getCredentialVersionTag", () => {
+  it("reads the data model from the first @context entry", () => {
+    expect(getW3CVersionLabel(twoCredentials)).toBe("V2.0");
+    expect(getW3CVersionLabel({ "@context": ["https://www.w3.org/2018/credentials/v1"] })).toBe("V1.1");
+    expect(getW3CVersionLabel({})).toBe("V1.1");
+  });
+
+  it("tags a credential the way a standalone credential is tagged", () => {
+    expect(getCredentialVersionTag(getPresentationCredentials(twoCredentials)[0])).toBe("W3C VC V2.0");
+  });
+});
+
+describe("getCredentialDownloadName", () => {
+  it("qualifies the presentation filename with the credential, so tabs do not overwrite each other", () => {
+    const [first, second] = getPresentationCredentials(twoCredentials);
+    // No extension — the utility bar appends its own.
+    expect(getCredentialDownloadName("presentation.json", first, 0)).toBe("presentation-chafta-coo");
+    expect(getCredentialDownloadName("presentation.json", second, 1)).not.toBe(
+      getCredentialDownloadName("presentation.json", first, 0)
+    );
+  });
+
+  it("copes with no filename and an unlabelled credential", () => {
+    expect(getCredentialDownloadName("", {}, 0)).toBe("presentation-credential-1");
+  });
+});
+
+describe("shared helpers on a presentation", () => {
+  it("treats a presentation as its own document data, rather than throwing", () => {
+    // getDocumentData throws on a presentation, which would take down every caller.
+    expect(getOpenAttestationData(twoCredentials)).toBe(twoCredentials);
+  });
+
+  it("reports no attachments on the envelope — each credential is asked on its own tab", () => {
+    expect(getAttachments(fixture("valid/with_attachments.json"))).toEqual([]);
+  });
+});

--- a/src/utils/presentation.test.ts
+++ b/src/utils/presentation.test.ts
@@ -100,10 +100,19 @@ describe("getCredentialDownloadName", () => {
   it("qualifies the presentation filename with the credential, so tabs do not overwrite each other", () => {
     const [first, second] = getPresentationCredentials(twoCredentials);
     // No extension — the utility bar appends its own.
-    expect(getCredentialDownloadName("presentation.json", first, 0)).toBe("presentation-chafta-coo");
+    expect(getCredentialDownloadName("presentation.json", first, 0)).toBe("presentation-chafta-coo-1");
     expect(getCredentialDownloadName("presentation.json", second, 1)).not.toBe(
       getCredentialDownloadName("presentation.json", first, 0)
     );
+  });
+
+  it("stays distinct for credentials that share a label", () => {
+    // Labels are NOT unique — two bills of lading in one presentation slug identically. Naming
+    // on the slug alone let one tab's download overwrite the other's, which is the collision
+    // this function exists to prevent.
+    const bol = { renderMethod: [{ templateName: "BILL_OF_LADING" }] };
+    expect(getCredentialDownloadName("presentation.json", bol, 0)).toBe("presentation-bill-of-lading-1");
+    expect(getCredentialDownloadName("presentation.json", bol, 1)).toBe("presentation-bill-of-lading-2");
   });
 
   it("copes with no filename and an unlabelled credential", () => {

--- a/src/utils/presentation.ts
+++ b/src/utils/presentation.ts
@@ -55,20 +55,29 @@ export const getPresentationHolder = (rawDocument: any): string => {
 };
 
 /**
- * A short label for a credential's tab. Prefers the renderer template name, which is what
- * distinguishes one credential from another on screen; falls back to its `type` (minus the
- * generic `VerifiableCredential`), then to a 1-based position.
+ * What a credential calls itself: the renderer template name, else its `type` (minus the generic
+ * `VerifiableCredential`). Undefined when it declares neither.
+ *
+ * Kept separate from getCredentialLabel because that function's positional fallback is only
+ * appropriate for display. Callers that append their own position need the descriptive part
+ * alone, or they end up repeating it — `credential-1-1`.
  */
-export const getCredentialLabel = (credential: any, index: number): string => {
+const getCredentialDescriptor = (credential: any): string | undefined => {
   const templateName = [credential?.renderMethod].flat()?.[0]?.templateName;
   if (typeof templateName === "string" && templateName.trim()) {
     return templateName.replace(/_/g, " ");
   }
   const types = [credential?.type].flat().filter(Boolean) as string[];
-  const specific = types.find((t) => t !== "VerifiableCredential");
-  if (specific) return specific;
-  return `Credential ${index + 1}`;
+  return types.find((t) => t !== "VerifiableCredential");
 };
+
+/**
+ * A short label for a credential's tab. Prefers the renderer template name, which is what
+ * distinguishes one credential from another on screen; falls back to its `type` (minus the
+ * generic `VerifiableCredential`), then to a 1-based position.
+ */
+export const getCredentialLabel = (credential: any, index: number): string =>
+  getCredentialDescriptor(credential) ?? `Credential ${index + 1}`;
 
 /** The VC Data Model 2.0 context URL — the first `@context` entry of a v2 document. */
 const VC_V2_CONTEXT = "https://www.w3.org/ns/credentials/v2";
@@ -97,14 +106,19 @@ export const getCredentialVersionTag = (credential: any): string => `W3C VC ${ge
  * Left alone, DocumentUtility names the download after the document's own `name` field and
  * falls back to "Untitled". Inside a presentation that collides: every credential without a
  * `name` saves as `Untitled.tt`, and each tab holds DIFFERENT content, so one silently
- * overwrites another. Qualify the presentation's filename with the credential's label instead:
- * `presentation-chafta-coo`.
+ * overwrites another. Qualify the presentation's filename with the credential instead:
+ * `presentation-chafta-coo-1`.
+ *
+ * The POSITION is always appended, never only as a fallback for a missing label. Labels are not
+ * unique — two bills of lading in one presentation produce the same slug, and naming on the slug
+ * alone reintroduced exactly the collision this function exists to prevent. The position is the
+ * only thing guaranteed distinct, and it matches the tab order on screen.
  */
 export const getCredentialDownloadName = (presentationFileName: string, credential: any, index: number): string => {
   const base = (presentationFileName || "presentation").replace(/\.(json|tt)$/i, "");
-  const slug = getCredentialLabel(credential, index)
+  const slug = (getCredentialDescriptor(credential) ?? "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "");
-  return `${base}-${slug || `credential-${index + 1}`}`;
+  return `${base}-${slug || "credential"}-${index + 1}`;
 };

--- a/src/utils/presentation.ts
+++ b/src/utils/presentation.ts
@@ -67,8 +67,11 @@ const getCredentialDescriptor = (credential: any): string | undefined => {
   if (typeof templateName === "string" && templateName.trim()) {
     return templateName.replace(/_/g, " ");
   }
-  const types = [credential?.type].flat().filter(Boolean) as string[];
-  return types.find((t) => t !== "VerifiableCredential");
+  // A presentation is user-supplied JSON, so `type` can hold anything. `filter(Boolean) as
+  // string[]` merely told the compiler otherwise: a non-string entry survived, was returned as
+  // the descriptor, and threw on the caller's .toLowerCase(). Narrow for real.
+  const types = [credential?.type].flat().filter((type): type is string => typeof type === "string");
+  return types.find((type) => type !== "VerifiableCredential");
 };
 
 /**

--- a/src/utils/presentation.ts
+++ b/src/utils/presentation.ts
@@ -1,0 +1,110 @@
+import { vc } from "@trustvc/trustvc";
+
+/**
+ * Whether trustvc's verifier will treat this document as a Verifiable Presentation.
+ *
+ * `vc.isRawPresentation` and `vc.isSignedPresentation` are the library's own predicates and
+ * do the work for every well-formed document — they are mutually exclusive (raw = unsigned,
+ * signed = has a holder proof), so answering "is this a presentation at all?" needs both.
+ *
+ * The shape check after them is NOT redundant. trustvc routes documents into its VP verifier
+ * fragments with an internal, unexported predicate that looks only at `type` +
+ * `verifiableCredential`, so it accepts two shapes the strict predicates reject: a
+ * presentation with no `@context`, and one with an empty credential list — the latter being a
+ * case its own W3CVpIssuerIdentity fragment reports on explicitly. If this predicate
+ * disagreed with that router, such a document would be sent down the credential path, where
+ * getDocumentData throws and the UI shows a generic failure instead of the verifier's actual
+ * finding.
+ *
+ * `proof` is deliberately not required, so an unsigned presentation is still recognised and
+ * can be reported invalid rather than silently treated as a credential.
+ */
+export const isVerifiablePresentation = (rawDocument: unknown): boolean => {
+  if (!rawDocument || typeof rawDocument !== "object") return false;
+  if (vc.isRawPresentation(rawDocument) || vc.isSignedPresentation(rawDocument)) {
+    return true;
+  }
+  const { type, verifiableCredential } = rawDocument as {
+    type?: string | string[];
+    verifiableCredential?: unknown;
+  };
+  const types = Array.isArray(type) ? type : [type];
+  return types.includes("VerifiablePresentation") && verifiableCredential !== undefined;
+};
+
+/**
+ * The credentials embedded in a presentation, always as an array — `verifiableCredential` may
+ * be a single object or a list. Returns [] for anything that is not a presentation.
+ */
+export const getPresentationCredentials = (rawDocument: unknown): any[] => {
+  if (!isVerifiablePresentation(rawDocument)) return [];
+  const credentials = (rawDocument as { verifiableCredential?: unknown }).verifiableCredential;
+  if (!credentials) return [];
+  return Array.isArray(credentials) ? credentials : [credentials];
+};
+
+/**
+ * A presentation has no issuer of its own: it is asserted by the HOLDER, and each embedded
+ * credential carries its own issuer. Show the holder, since that is who is making the claim to
+ * the verifier. (The embedded issuers are still checked — the W3CVpIssuerIdentity fragment
+ * resolves every one of them.)
+ */
+export const getPresentationHolder = (rawDocument: any): string => {
+  const holder = typeof rawDocument?.holder === "string" ? rawDocument.holder : rawDocument?.holder?.id;
+  return holder?.toUpperCase() || "Unknown";
+};
+
+/**
+ * A short label for a credential's tab. Prefers the renderer template name, which is what
+ * distinguishes one credential from another on screen; falls back to its `type` (minus the
+ * generic `VerifiableCredential`), then to a 1-based position.
+ */
+export const getCredentialLabel = (credential: any, index: number): string => {
+  const templateName = [credential?.renderMethod].flat()?.[0]?.templateName;
+  if (typeof templateName === "string" && templateName.trim()) {
+    return templateName.replace(/_/g, " ");
+  }
+  const types = [credential?.type].flat().filter(Boolean) as string[];
+  const specific = types.find((t) => t !== "VerifiableCredential");
+  if (specific) return specific;
+  return `Credential ${index + 1}`;
+};
+
+/** The VC Data Model 2.0 context URL — the first `@context` entry of a v2 document. */
+const VC_V2_CONTEXT = "https://www.w3.org/ns/credentials/v2";
+
+/**
+ * The data-model version label for a credential or presentation: 'V2.0' or 'V1.1'.
+ *
+ * `vc.isSignedDocumentV2_0` only answers this for signed CREDENTIALS, so it cannot classify a
+ * presentation envelope; both are decided the same way, by the first `@context` entry.
+ */
+export const getW3CVersionLabel = (document: any): "V2.0" | "V1.1" => {
+  const first = [document?.["@context"]].flat()[0];
+  return first === VC_V2_CONTEXT ? "V2.0" : "V1.1";
+};
+
+/**
+ * The version tag shown against a credential embedded in a presentation, matching the tag the
+ * document status panel shows for a standalone credential.
+ */
+export const getCredentialVersionTag = (credential: any): string => `W3C VC ${getW3CVersionLabel(credential)}`;
+
+/**
+ * The download name for one credential inside a presentation, without an extension — the
+ * utility bar appends its own.
+ *
+ * Left alone, DocumentUtility names the download after the document's own `name` field and
+ * falls back to "Untitled". Inside a presentation that collides: every credential without a
+ * `name` saves as `Untitled.tt`, and each tab holds DIFFERENT content, so one silently
+ * overwrites another. Qualify the presentation's filename with the credential's label instead:
+ * `presentation-chafta-coo`.
+ */
+export const getCredentialDownloadName = (presentationFileName: string, credential: any, index: number): string => {
+  const base = (presentationFileName || "presentation").replace(/\.(json|tt)$/i, "");
+  const slug = getCredentialLabel(credential, index)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return `${base}-${slug || `credential-${index + 1}`}`;
+};

--- a/src/utils/presentationErrors.test.ts
+++ b/src/utils/presentationErrors.test.ts
@@ -1,0 +1,138 @@
+import fs from "fs";
+import path from "path";
+import { errorMessages, VerificationFragment } from "@trustvc/trustvc";
+import { getPresentationError } from "./presentationErrors";
+
+const { TYPES } = errorMessages;
+
+const fixture = (name: string) =>
+  JSON.parse(fs.readFileSync(path.join(__dirname, "../test/fixture/w3c/presentations", name), "utf8"));
+
+const twoCredentials = fixture("valid/two_credentials.json");
+
+/** A presentation fragment set where the named fragment failed with `reason`. */
+const vpFragments = (name: string, reason: string): VerificationFragment[] =>
+  [
+    { name: "W3CVpSignatureIntegrity", type: "DOCUMENT_INTEGRITY", status: "VALID" },
+    { name: "W3CVpCredentialStatus", type: "DOCUMENT_STATUS", status: "VALID" },
+    { name: "W3CVpIssuerIdentity", type: "ISSUER_IDENTITY", status: "VALID" },
+  ].map((f) => (f.name === name ? { ...f, status: "INVALID", reason: { message: reason } } : f)) as any;
+
+describe("getPresentationError", () => {
+  it("returns nothing when no presentation fragment failed", () => {
+    expect(getPresentationError(vpFragments("none", ""))).toBeUndefined();
+    expect(getPresentationError([])).toBeUndefined();
+    expect(getPresentationError(null)).toBeUndefined();
+  });
+
+  it("ignores a failing credential fragment — those are not presentation failures", () => {
+    const frags = [
+      { name: "W3CSignatureIntegrity", type: "DOCUMENT_INTEGRITY", status: "INVALID", reason: { message: "bad" } },
+    ] as any;
+    expect(getPresentationError(frags)).toBeUndefined();
+  });
+
+  it("reports an unsigned presentation as invalid, not as tampering", () => {
+    const error = getPresentationError(
+      vpFragments(
+        "W3CVpSignatureIntegrity",
+        'Presentation is not signed (no holder "proof"), so ownership cannot be proven.'
+      )
+    );
+    expect(error?.type).toBe(TYPES.INVALID);
+    expect(error?.message).toMatch(/not signed/);
+  });
+
+  it("distinguishes a holder mismatch from tampering", () => {
+    const error = getPresentationError(
+      vpFragments("W3CVpSignatureIntegrity", "Presentation signer does not match the declared holder.")
+    );
+    expect(error?.type).toBe(TYPES.INVALID);
+    expect(error?.message).toMatch(/someone other than the holder/);
+  });
+
+  it("reports a genuinely bad proof as tampering", () => {
+    const error = getPresentationError(vpFragments("W3CVpSignatureIntegrity", "Invalid signature."));
+    expect(error?.type).toBe(TYPES.HASH);
+    // No override — the established HASH copy is used.
+    expect(error?.message).toBeUndefined();
+  });
+
+  it("reports an empty presentation with copy of its own", () => {
+    const error = getPresentationError(
+      vpFragments("W3CVpIssuerIdentity", "Presentation contains no verifiable credentials.")
+    );
+    expect(error?.type).toBe(TYPES.INVALID);
+    expect(error?.message).toBe("This presentation does not contain any credentials.");
+  });
+
+  it("names the embedded credential at fault by position AND tab label", () => {
+    const error = getPresentationError(
+      vpFragments("W3CVpCredentialStatus", "Embedded credential at index 1 has been revoked."),
+      twoCredentials
+    );
+    expect(error?.type).toBe(TYPES.REVOKED);
+    expect(error?.message).toContain('Credential 2 ("BILL OF LADING")');
+    expect(error?.message).toMatch(/revoked by its issuer/);
+  });
+
+  it("names several credentials, and pluralises around them", () => {
+    const error = getPresentationError(
+      vpFragments("W3CVpCredentialStatus", "Embedded credential(s) at index 0, 1 have been revoked."),
+      twoCredentials
+    );
+    expect(error?.message).toContain('Credential 1 ("CHAFTA COO") and Credential 2 ("BILL OF LADING")');
+    expect(error?.message).toMatch(/have been revoked by their issuers/);
+  });
+
+  it("falls back to the position alone when the document is not supplied", () => {
+    const error = getPresentationError(
+      vpFragments("W3CVpCredentialStatus", "Embedded credential at index 1 has been revoked.")
+    );
+    expect(error?.message).toContain("Credential 2");
+    expect(error?.message).not.toContain('("');
+  });
+
+  it("separates an expired CREDENTIAL from an expired PRESENTATION, which need opposite advice", () => {
+    const credential = getPresentationError(
+      vpFragments("W3CVpCredentialStatus", "Embedded credential at index 0 has expired (validUntil 2020-01-01)."),
+      twoCredentials
+    );
+    // Only the issuer can reissue a credential — presenting again cannot help.
+    expect(credential?.message).toMatch(/Ask the issuer to reissue/);
+
+    const presentation = getPresentationError(
+      vpFragments("W3CVpSignatureIntegrity", "Presentation has expired (validUntil 2020-01-01).")
+    );
+    expect(presentation?.message).toMatch(/Ask the holder to present the credentials again/);
+  });
+
+  it("blames an unresolvable issuer rather than tampering, even when the proof fails too", () => {
+    // A DID that will not resolve necessarily fails the signature check as well; matched the
+    // other way round, an unpublished did:web reads to the user as a tampered document.
+    const frags = [
+      {
+        name: "W3CVpSignatureIntegrity",
+        type: "DOCUMENT_INTEGRITY",
+        status: "INVALID",
+        reason: { message: "has an invalid signature: Cannot read properties of null" },
+      },
+      { name: "W3CVpCredentialStatus", type: "DOCUMENT_STATUS", status: "VALID" },
+      {
+        name: "W3CVpIssuerIdentity",
+        type: "ISSUER_IDENTITY",
+        status: "INVALID",
+        reason: { message: "Could not resolve issuer(s): index 0 (did:web:nope.example)." },
+      },
+    ] as any;
+    const error = getPresentationError(frags, twoCredentials);
+    expect(error?.type).toBe(TYPES.IDENTITY);
+    expect(error?.message).toMatch(/cannot be identified/);
+  });
+
+  it("treats an unrecognised presentation failure as invalid rather than tampered", () => {
+    const error = getPresentationError(vpFragments("W3CVpIssuerIdentity", "something entirely new went wrong"));
+    expect(error?.type).toBe(TYPES.INVALID);
+    expect(error?.message).toBeUndefined();
+  });
+});

--- a/src/utils/presentationErrors.ts
+++ b/src/utils/presentationErrors.ts
@@ -1,0 +1,218 @@
+import { errorMessages, VerificationFragment } from "@trustvc/trustvc";
+import { getCredentialLabel, getPresentationCredentials } from "./presentation";
+
+const { TYPES } = errorMessages;
+
+/** The presentation verifier fragments. */
+const VP_FRAGMENTS = ["W3CVpSignatureIntegrity", "W3CVpCredentialStatus", "W3CVpIssuerIdentity"];
+
+/**
+ * Every reason across the failing presentation fragments. More than one can fail at once — an
+ * empty presentation fails both the proof and the issuer check — so all of them are considered
+ * rather than just the first, letting the specific explanation win over a generic one.
+ */
+const failingVpReasons = (frags: VerificationFragment[]): string[] =>
+  frags
+    .filter((f) => VP_FRAGMENTS.includes(f.name) && (f.status === "INVALID" || f.status === "ERROR"))
+    .map((f) => (f as any)?.reason?.message ?? "");
+
+/**
+ * Names the embedded credential(s) a verifier reason blames — by POSITION and by the label the
+ * credential tabs show, e.g. `Credential 2 ("BILL OF LADING")`.
+ *
+ * Both halves are needed, and each alone is wrong:
+ *
+ * - Position alone ("Credential 2", or the verifier's zero-based "index 1") names nothing the
+ *   user can see: real documents label their tabs by template or type — "CHAFTA COO", "BILL OF
+ *   LADING" — and only fall back to `Credential N` when a credential has neither.
+ * - Label alone is ambiguous, because the credential tabs render the label with no
+ *   disambiguation. Two bills of lading in one presentation produce two identical tabs.
+ *
+ * Together they are unambiguous and findable: tabs render in credential order, so the position
+ * locates the tab and the label confirms it is the right one.
+ *
+ * Reasons name indices in several shapes, and more than one at a time:
+ *   "Embedded credential at index 0 has expired (...)"
+ *   "Embedded credential(s) at index 0, 2 have no issuer."
+ *   "Could not resolve issuer(s): index 0 (did:web:a), index 1 (did:web:b)."
+ * so every `index N` is collected, not just the first. Without a document, or with no index at
+ * all, it degrades to a plainer phrase rather than naming the wrong credential.
+ */
+const credentialsAtFault = (reason: string, doc?: unknown): { phrase: string; plural: boolean } => {
+  // `index` may introduce a COMMA-SEPARATED LIST ("index 0, 2 have no issuer"), not just one
+  // number, so the list is captured whole and split. Matching a bare `index (\d+)` would read
+  // only the first and silently drop every credential after it. The trailing group stops at the
+  // first non-number, so "index 0 (did:web:a), index 1 (did:web:b)" still reads as two separate
+  // matches rather than running them together.
+  const indices = [
+    ...new Set(
+      [...reason.matchAll(/\bindex\s+(\d+(?:\s*,\s*\d+)*)/gi)].flatMap((m) =>
+        m[1].split(",").map((n) => Number(n.trim()))
+      )
+    ),
+  ].sort((a, b) => a - b);
+  if (indices.length === 0) return { phrase: "A credential", plural: false };
+
+  let credentials: unknown[] = [];
+  try {
+    credentials = doc ? getPresentationCredentials(doc) ?? [] : [];
+  } catch {
+    credentials = [];
+  }
+
+  const names = indices.map((index) => {
+    const position = `Credential ${index + 1}`;
+    const credential = credentials[index];
+    if (!credential) return position;
+    const label = getCredentialLabel(credential, index);
+    // getCredentialLabel falls back to this exact string; do not repeat it.
+    return label === position ? position : `${position} ("${label}")`;
+  });
+
+  return {
+    phrase: names.length === 1 ? names[0] : `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`,
+    plural: names.length > 1,
+  };
+};
+
+/**
+ * Maps a presentation failure onto the established error copy.
+ *
+ * trustvc's errorMessageHandling was written for OpenAttestation: it sees an invalid
+ * DOCUMENT_INTEGRITY and returns HASH for every presentation failure, so an expired or unsigned
+ * presentation is reported as "Document has been tampered with". Matching on the verifier's
+ * reason instead gives the accurate existing message — a bad signature really is HASH, a
+ * revoked credential really is REVOKED — and the raw verifier wording ("Invalid signature.")
+ * never reaches the user.
+ *
+ * `message` is only set where no existing copy conveys the cause; there is no EXPIRED type, for
+ * instance. Where it is absent the type's own failureMessage is used. A function receives the
+ * verifier reason that matched, so copy can name the credential at fault.
+ */
+const PRESENTATION_FAILURES: Array<{
+  match: RegExp;
+  type: string;
+  message?: string | ((reason: string, doc?: unknown) => string);
+}> = [
+  {
+    match: /no verifiable credentials/i,
+    type: TYPES.INVALID,
+    message: "This presentation does not contain any credentials.",
+  },
+  // An EMBEDDED credential's problem, ahead of the presentation-level rules below. These must
+  // name WHICH credential and point at the issuer: the presentation itself is fine, and the
+  // default copy ("This document has been revoked", "Ask the holder to present again") reads as
+  // though the presentation were at fault and sends the user to the wrong party.
+  {
+    match: /embedded credential.*(has|have) been (revoked|suspended)/i,
+    type: TYPES.REVOKED,
+    message: (reason, doc) => {
+      const { phrase, plural } = credentialsAtFault(reason, doc);
+      return `${phrase} in this presentation ${plural ? "have" : "has"} been revoked by ${
+        plural ? "their issuers" : "its issuer"
+      }. Contact them for more details.`;
+    },
+  },
+  {
+    match: /embedded credential.*(has|have) expired/i,
+    type: TYPES.INVALID,
+    message: (reason, doc) => {
+      const { phrase, plural } = credentialsAtFault(reason, doc);
+      return `${phrase} in this presentation ${plural ? "have" : "has"} expired. Ask the issuer to reissue ${
+        plural ? "them" : "it"
+      } — presenting ${plural ? "them" : "it"} again will not help.`;
+    },
+  },
+  {
+    match: /embedded credential.*(is|are) not yet valid/i,
+    type: TYPES.INVALID,
+    message: (reason, doc) => {
+      const { phrase, plural } = credentialsAtFault(reason, doc);
+      return `${phrase} in this presentation ${plural ? "are" : "is"} not valid yet. Check with the issuer when ${
+        plural ? "they become" : "it becomes"
+      } valid.`;
+    },
+  },
+  // Revocation is reported ahead of tampering: it is the more actionable answer for the holder,
+  // and the realistic case (revoked upstream after the presentation was signed) leaves the proof
+  // intact anyway.
+  { match: /revoked|suspended/i, type: TYPES.REVOKED },
+  // Issuer resolution is reported ahead of tampering for the same reason — it is the ROOT CAUSE,
+  // not a co-occurring failure. Verifying an embedded credential's signature needs the issuer's
+  // public key, so a DID that will not resolve necessarily fails the signature check too ("has
+  // an invalid signature: Cannot read properties of null (reading 'verificationMethod')" — a raw
+  // TypeError from the failed lookup). Matched the other way round, an unpublished did:web is
+  // reported to the user as a tampered document.
+  {
+    match: /could not resolve issuer|have no issuer/i,
+    type: TYPES.IDENTITY,
+    message: (reason, doc) => {
+      const { phrase, plural } = credentialsAtFault(reason, doc);
+      return `${phrase} in this presentation ${
+        plural ? "name issuers" : "names an issuer"
+      } that cannot be identified, so ${plural ? "they cannot" : "it cannot"} be verified. Contact the issuer.`;
+    },
+  },
+  { match: /invalid signature|tampered/i, type: TYPES.HASH },
+  // The PRESENTATION's own window. Reached only after the embedded-credential rules above,
+  // because both read "... has expired (validUntil ...)" and a single /has expired/ rule would
+  // otherwise catch the credential case and tell the user to ask the holder to present again —
+  // advice that can never work, since only the issuer can reissue a credential.
+  {
+    match: /has expired/i,
+    type: TYPES.INVALID,
+    message:
+      "This presentation has expired and can no longer be used. Ask the holder to present the credentials again.",
+  },
+  {
+    match: /not signed|no holder/i,
+    type: TYPES.INVALID,
+    message: "This presentation is not signed, so the presenter cannot prove they hold these credentials.",
+  },
+  // Signed correctly, but by somebody other than the declared holder — the shape of presenting a
+  // credential that is about someone else. Distinct from an unsigned presentation, and from
+  // tampering: the signature is genuine, it just is not the holder's.
+  {
+    match: /does not match the declared holder/i,
+    type: TYPES.INVALID,
+    message:
+      "This presentation was signed by someone other than the holder it names, so the presenter cannot prove these credentials are theirs.",
+  },
+];
+
+const matchPresentationFailure = (frags: VerificationFragment[]) => {
+  const reasons = failingVpReasons(frags);
+  if (reasons.length === 0) return undefined;
+  // Ordered most specific first, so it wins over a co-occurring generic failure. The reason that
+  // matched is carried along so copy can name the credential it blames.
+  for (const failure of PRESENTATION_FAILURES) {
+    const reason = reasons.find((r) => failure.match.test(r));
+    if (reason !== undefined) return { ...failure, reason };
+  }
+  // An unrecognised presentation failure is invalid, not tampered.
+  return { match: /./, type: TYPES.INVALID, reason: reasons[0] };
+};
+
+export interface PresentationError {
+  type: string;
+  /** Overriding copy, where no existing failureMessage conveys the cause. */
+  message?: string;
+}
+
+/**
+ * The single error a failing presentation should be reported as, or undefined when the
+ * fragments describe no presentation failure at all (a credential, or a valid presentation).
+ *
+ * `doc` is optional; without it, copy that names a credential falls back to the position alone
+ * rather than the tab label.
+ */
+export const getPresentationError = (
+  frags: VerificationFragment[] | null | undefined,
+  doc?: unknown
+): PresentationError | undefined => {
+  if (!frags?.length) return undefined;
+  const failure = matchPresentationFailure(frags);
+  if (!failure) return undefined;
+  const { message, reason, type } = failure;
+  return { type, message: typeof message === "function" ? message(reason, doc) : message };
+};

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -21,6 +21,7 @@ import { getSupportedChainIds, getUnsupportedChainIds } from "../common/utils/ch
 import { AvailableBlockChains, ChainId } from "../constants/chain-info";
 import { IS_DEVELOPMENT } from "../config";
 import { ProcessedFiles } from "../types";
+import { isVerifiablePresentation } from "./presentation";
 
 const { TYPES } = errorMessages;
 
@@ -32,6 +33,12 @@ export const getOpenAttestationData = (
   wrappedDocument: WrappedOrSignedOpenAttestationDocument
 ): OpenAttestationDocument => {
   if (isSignedDocument(wrappedDocument) || vc.isRawDocument(wrappedDocument)) {
+    return wrappedDocument as any;
+  }
+  // A Verifiable Presentation is its own document data. Without this it falls through to
+  // OpenAttestation's getDocumentData, which THROWS on a presentation and takes every caller
+  // down with it (the expiry lookup in CertificateViewer among them).
+  if (isVerifiablePresentation(wrappedDocument)) {
     return wrappedDocument as any;
   }
   return getDocumentData(wrappedDocument);
@@ -81,6 +88,11 @@ export const getKeyId = (wrappedDocument: WrappedDocument<OpenAttestationDocumen
 export const getAttachments = (
   rawDocument: WrappedOrSignedOpenAttestationDocument | RawVerifiableCredential
 ): OpenAttestationAttachment[] | undefined => {
+  // A presentation carries no attachments of its own — each embedded credential carries its
+  // own, and is asked separately when its tab renders.
+  if (isVerifiablePresentation(rawDocument)) {
+    return [];
+  }
   if (isWrappedV2Document(rawDocument)) {
     const documentData = getDataV2(rawDocument);
     return documentData.attachments;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for viewing W3C Verifiable Presentations and their embedded credentials.
  - View each credential in its own tab with individual verification results, issuer details, version labels, attachments, and downloads.
  - Added presentation-specific status tags, credential counts, holder-based “Presented by” labels, and clearer verification checks.
  - Added tailored error messages for expired, revoked, unsigned, tampered, and invalid presentations or credentials.

- **Bug Fixes**
  - Prevented stale verification results and asynchronous updates from affecting newer documents.
  - Improved download names for credentials contained in presentations.
  - Prevented errors when documents have no supported display templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->